### PR TITLE
fix(loader): eliminate probe 404 for opponent_deck_11.json

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,6 +29,13 @@ jobs:
       - run: npm test
       - run: npm run build
       - uses: actions/configure-pages@v4
+      - name: Delete stale github-pages artifacts
+        run: |
+          gh api repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts \
+            --jq '.artifacts[] | select(.name=="github-pages") | .id' | \
+            xargs -I{} gh api -X DELETE repos/${{ github.repository }}/actions/artifacts/{} || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/upload-pages-artifact@v3
         with:
           path: dist

--- a/js/tcg-format/tcg-loader.ts
+++ b/js/tcg-format/tcg-loader.ts
@@ -145,12 +145,13 @@ export async function loadTcgFolder(baseUrl: string): Promise<TcgLoadResult> {
     applyTypeMeta({ rarities: raritiesData });
   }
 
-  // Scan opponents/ folder — try opponent_deck_1..N
+  // Scan opponents/ folder — load exactly as many as described in en_opponents_description.json
+  // (avoids a probe 404 on the first missing file)
+  const opponentCount = enOppDescs?.length ?? 0;
   const tcgOpponents: TcgOpponentDeck[] = [];
-  for (let i = 1; i <= 50; i++) {
+  for (let i = 1; i <= opponentCount; i++) {
     const oppData = await fetchJson<TcgOpponentDeck>(`opponents/opponent_deck_${i}.json`);
-    if (!oppData) break;
-    tcgOpponents.push(oppData);
+    if (oppData) tcgOpponents.push(oppData);
   }
   tcgOpponents.sort((a, b) => a.id - b.id);
 


### PR DESCRIPTION
## Summary

- **Root cause**: The opponent loader used a scan loop that fetched `opponents/opponent_deck_N.json` until it got a 404, causing browsers to log a console error on every startup for the first missing file (`opponent_deck_11.json` with 10 opponents)
- **Fix**: Use the opponent description array length (already loaded from `en_opponents_description.json` just before the loop) as the exact upper bound — no probe request needed
- **Bonus**: Also applies the stale-artifact CI fix so `cancel-in-progress` no longer causes duplicate artifact errors on the next deploy

## Test plan

- [ ] Open browser devtools → Network tab, start the game — verify no 404 appears for `opponent_deck_11.json`
- [ ] Verify all 10 opponents still appear in the opponent select screen
- [ ] CI deploys successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)