### PR TITLE
docs: correct .tcg format description and directory listings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md — Echoes of Sanguo
 
-Browser-based TCG inspired by Yu-Gi-Oh! Forbidden Memories. Built with React 19, TypeScript, Vite, and a custom binary card format (.tcg).
+Browser-based TCG inspired by Yu-Gi-Oh! Forbidden Memories. Built with React 19, TypeScript, Vite, and a custom ZIP-based card format (.tcg).
 
 ## Quick Commands
 
@@ -42,9 +42,9 @@ js/
 ├── mod-api.ts             # window.EchoesOfSanguoMod API for community mods
 ├── i18n.ts                # i18next setup (de + en)
 ├── main.js                # Entry point (loads base.tcg-src, mounts React)
-├── tcg-format/            # Binary card format serialization/deserialization
-│   ├── tcg-loader.ts      # Load .tcg folder (trailing /) or ZIP → CARD_DB
-│   ├── tcg-builder.ts     # Build .tcg from card data
+├── tcg-format/            # ZIP-based card format (.tcg) — pack, load, validate
+│   ├── tcg-loader.ts      # Load .tcg ZIP → CARD_DB, FUSION_RECIPES, etc.
+│   ├── tcg-builder.ts     # Pack base.tcg-src/ → base.tcg (ZIP)
 │   ├── tcg-validator.ts   # Format validation
 │   ├── effect-serializer.ts
 │   └── generate-base-tcg.ts  # CLI script for npm run generate:tcg
@@ -72,11 +72,9 @@ public/
 │   ├── manifest.json      # Format version
 │   ├── shop.json          # Shop/booster pack definitions
 │   ├── campaign.json      # Campaign map data
-│   ├── locales/           # Key-based translation overrides (de_races.json, etc.)
-│   ├── opponents/         # Per-opponent deck JSON files
-│   ├── img/               # Card artwork PNGs
-│   ├── en_cards_description.json
-│   └── de_cards_description.json
+│   ├── id_migration.json  # String-ID → Numeric-ID mapping
+│   ├── locales/           # Translation overrides (de_cards_description.json, de_races.json, …)
+│   └── opponents/         # Per-opponent deck JSON files
 ├── audio/                 # Sound effects
 └── title-bg.png
 android/                   # Capacitor Android project

--- a/README.md
+++ b/README.md
@@ -154,18 +154,19 @@ ECHOES-OF-SANGUO/
 │   ├── types.ts                – Kern-Typdefinitionen (Enums, Interfaces)
 │   ├── cards.ts                – Kartendatenbank-Store & Lookup-Funktionen
 │   ├── cards-data.ts           – Erweiterte Kartendefinitionen
-│   ├── engine.ts               – Game Engine (Spiellogik, KI, Kampf, Fusion, Effekte)
+│   ├── engine.ts               – Game Engine (Spiellogik, Kampf, Fusion, Effekte)
 │   ├── effect-registry.ts      – Datengetriebener Effekt-Executor
+│   ├── ai-behaviors.ts         – KI-Verhaltensprofile (AI_BEHAVIOR_REGISTRY)
 │   ├── progression.ts          – localStorage-Manager (Münzen, Sammlung, Deck)
 │   ├── audio.ts                – SFX/Musik-Manager
 │   ├── i18n.ts                 – i18next-Setup
 │   ├── mod-api.ts              – Modding-API (window.EchoesOfSanguoMod)
-│   ├── tcg-format/              – Eigenes binäres Kartenformat (.tcg)
-│   │   ├── tcg-builder.ts       – Serialisierer: Kartendaten → Binär
-│   │   ├── tcg-loader.ts        – Deserialisierer: Binär → Spielobjekte
-│   │   ├── tcg-validator.ts     – Validierungslogik
-│   │   ├── effect-serializer.ts – Effekt-Binär-Codec
-│   │   └── generate-base-tcg.ts – CLI: base.tcg aus cards-data.ts generieren
+│   ├── tcg-format/              – Eigenes Kartenformat (.tcg = ZIP-Archiv mit JSON)
+│   │   ├── tcg-builder.ts       – Packt base.tcg-src/ → base.tcg (ZIP)
+│   │   ├── tcg-loader.ts        – Lädt .tcg ZIP → CARD_DB, FUSION_RECIPES etc.
+│   │   ├── tcg-validator.ts     – Validierungslogik für TCG-Archive
+│   │   ├── effect-serializer.ts – Effekt-String-Codec
+│   │   └── generate-base-tcg.ts – CLI: base.tcg-src/ validieren & packen
 │   └── react/
 │       ├── App.tsx             – Root-Komponente (Provider-Tree + Router)
 │       ├── contexts/           – React Contexts (Game, Screen, Progression, Modal, Selection)
@@ -176,7 +177,17 @@ ECHOES-OF-SANGUO/
 │       └── utils/
 │           └── pack-logic.ts   – Booster-Pack-Generierung
 ├── public/
-│   ├── base.tcg                 – Kompilierte Kartendatenbank (Binärformat)
+│   ├── base.tcg                 – Kompiliertes Kartenarchiv (ZIP-Format)
+│   ├── base.tcg-src/            – Quelldaten für base.tcg (direkt von Vite ausgeliefert)
+│   │   ├── cards.json           – Kartenstats (numerische IDs)
+│   │   ├── meta.json            – Fusionsrezepte & Starterdecks
+│   │   ├── races/attributes/card_types/rarities.json – Enum-Metadaten
+│   │   ├── manifest.json        – Format-Version
+│   │   ├── shop.json            – Booster-Pack-Definitionen
+│   │   ├── campaign.json        – Kampagnengraph
+│   │   ├── id_migration.json    – String-ID → Numerische-ID Mapping
+│   │   ├── opponents/           – Pro-Gegner Deck-JSON-Dateien
+│   │   └── locales/             – Übersetzungs-Overrides (de_cards_description.json etc.)
 │   └── audio/                  – Sound-Effekte
 ├── locales/
 │   ├── de.json                 – Deutsche Übersetzungen
@@ -188,15 +199,16 @@ ECHOES-OF-SANGUO/
 
 ---
 
-## Eigenes Binärformat (.tcg)
+## Kartenformat (.tcg)
 
-Kartendaten werden in einem eigenen Binärformat (`base.tcg`) gespeichert und beim Start geladen:
+`base.tcg` ist ein **ZIP-Archiv** (umbenannt zu `.tcg`) mit JSON-Dateien und Karten-Artwork. Es wird beim Start geladen:
 
-- **tcg-builder.ts** – Kodiert TypeScript-Objekte zu Binärdaten
-- **tcg-loader.ts** – Dekodiert Binärdaten zu Laufzeitobjekten (CARD_DB, FUSION_RECIPES, etc.)
-- **effect-serializer.ts** – Effekt-Bäume als kompakter Binär-Codec
+- **tcg-builder.ts** – Packt `public/base.tcg-src/` → `public/base.tcg` (ZIP)
+- **tcg-loader.ts** – Entpackt das ZIP und befüllt CARD_DB, FUSION_RECIPES etc.
+- **tcg-validator.ts** – Prüft Vollständigkeit und Konsistenz des Archivs
+- **effect-serializer.ts** – Parst und serialisiert Effekt-Strings
 
-Generierung via `npm run generate:tcg` aus `js/cards-data.ts`.
+Generierung via `npm run generate:tcg` — validiert `public/base.tcg-src/` und packt es neu.
 
 ---
 


### PR DESCRIPTION
## Summary

- Replace all "Binärformat/binary" references with correct ZIP-based wording
- Add missing `ai-behaviors.ts` and `tcg-validator.ts` to file listings
- Add `public/base.tcg-src/` subtree to README directory overview
- Fix CLAUDE.md: remove non-existent `en_cards_description.json` and misplaced `de_cards_description.json` (lives in `locales/`, not root)
- Add `id_migration.json` to CLAUDE.md listing

## Test plan
- [ ] Docs-only change — no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)