### PR TITLE
feat(flip): implement flip effects and face-down ATK summon

### DIFF
--- a/js/engine.ts
+++ b/js/engine.ts
@@ -114,6 +114,7 @@ export class FieldCard {
   position: Position;
   faceDown: boolean;
   hasAttacked: boolean;
+  hasFlipped: boolean;
   summonedThisTurn: boolean;
   tempATKBonus: number;
   tempDEFBonus: number;
@@ -134,6 +135,7 @@ export class FieldCard {
     this.position   = position; // 'atk' | 'def'
     this.faceDown   = faceDown;
     this.hasAttacked= false;
+    this.hasFlipped = false;
     this.summonedThisTurn = true; // summoning sickness
     this.tempATKBonus = 0;
     this.tempDEFBonus = 0;
@@ -336,6 +338,17 @@ export class GameEngine {
     return this.summonMonster(owner, handIndex, zone, 'def', true);
   }
 
+  flipSummon(owner: Owner, zone: number){
+    const fc = this.state[owner].field.monsters[zone];
+    if(!fc || !fc.faceDown){ this.addLog('Kein verdecktes Monster!'); return false; }
+    if(fc.summonedThisTurn){ this.addLog('Kann nicht im selben Zug geflippt werden!'); return false; }
+    fc.faceDown = false;
+    this.addLog(`${fc.card.name} wird aufgedeckt (Flip-Beschwörung)!`);
+    this._triggerFlipEffect(fc, owner, zone);
+    this.ui.render(this.state);
+    return true;
+  }
+
   specialSummon(owner: Owner, card: CardData, zone?: number){
     const st = this.state[owner];
     if(zone === undefined){
@@ -511,6 +524,13 @@ export class GameEngine {
     const attFC = atkSt.field.monsters[attackerZone];
     if(!attFC){ this.addLog('Kein angreifendes Monster!'); return; }
     if(attFC.hasAttacked){ this.addLog(`${attFC.card.name} hat bereits angegriffen!`); return; }
+    // auto-flip face-down attacker
+    if(attFC.faceDown){
+      attFC.faceDown = false;
+      attFC.position = 'atk';
+      this.addLog(`${attFC.card.name} wird aufgedeckt (Angriff)!`);
+      this._triggerFlipEffect(attFC, attackerOwner, attackerZone);
+    }
     if(attFC.position !== 'atk'){ this.addLog('Monster muss im Angriffsmodus sein!'); return; }
 
     const defFC = defSt.field.monsters[defenderZone];
@@ -548,6 +568,13 @@ export class GameEngine {
       this.addLog('Gegner hat Monster auf dem Spielfeld!'); return;
     }
     if(attFC.hasAttacked) return;
+    // auto-flip face-down attacker
+    if(attFC.faceDown){
+      attFC.faceDown = false;
+      attFC.position = 'atk';
+      this.addLog(`${attFC.card.name} wird aufgedeckt (Angriff)!`);
+      this._triggerFlipEffect(attFC, attackerOwner, attackerZone);
+    }
     if(attFC.position !== 'atk') return;
 
     if(attackerOwner === 'opponent'){
@@ -568,7 +595,7 @@ export class GameEngine {
     if(defFC.faceDown){
       defFC.faceDown = false;
       this.addLog(`${defFC.card.name} wird aufgedeckt!`);
-      // flip effect if any – simplified
+      this._triggerFlipEffect(defFC, defOwner, defZone);
     }
 
     const defVal = defFC.position === 'atk' ? defFC.effectiveATK() : defFC.effectiveDEF();
@@ -689,6 +716,21 @@ export class GameEngine {
       executeEffectBlock(card.effect, ctx);
     } catch(e) {
       EchoesOfSanguo.log('EFFECT', `Fehler in Effekt [${card.id}] trigger=${trigger}: ${e instanceof Error ? e.message : String(e)}`, '#f44');
+    }
+  }
+
+  _triggerFlipEffect(fc: FieldCard, owner: Owner, zone: number){
+    if(fc.hasFlipped) return;
+    fc.hasFlipped = true;
+    const card = fc.card;
+    if(!card.effect || card.effect.trigger !== 'onFlip') return;
+    EchoesOfSanguo.log('EFFECT', `${card.name} (${owner}) – Flip-Effekt`);
+    if(this.ui.showActivation) this.ui.showActivation(card, card.description);
+    try {
+      const ctx: EffectContext = { engine: this, owner };
+      executeEffectBlock(card.effect, ctx);
+    } catch(e) {
+      EchoesOfSanguo.log('EFFECT', `Fehler in Flip-Effekt [${card.id}]: ${e instanceof Error ? e.message : String(e)}`, '#f44');
     }
   }
 

--- a/js/react/contexts/ModalContext.tsx
+++ b/js/react/contexts/ModalContext.tsx
@@ -3,7 +3,7 @@ import type { CardData, GameState, PromptOptions } from '../../types.js';
 
 export type ModalState =
   | null
-  | { type: 'card-action'; card: CardData; index: number; state: GameState }
+  | { type: 'card-action'; card: CardData; index: number; state: GameState; source?: 'hand' | 'field' }
   | { type: 'card-detail'; card: CardData; fc?: any | null }
   | { type: 'trap-prompt'; opts: PromptOptions; resolve: (v: boolean) => void }
   | { type: 'grave-select'; cards: CardData[]; resolve: (card: CardData) => void }

--- a/js/react/modals/CardActionMenu.tsx
+++ b/js/react/modals/CardActionMenu.tsx
@@ -8,7 +8,7 @@ import type { ModalState } from '../contexts/ModalContext.js';
 interface Props { modal: Extract<ModalState, { type: 'card-action' }>; }
 
 export function CardActionMenu({ modal }: Props) {
-  const { card, index, state } = modal;
+  const { card, index, state, source } = modal;
   const { gameRef }           = useGame();
   const { openModal, closeModal } = useModal();
   const { setSel }            = useSelection();
@@ -39,13 +39,21 @@ export function CardActionMenu({ modal }: Props) {
 
   const actions: React.ReactNode[] = [];
 
-  if (isMon && phase === 'main') {
+  if (isMon && phase === 'main' && source === 'field') {
+    // Field monster actions
+    const fc = state.player.field.monsters[index];
+    if (fc && fc.faceDown && !fc.summonedThisTurn) {
+      actions.push(btn(t('card_action.flip_summon'), () => { game.flipSummon('player', index); closeModal(); }));
+    }
+  } else if (isMon && phase === 'main') {
+    // Hand monster actions
     if (state.player.normalSummonUsed) {
       actions.push(btn(t('card_action.already_played'), null, true));
     } else {
       if (freeZone !== -1) {
         actions.push(btn(t('card_action.summon_atk'), () => { game.summonMonster('player', index, freeZone, 'atk'); closeModal(); }));
         actions.push(btn(t('card_action.summon_def'), () => { game.summonMonster('player', index, freeZone, 'def'); closeModal(); }));
+        actions.push(btn(t('card_action.set_atk'), () => { game.summonMonster('player', index, freeZone, 'atk', true); closeModal(); }));
       }
     }
     if (fusionOpts.length > 0 && !state.player.normalSummonUsed) {

--- a/js/react/screens/game/PlayerField.tsx
+++ b/js/react/screens/game/PlayerField.tsx
@@ -38,7 +38,7 @@ export function PlayerField({ showDirect, setShowDirect }: Props) {
     const fc = player.field.monsters[zone];
     if (!fc) return false;
     if (!isMyTurn || phase !== 'battle') return false;
-    return !fc.hasAttacked && fc.position === 'atk' && !fc.summonedThisTurn;
+    return !fc.hasAttacked && (fc.position === 'atk' || fc.faceDown) && !fc.summonedThisTurn;
   }
 
   function isPlayerSpellTrapInteractive(zone: number) {
@@ -54,7 +54,7 @@ export function PlayerField({ showDirect, setShowDirect }: Props) {
   const onOwnFieldCardClick = useCallback((fc: any, zone: number) => {
     const game = gameRef.current;
     if (!game || !isMyTurn || phase !== 'main') return;
-    openModal({ type: 'card-action', card: fc.card, index: zone, state: gameState });
+    openModal({ type: 'card-action', card: fc.card, index: zone, state: gameState, source: 'field' });
   }, [gameRef, isMyTurn, phase, openModal, gameState]);
 
   const onAttackerSelect = useCallback((zone: number) => {

--- a/js/tcg-format/enums.ts
+++ b/js/tcg-format/enums.ts
@@ -151,7 +151,7 @@ export function intToRarity(n: number): Rarity {
 // Effect triggers and trap triggers share the same string space in serialization
 
 const TRIGGER_STRINGS: ReadonlySet<string> = new Set([
-  'onSummon', 'onDestroyByBattle', 'onDestroyByOpponent', 'passive',
+  'onSummon', 'onDestroyByBattle', 'onDestroyByOpponent', 'passive', 'onFlip',
   'onAttack', 'onOwnMonsterAttacked', 'onOpponentSummon', 'manual',
 ]);
 

--- a/js/types.ts
+++ b/js/types.ts
@@ -8,7 +8,7 @@ export type Owner        = 'player' | 'opponent';
 export type Phase        = 'draw' | 'main' | 'battle' | 'end';
 export type Position     = 'atk' | 'def';
 export type TrapTrigger  = 'onAttack' | 'onOwnMonsterAttacked' | 'onOpponentSummon' | 'manual';
-export type EffectTrigger= 'onSummon' | 'onDestroyByBattle' | 'onDestroyByOpponent' | 'passive';
+export type EffectTrigger= 'onSummon' | 'onDestroyByBattle' | 'onDestroyByOpponent' | 'passive' | 'onFlip';
 export type SpellType    = 'normal' | 'targeted' | 'fromGrave';
 
 // ── Int-based Enums (card data — stored in .tcg format) ────
@@ -278,6 +278,7 @@ export declare class FieldCard {
   position:         Position;
   faceDown:         boolean;
   hasAttacked:      boolean;
+  hasFlipped:       boolean;
   summonedThisTurn: boolean;
   tempATKBonus:     number;
   tempDEFBonus:     number;

--- a/locales/de.json
+++ b/locales/de.json
@@ -170,6 +170,8 @@
     "set_spell": "🔽 Setzen",
     "set_trap": "🔽 Fallen setzen",
     "activate_trap": "⚠ Falle aktivieren",
+    "flip_summon": "🔄 Flip-Beschwörung",
+    "set_atk": "🔽 Verdeckt setzen (ATK)",
     "view": "🔍 Ansehen",
     "cancel": "✕ Abbrechen",
     "hint_spell_own": "Wähle ein eigenes Monster als Ziel.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -170,6 +170,8 @@
     "set_spell": "🔽 Set",
     "set_trap": "🔽 Set Trap",
     "activate_trap": "⚠ Activate Trap",
+    "flip_summon": "🔄 Flip Summon",
+    "set_atk": "🔽 Set Face-Down (ATK)",
     "view": "🔍 View",
     "cancel": "✕ Cancel",
     "hint_spell_own": "Choose your own monster as a target.",


### PR DESCRIPTION
## Summary

- Monster mit `onFlip`-Trigger lösen ihren Effekt genau einmal aus — beim Aufdecken durch Angriff, Flip-Beschwörung oder wenn ein verdecktes Monster selbst angreift
- Neue Option im CardActionMenu: „Verdeckt setzen (ATK)" für Handkarten
- Flip-Beschwörung-Button erscheint beim Anklicken eigener verdeckter Feldmonster

## Änderungen

- `js/types.ts` — `'onFlip'` in `EffectTrigger`, `hasFlipped` in `FieldCard`
- `js/engine.ts` — `_triggerFlipEffect()`, `flipSummon()`, Auto-Flip in `attack()`/`attackDirect()`/`_resolveBattle()`
- `js/tcg-format/enums.ts` — `'onFlip'` in `TRIGGER_STRINGS`
- `js/react/contexts/ModalContext.tsx` — `source?: 'hand' | 'field'` im ModalState
- `js/react/screens/game/PlayerField.tsx` — verdeckte Monster dürfen angreifen
- `js/react/modals/CardActionMenu.tsx` — Flip-Summon + Verdeckt-ATK Buttons
- `locales/de.json` + `locales/en.json` — neue i18n Keys

## Test plan

- [ ] Monster verdeckt (DEF) setzen → nächster Zug anklicken → Flip-Beschwörung-Button erscheint
- [ ] Flip-Beschwörung ausführen → Monster wird aufgedeckt, Flip-Effekt löst aus, danach angreifen möglich
- [ ] Verdecktes Monster direkt in Battle Phase angreifen lassen → automatisch aufdecken + Flip-Effekt + Kampf
- [ ] Gegner greift verdecktes Monster an → Aufdecken + Flip-Effekt
- [ ] Flip-Effekt löst nur einmal aus (hasFlipped Guard)
- [ ] Im selben Zug gesetztes Monster kann nicht geflippt werden
- [ ] `npm test` — 390/392 Tests bestehen (2 pre-existing failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)