### PR TITLE
fix(ui): show full hand card stats in portrait mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -885,8 +885,10 @@ button { cursor: pointer; border: none; font-family: inherit; transition: none; 
     --card-h: calc(var(--card-w) / 0.715);
     --card-w-opp: var(--card-w);
     --card-h-opp: var(--card-h);
+    height: calc(100vh - env(safe-area-inset-bottom, 0px));
+    height: calc(100dvh - env(safe-area-inset-bottom, 0px));
     grid-template-rows:
-      48px calc(var(--card-h-opp) * 0.25) 1fr calc(var(--card-h) * 0.75);
+      48px calc(var(--card-h-opp) * 0.25) 1fr var(--card-h);
   }
 
   /* Shift all rows down by 1 to make room for portrait bar */
@@ -991,6 +993,7 @@ button { cursor: pointer; border: none; font-family: inherit; transition: none; 
 
   /* Hands: only right-pad by the 30px graves strip */
   #hand-area     { padding-right: 30px; padding-left: 0; }
+  #player-hand   { margin-top: -8px; }
   #opp-hand-area { padding-left: 0; }
 
   /* Hand card overlap for up to 7 cards */


### PR DESCRIPTION
## Summary

- Use `100dvh` instead of `100vh` for game screen height in portrait mode — accounts for mobile browser chrome (URL bar, gesture bar) eating viewport space
- Increase hand area grid row from 75% to 100% of card height so ATK/DEF stats are fully visible
- Reduce hand card overlap (`margin-top`) from `-30px` to `-8px` in portrait mode
- Add `env(safe-area-inset-bottom)` for notched devices (iOS home indicator, Android gesture nav)

## Test plan

- [ ] Open game on mobile device or Chrome DevTools mobile emulator (360-430px width)
- [ ] Verify ATK/DEF stats on hand cards are fully visible in portrait mode
- [ ] Verify no scrollbar appears
- [ ] Verify field zones are not excessively compressed
- [ ] Verify landscape mode is unaffected

https://claude.ai/code/session_01Awsi9aNvX1CtakTDRVp9k6