### PR TITLE
feat(ui): portrait mobile layout, options button, and surrender

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -821,16 +821,227 @@ button { cursor: pointer; border: none; font-family: inherit; transition: none; 
   border-top: 1px solid var(--border);
 }
 
-/* ── Landscape Smartphone (niedrige Höhe) ────────────────── */
-@media (max-height: 450px) {
+/* Surrender section */
+.options-surrender {
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid rgba(180,40,40,0.4);
+}
+
+.btn-surrender {
+  width: 100%;
+  background: #4a0a0a;
+  border: 2px solid rgba(200,50,50,0.7);
+  color: #ffaaaa;
+  font-family: inherit;
+  font-size: 0.8125rem;
+  font-weight: bold;
+  padding: 10px 16px;
+  cursor: pointer;
+  border-radius: 0;
+  letter-spacing: 1px;
+  transition: none;
+}
+.btn-surrender:hover { background: #6a1010; border-color: #e05050; }
+.btn-surrender:active { background: #8a1a1a; }
+
+.surrender-confirm p {
+  font-size: 0.75rem;
+  color: #ffaaaa;
+  margin-bottom: 12px;
+  line-height: 1.5;
+}
+.surrender-confirm-btns {
+  display: flex; gap: 8px;
+}
+.surrender-confirm-btns .btn-cancel {
+  flex: 1;
+}
+.surrender-confirm-btns .btn-surrender {
+  flex: 2;
+}
+
+/* Portrait bar: hidden on desktop, shown in portrait mobile */
+#portrait-bar { display: none; }
+
+/* ── Portrait Smartphone (≤ 540px) — Top-bar layout ──────── */
+/*
+  Strategy: replace side panels with a 48px top control bar.
+  Cards use full viewport width minus tiny 30px graves-only right strip.
+  Formula: (100vw - 30px - 8px padding - 4 gaps×2px) / 5 ≈ (100vw - 46px) / 5
+  At 375px: (375 - 46) / 5 ≈ 65.8px wide cards — nearly double the old 49px.
+*/
+@media (max-width: 540px) {
+  #game-screen {
+    --card-w: calc((100vw - 46px) / 5);
+    --card-h: calc(var(--card-w) / 0.715);
+    --card-w-opp: var(--card-w);
+    --card-h-opp: var(--card-h);
+    grid-template-rows:
+      48px calc(var(--card-h-opp) * 0.25) 1fr calc(var(--card-h) * 0.75);
+  }
+
+  /* Shift all rows down by 1 to make room for portrait bar */
+  #opp-hand-area { grid-row: 2; }
+  #field         { grid-row: 3; }
+  #hand-area     { grid-row: 4; }
+
+  /* Portrait top bar — visible in portrait only */
+  #portrait-bar {
+    grid-row: 1;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 0 8px;
+    background: rgba(2, 8, 4, 0.97);
+    border-bottom: 1px solid rgba(30, 80, 45, 0.5);
+    z-index: 30;
+  }
+
+  .portrait-opts-btn {
+    background: rgba(20, 60, 30, 0.8);
+    border: 1px solid rgba(60, 160, 80, 0.4);
+    border-radius: 4px;
+    color: #a0e0b0;
+    font-size: 18px;
+    width: 36px; height: 36px;
+    display: flex; align-items: center; justify-content: center;
+    cursor: pointer; padding: 0;
+    flex-shrink: 0;
+  }
+  .portrait-hud {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 4px;
+    overflow: hidden;
+  }
+  .phud-lp {
+    font-family: 'Press Start 2P', monospace;
+    font-size: 9px;
+    white-space: nowrap;
+  }
+  .phud-opp    { color: #ff8080; }
+  .phud-player { color: #80ff80; }
+  .phud-phase {
+    font-family: 'Press Start 2P', monospace;
+    font-size: 6px;
+    color: #d0c090;
+    text-align: center;
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .portrait-phase-btn {
+    width: 36px; height: 36px;
+    border-radius: 4px;
+    border: 1px solid rgba(60, 160, 80, 0.4);
+    font-size: 16px;
+    display: flex; align-items: center; justify-content: center;
+    cursor: pointer; padding: 0;
+    flex-shrink: 0;
+  }
+  .portrait-phase-btn.phase-main              { background: rgba(80, 40, 0, 0.9);  color: #ffcc00; border-color: #ffcc00; }
+  .portrait-phase-btn.phase-battle            { background: rgba(100, 0, 0, 0.9);  color: #ff6060; border-color: #ff4040; }
+  .portrait-phase-btn.phase-end,
+  .portrait-phase-btn.phase-draw,
+  .portrait-phase-btn.phase-standby           { background: rgba(20, 60, 30, 0.8); color: #a0e0b0; }
+  .portrait-phase-btn.waiting,
+  .portrait-phase-btn:disabled                { background: rgba(20, 30, 25, 0.8); color: #607060; opacity: 0.6; cursor: default; }
+
+  /* Hide left panel entirely — options button moved to portrait bar */
+  #field-left { display: none; }
+
+  /* Right panel: minimal width — graves only, no background */
+  #field-right {
+    width: 30px; min-width: 30px;
+    padding: 0;
+    background: transparent;
+    border-left: none;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: center;
+  }
+  #field-right-center { display: none; }
+
+  /* Graves: compact for 30px panel */
+  .grave-icon       { width: 26px; height: 26px; }
+  .grave-icon-sym   { font-size: 13px; }
+  .grave-icon-count { font-size: 8px; }
+
+  /* Center: full field width */
+  #field-center {
+    flex: 1;
+    width: 100%;
+    padding: 4px 2px;
+    box-sizing: border-box;
+  }
+
   .zone-row { gap: 2px; }
-  #field-left  { min-width: 44px; width: 12%; padding: 6px 2px; }
-  #field-right { min-width: 80px; width: 20%; padding: 6px 4px; }
-  #btn-options { width: 36px; height: 36px; font-size: 15px; }
-  #btn-next-phase { font-size: 0.625rem; padding: 6px 4px; }
-  .grave-icon { width: 34px; height: 34px; }
-  .grave-icon-sym { font-size: 13px; }
-  .lp-value { font-size: 0.75rem; }
-  #player-hand .hand-card { margin-right: -14px; }
+
+  /* Hands: only right-pad by the 30px graves strip */
+  #hand-area     { padding-right: 30px; padding-left: 0; }
+  #opp-hand-area { padding-left: 0; }
+
+  /* Hand card overlap for up to 7 cards */
+  #player-hand .hand-card            { margin-right: -14px; }
+  #player-hand .hand-card:last-child { margin-right: 0; }
+  #opp-hand                          { gap: 0; }
+  #opp-hand .opp-hand-card            { margin-right: -10px; }
+  #opp-hand .opp-hand-card:last-child { margin-right: 0; }
+}
+
+/* ── Landscape Smartphone (niedrige Höhe) ────────────────── */
+/* In landscape, width is sufficient — revert to height-based sizing.
+   This query comes after portrait so it wins on devices matching both.
+   Also restores the side panels and 3-row grid that portrait replaced. */
+@media (max-height: 450px) {
+  #game-screen {
+    --card-h: calc((100vh - 40px) / 5);
+    --card-w: calc(var(--card-h) * 0.715);
+    --card-w-opp: var(--card-w);
+    --card-h-opp: var(--card-h);
+    grid-template-rows:
+      calc(var(--card-h) * 0.25) 1fr calc(var(--card-h) * 0.75);
+  }
+
+  /* Restore 3-row grid assignments (portrait shifted these to rows 2/3/4) */
+  #portrait-bar  { display: none; }
+  #opp-hand-area { grid-row: 1; }
+  #field         { grid-row: 2; }
+  #hand-area     { grid-row: 3; }
+
+  /* Restore side panels */
+  #field-left  { display: flex; min-width: 44px; width: 44px; padding: 0; }
+  #field-right { min-width: 72px; width: 72px; padding: 0; background: rgba(4, 12, 6, 0.88); border-left: 1px solid rgba(30, 80, 45, 0.4); }
+  #field-right-center {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 0 4px;
+    align-items: stretch;
+  }
+
+  #btn-options    { width: 36px; height: 36px; font-size: 15px; }
+  #btn-next-phase { font-size: 0.5625rem; padding: 5px 2px; white-space: normal; line-height: 1.2; }
+
+  .grave-icon             { width: 34px; height: 34px; }
+  .grave-icon-sym         { font-size: 13px; }
+  .grave-icon-count       { font-size: 8px; }
+
+  #lp-panel               { padding-right: 0; gap: 2px; flex: none; width: 100%; }
+  .lp-row                 { padding: 2px 3px; gap: 1px; }
+  .lp-who                 { font-size: 7px; margin-bottom: 0; }
+  .lp-bottom .io-bar-bg   { display: none; }
+  .lp-value               { font-size: 0.625rem; }
+  .lp-deck                { font-size: 7px; }
+
+  #hand-area              { padding-right: 72px; }
+  #opp-hand-area          { padding-left: 44px; }
+
+  .zone-row { gap: 2px; }
+  #player-hand .hand-card            { margin-right: -14px; }
   #player-hand .hand-card:last-child { margin-right: 0; }
 }

--- a/js/engine.ts
+++ b/js/engine.ts
@@ -298,6 +298,11 @@ export class GameEngine {
     }
   }
 
+  surrender(): void {
+    this.addLog('=== SURRENDER ===');
+    this._endDuel('defeat');
+  }
+
   // ───────── Draw ─────────────────────────────────────────
   drawCard(owner: Owner, count = 1){
     const st = this.state[owner];

--- a/js/react/contexts/GameContext.tsx
+++ b/js/react/contexts/GameContext.tsx
@@ -106,7 +106,7 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
             Progression.recordDuelResult(opponentId, result === 'victory');
             const cfg = OPPONENT_CONFIGS.find((o: any) => o.id === opponentId);
             if (cfg) {
-              coinsEarned = result === 'victory' ? cfg.coinsWin : cfg.coinsLoss;
+              coinsEarned = result === 'victory' ? cfg.coinsWin : 0;
               Progression.addCoins(coinsEarned);
             }
             refreshRef.current();

--- a/js/react/modals/OptionsModal.tsx
+++ b/js/react/modals/OptionsModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useModal }     from '../contexts/ModalContext.js';
+import { useGame }      from '../contexts/GameContext.js';
 import { Progression }  from '../../progression.js';
 import { Audio }        from '../../audio.js';
 import i18n             from '../../i18n.js';
@@ -8,17 +9,25 @@ import i18n             from '../../i18n.js';
 export function OptionsModal() {
   const { closeModal } = useModal();
   const { t } = useTranslation();
+  const { gameState, gameRef } = useGame();
   const saved = Progression.getSettings();
 
-  const [lang,      setLang]      = useState(saved.lang);
-  const [volMaster, setVolMaster] = useState(saved.volMaster);
-  const [volMusic,  setVolMusic]  = useState(saved.volMusic);
-  const [volSfx,    setVolSfx]    = useState(saved.volSfx);
+  const [lang,        setLang]        = useState(saved.lang);
+  const [volMaster,   setVolMaster]   = useState(saved.volMaster);
+  const [volMusic,    setVolMusic]    = useState(saved.volMusic);
+  const [volSfx,      setVolSfx]      = useState(saved.volSfx);
+  const [showConfirm, setShowConfirm] = useState(false);
 
   function apply() {
     i18n.changeLanguage(lang);
     Progression.saveSettings({ lang, volMaster, volMusic, volSfx });
     Audio.setVolumes(volMaster, volMusic, volSfx);
+  }
+
+  function handleSurrender() {
+    apply();
+    gameRef.current?.surrender();
+    closeModal();
   }
 
   return (
@@ -65,7 +74,28 @@ export function OptionsModal() {
         <button className="btn-secondary" onClick={apply}>{t('common.apply')}</button>
         <button className="btn-primary"   onClick={() => { apply(); closeModal(); }}>{t('common.ok')}</button>
       </div>
+
+      {gameState !== null && (
+        <div className="options-surrender">
+          {!showConfirm ? (
+            <button className="btn-surrender" onClick={() => setShowConfirm(true)}>
+              {t('game.surrender')}
+            </button>
+          ) : (
+            <div className="surrender-confirm">
+              <p>{t('game.surrender_confirm')}</p>
+              <div className="surrender-confirm-btns">
+                <button className="btn-cancel" onClick={() => setShowConfirm(false)}>
+                  {t('game.surrender_cancel')}
+                </button>
+                <button className="btn-surrender" onClick={handleSurrender}>
+                  {t('game.surrender_yes')}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }
-

--- a/js/react/screens/GameScreen.tsx
+++ b/js/react/screens/GameScreen.tsx
@@ -44,16 +44,61 @@ export default function GameScreen() {
 
   if (!gameState) return null;
 
-  const player = gameState.player;
-  const opp    = gameState.opponent;
+  const player   = gameState.player;
+  const opp      = gameState.opponent;
+  const phase    = gameState.phase;
+  const isMyTurn = gameState.activePlayer === 'player';
 
   function onGraveClick(owner: 'player' | 'opponent') {
     const grave = owner === 'player' ? player.graveyard : opp.graveyard;
     if (grave.length > 0) openModal({ type: 'card-detail', card: grave[grave.length - 1] });
   }
 
+  function onPortraitPhase() {
+    const game = gameRef.current;
+    if (!game || !isMyTurn) return;
+    hideDirectAndReset();
+    if (phase === 'end') game.endTurn();
+    else game.advancePhase();
+  }
+
+  const PHASE_LABEL: Record<string, string> = {
+    draw: t('game.phase_draw'), standby: t('game.phase_standby'),
+    main: t('game.phase_main'), battle: t('game.phase_battle'),
+    end:  t('game.phase_end'),
+  };
+
+  const portraitPhaseIcon = !isMyTurn ? '⏸'
+    : phase === 'main'   ? '⚔'
+    : phase === 'battle' ? '→'
+    : '⏭';
+
   return (
     <div id="game-screen">
+
+      {/* ── Portrait-only top control bar ─────────────────────── */}
+      <div id="portrait-bar">
+        <button
+          className="portrait-opts-btn"
+          title="Optionen"
+          onClick={() => openModal({ type: 'main-options' })}
+        >☰</button>
+
+        <div className="portrait-hud">
+          <span className="phud-lp phud-opp">♥ {opp.lp}</span>
+          <span className="phud-phase">{PHASE_LABEL[phase] ?? phase}</span>
+          <span className="phud-lp phud-player">♥ {player.lp}</span>
+        </div>
+
+        <button
+          className={`portrait-phase-btn phase-${phase}${!isMyTurn ? ' waiting' : ''}`}
+          disabled={!isMyTurn}
+          onClick={onPortraitPhase}
+          aria-label={t('game.aria_next_phase')}
+        >
+          {portraitPhaseIcon}
+        </button>
+      </div>
 
       {/* Opponent hand */}
       <div id="opp-hand-area">
@@ -71,7 +116,7 @@ export default function GameScreen() {
 
         {/* Left panel */}
         <div id="field-left">
-          <button id="btn-options" title="Optionen" onClick={() => {}}>
+          <button id="btn-options" title="Optionen" onClick={() => openModal({ type: 'main-options' })}>
             <span className="btn-options-mobile">☰</span>
             <span className="btn-options-desktop">OPTIONS</span>
           </button>

--- a/locales/de.json
+++ b/locales/de.json
@@ -158,7 +158,11 @@
     "hint_selected": "{{name}} ausgewählt.",
     "grave_opp": "Gegner Friedhof",
     "grave_player": "Spieler Friedhof",
-    "aria_next_phase": "Nächste Phase (B/E/T)"
+    "aria_next_phase": "Nächste Phase (B/E/T)",
+    "surrender": "⚑ Aufgeben",
+    "surrender_confirm": "Wirklich aufgeben? Das Duell wird als Niederlage gewertet.",
+    "surrender_yes": "⚑ Ja, aufgeben",
+    "surrender_cancel": "← Zurück"
   },
   "card_action": {
     "already_played": "⛔ Monster bereits gespielt",

--- a/locales/en.json
+++ b/locales/en.json
@@ -158,7 +158,11 @@
     "hint_selected": "{{name}} selected.",
     "grave_opp": "Opponent Graveyard",
     "grave_player": "Player Graveyard",
-    "aria_next_phase": "Next Phase (B/E/T)"
+    "aria_next_phase": "Next Phase (B/E/T)",
+    "surrender": "⚑ Surrender",
+    "surrender_confirm": "Really surrender? The duel will be counted as a defeat.",
+    "surrender_yes": "⚑ Yes, surrender",
+    "surrender_cancel": "← Back"
   },
   "card_action": {
     "already_played": "⛔ Monster already played",


### PR DESCRIPTION
## Changes

### Mobile Portrait Layout
- Added responsive portrait mode for screens ≤540px width
- Replaces side panels with 48px top control bar containing:
  - Options button (☰)
  - Compact HUD showing opponent/player LP and current phase
  - Phase advancement button with phase-specific icons
- Optimizes card sizing: cards nearly double in width (≈66px vs 49px)
- Restores standard 3-row grid in landscape mode (max-height: 450px)

### Surrender Mechanic
- Added `GameEngine.surrender()` method that ends duel as defeat
- Integrated surrender UI into OptionsModal with two-step confirmation
- Updated GameContext to award 0 coins on surrender/defeat (was coinsLoss)

### UI Updates
- Options button now functional in both desktop and portrait modes
- Added phase button styling with contextual colors and icons
- Styled surrender button with red theme and confirmation dialog
- Added translations for surrender prompts (EN/DE)

### Layout Refinements
- Graves panel minimized to 30px in portrait mode
- Hand card overlap adjusted for mobile (up to 7 cards visible)
- Proper padding adjustments for all card areas across breakpoints