### PR TITLE
feat(ui): battle UI improvements and mobile UX fixes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -637,10 +637,22 @@ button { cursor: pointer; border: none; font-family: inherit; transition: none; 
 .detail-stats { font-size: 0.875rem; font-weight: bold; color: var(--gold); }
 
 /* Trap Prompt */
-#trap-prompt-modal { max-width: 340px; text-align: center; }
+#trap-prompt-modal { max-width: 380px; text-align: center; }
 #trap-prompt-card { display: flex; justify-content: center; margin: 10px 0; }
 #trap-prompt-msg  { font-size: 0.75rem; color: var(--text); margin: 8px 0; }
 .prompt-buttons { display: flex; gap: 10px; justify-content: center; margin-top: 12px; }
+.trap-battle-context {
+  background: rgba(40, 10, 10, 0.85);
+  border: 1px solid rgba(255, 80, 80, 0.5);
+  border-radius: 4px;
+  padding: 8px 12px;
+  margin: 8px 0 4px;
+  text-align: center;
+  font-family: 'Silkscreen', monospace;
+  font-size: 0.75rem;
+  color: #ffcccc;
+  line-height: 1.5;
+}
 
 /* Grave Selection */
 #grave-select-modal { max-width: 500px; }
@@ -871,6 +883,8 @@ button { cursor: pointer; border: none; font-family: inherit; transition: none; 
 
 /* Portrait bar: hidden on desktop, shown in portrait mobile */
 #portrait-bar { display: none; }
+/* Floating phase button: hidden on desktop, shown in portrait mobile */
+.floating-phase-btn { display: none; }
 
 /* ── Portrait Smartphone (≤ 540px) — Top-bar layout ──────── */
 /*
@@ -1002,6 +1016,37 @@ button { cursor: pointer; border: none; font-family: inherit; transition: none; 
   #opp-hand                          { gap: 0; }
   #opp-hand .opp-hand-card            { margin-right: -10px; }
   #opp-hand .opp-hand-card:last-child { margin-right: 0; }
+
+  /* Floating phase button — bottom-right, thumb-reachable */
+  .floating-phase-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: fixed;
+    bottom: calc(env(safe-area-inset-bottom, 8px) + 8px);
+    right: 12px;
+    z-index: 90;
+    min-width: 80px;
+    height: 48px;
+    padding: 0 14px;
+    border-radius: 8px;
+    font-family: 'Press Start 2P', monospace;
+    font-size: 0.6rem;
+    letter-spacing: 0.5px;
+    cursor: pointer;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.6);
+    animation: nextPhasePulse 1.6s ease-in-out infinite;
+  }
+  .floating-phase-btn.phase-main    { background: rgba(80, 40, 0, 0.95);  color: #ffcc00; border: 2px solid #ffcc00; }
+  .floating-phase-btn.phase-battle  { background: rgba(100, 0, 0, 0.95);  color: #ff6060; border: 2px solid #ff4040; }
+  .floating-phase-btn.phase-end,
+  .floating-phase-btn.phase-draw,
+  .floating-phase-btn.phase-standby { background: rgba(20, 60, 30, 0.95); color: #a0e0b0; border: 2px solid rgba(60, 160, 80, 0.6); }
+  .floating-phase-btn.waiting,
+  .floating-phase-btn:disabled       { background: rgba(20, 30, 25, 0.85); color: #607060; border: 2px solid #405040; opacity: 0.5; cursor: default; animation: none; }
+
+  /* Dim the portrait-bar phase button since floating button is primary */
+  .portrait-phase-btn { opacity: 0.4; }
 }
 
 /* ── Landscape Smartphone (niedrige Höhe) ────────────────── */

--- a/js/engine.ts
+++ b/js/engine.ts
@@ -573,18 +573,30 @@ export class GameEngine {
     for(let i=0;i<5;i++){
       const fst = traps[i];
       if(fst && fst.card.type === CardType.Trap && fst.faceDown && !fst.used && fst.card.trapTrigger === triggerType){
-        // Race UI prompt against an 8-second timeout so the game never hangs
-        // if the modal is closed or the promise never resolves.
-        const timeout = new Promise<boolean>(resolve => setTimeout(() => resolve(false), 8000));
         const promptFn = this.ui.prompt;
         if (!promptFn) continue;
-        const activate = await Promise.race([promptFn({
+
+        // Build battle context so the UI can show who attacks what
+        const battleContext: import('./types.js').BattleContext = { triggerType };
+        if (args[0]) {
+          battleContext.attackerName = args[0].card.name;
+          battleContext.attackerAtk  = args[0].effectiveATK();
+        }
+        if (args[1]) {
+          battleContext.defenderName = args[1].card.name;
+          battleContext.defenderDef  = args[1].effectiveDEF();
+          battleContext.defenderAtk  = args[1].effectiveATK();
+          battleContext.defenderPos  = args[1].position;
+        }
+
+        const activate = await promptFn({
           title: 'Activate trap?',
           cardId: fst.card.id,
           message: `${fst.card.name}: ${fst.card.description}`,
           yes: 'Yes, activate!',
-          no:  'No, skip'
-        }), timeout]);
+          no:  'No, skip',
+          battleContext,
+        });
         if(activate){
           return this.activateTrapFromField('player', i, ...args);
         }

--- a/js/react/components/Card.tsx
+++ b/js/react/components/Card.tsx
@@ -12,9 +12,10 @@ function getTypeLabel(card: any): string {
   return getCardTypeById(card.type)?.value ?? '';
 }
 
-/** Map CardType enum to CSS class prefix */
-function typeCss(type: number): string {
-  return getCardTypeById(type)?.key.toLowerCase() ?? 'monster';
+/** Map CardType enum to CSS class prefix — distinguishes normal vs effect monsters */
+function typeCss(card: any): string {
+  if (card.type === CardType.Monster) return card.effect ? 'effect' : 'normal';
+  return getCardTypeById(card.type)?.key.toLowerCase() ?? 'monster';
 }
 
 /** Map Attribute enum to CSS class suffix */
@@ -81,7 +82,7 @@ export function Card({ card, fc = null, dimmed = false, rotated = false, big = f
       </div>
     : <div className={`${styles.cardStats} ${styles.noStats}`} />;
 
-  const tCss = typeCss(card.type);
+  const tCss = typeCss(card);
   const aCss = attrCssKey(card.attribute);
 
   const cls = [
@@ -129,10 +130,14 @@ export function Card({ card, fc = null, dimmed = false, rotated = false, big = f
 }
 
 // Re-export CSS helpers for use by other components
-export function TYPE_CSS_FN(type: number): string { return typeCss(type); }
+export function TYPE_CSS_FN(card: any): string { return typeCss(card); }
 export function ATTR_CSS_FN(attr: number | undefined): string { return attrCssKey(attr); }
 
-// Backward-compatible record-style exports (used by CollectionScreen, DeckbuilderScreen, PackOpeningScreen)
+/** Card-aware CSS class: distinguishes normal vs effect monsters */
+export function cardTypeCss(card: any): string { return typeCss(card); }
+
+// Backward-compatible record-style exports — NOTE: cannot distinguish normal/effect.
+// Prefer cardTypeCss(card) for monster cards.
 export const TYPE_CSS: Record<number, string> = new Proxy({} as Record<number, string>, {
   get(_t, prop) { return getCardTypeById(Number(prop))?.key.toLowerCase() ?? 'monster'; },
 });

--- a/js/react/components/FieldCardComponent.tsx
+++ b/js/react/components/FieldCardComponent.tsx
@@ -1,5 +1,5 @@
 import { attachHover } from './hoverApi.js';
-import { Card, TYPE_CSS, ATTR_CSS } from './Card.js';
+import { Card, cardTypeCss, ATTR_CSS } from './Card.js';
 
 interface Props {
   fc: any;
@@ -30,7 +30,7 @@ export function FieldCardComponent({
   } else if (fc.faceDown && isPlayer) {
     cls = `card field-card face-down own-facedown attr-${card.attribute ? ATTR_CSS[card.attribute] || 'spell' : 'spell'}`;
   } else {
-    cls = `card field-card ${TYPE_CSS[card.type] || 'monster'}-card attr-${card.attribute ? ATTR_CSS[card.attribute] || 'spell' : 'spell'} pos-${fc.position}`;
+    cls = `card field-card ${cardTypeCss(card)}-card attr-${card.attribute ? ATTR_CSS[card.attribute] || 'spell' : 'spell'} pos-${fc.position}`;
   }
   if (fc.hasAttacked && isPlayer) cls += ' exhausted';
   if (selected)    cls += ' selected';

--- a/js/react/components/FieldSpellTrapComponent.tsx
+++ b/js/react/components/FieldSpellTrapComponent.tsx
@@ -1,5 +1,5 @@
 import { attachHover } from './hoverApi.js';
-import { Card, TYPE_CSS } from './Card.js';
+import { Card, cardTypeCss } from './Card.js';
 import { CardType } from '../../types.js';
 
 interface Props {
@@ -23,7 +23,7 @@ export function FieldSpellTrapComponent({ fst, owner, zone, interactive, onClick
   } else if (fst.faceDown && isPlayer) {
     cls = 'card field-card face-down own-facedown attr-spell';
   } else {
-    cls = `card field-card ${TYPE_CSS[card.type] || 'spell'}-card attr-spell`;
+    cls = `card field-card ${cardTypeCss(card)}-card attr-spell`;
   }
   if (interactive) cls += ' interactive';
 

--- a/js/react/components/HandCard.tsx
+++ b/js/react/components/HandCard.tsx
@@ -1,5 +1,5 @@
 import { useRef } from 'react';
-import { Card, TYPE_CSS, ATTR_CSS } from './Card.js';
+import { Card, cardTypeCss, ATTR_CSS } from './Card.js';
 import { attachHover } from './hoverApi.js';
 
 interface Props {
@@ -18,7 +18,7 @@ export function HandCard({ card, index, playable, fusionable, targetable, newlyD
 
   const cls = [
     'card hand-card',
-    `${TYPE_CSS[card.type] || 'monster'}-card`,
+    `${cardTypeCss(card)}-card`,
     `attr-${card.attribute ? ATTR_CSS[card.attribute] || 'spell' : 'spell'}`,
     playable   ? 'playable'   : '',
     fusionable ? 'fusionable' : '',

--- a/js/react/modals/CardListModal.tsx
+++ b/js/react/modals/CardListModal.tsx
@@ -3,7 +3,7 @@ import { useModal }        from '../contexts/ModalContext.js';
 import { Card }            from '../components/Card.js';
 import { CARD_DB, FUSION_RECIPES } from '../../cards.js';
 import { CardType, isEffectMonster } from '../../types.js';
-import { TYPE_CSS, ATTR_CSS } from '../components/Card.js';
+import { cardTypeCss, ATTR_CSS } from '../components/Card.js';
 
 export function CardListModal() {
   const { openModal, closeModal } = useModal();
@@ -31,7 +31,7 @@ export function CardListModal() {
               {cards.map((card: any) => (
                 <div
                   key={card.id}
-                  className={`card hand-card ${TYPE_CSS[card.type] || 'monster'}-card attr-${card.attribute ? ATTR_CSS[card.attribute] || 'spell' : 'spell'}`}
+                  className={`card hand-card ${cardTypeCss(card)}-card attr-${card.attribute ? ATTR_CSS[card.attribute] || 'spell' : 'spell'}`}
                   style={{ cursor: 'pointer' }}
                   onClick={() => openModal({ type: 'card-detail', card })}
                 >

--- a/js/react/modals/GraveSelectModal.tsx
+++ b/js/react/modals/GraveSelectModal.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { useModal }  from '../contexts/ModalContext.js';
-import { Card, TYPE_CSS, ATTR_CSS } from '../components/Card.js';
+import { Card, cardTypeCss, ATTR_CSS } from '../components/Card.js';
 import type { ModalState } from '../contexts/ModalContext.js';
 
 interface Props { modal: Extract<ModalState, { type: 'grave-select' }>; }
@@ -17,7 +17,7 @@ export function GraveSelectModal({ modal }: Props) {
         {cards.map((card, i) => (
           <div
             key={i}
-            className={`card hand-card ${TYPE_CSS[card.type] || 'monster'}-card attr-${card.attribute ? ATTR_CSS[card.attribute] || 'spell' : 'spell'}`}
+            className={`card hand-card ${cardTypeCss(card)}-card attr-${card.attribute ? ATTR_CSS[card.attribute] || 'spell' : 'spell'}`}
             style={{ cursor: 'pointer' }}
             onClick={() => { closeModal(); resolve(card); }}
           >

--- a/js/react/modals/TrapPromptModal.tsx
+++ b/js/react/modals/TrapPromptModal.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { useModal }  from '../contexts/ModalContext.js';
 import { Card }       from '../components/Card.js';
 import { CARD_DB }    from '../../cards.js';
@@ -8,13 +9,39 @@ interface Props { modal: Extract<ModalState, { type: 'trap-prompt' }>; }
 export function TrapPromptModal({ modal }: Props) {
   const { opts, resolve } = modal;
   const { closeModal }   = useModal();
+  const { t }            = useTranslation();
   const card             = (CARD_DB as any)[opts.cardId];
+  const bc               = opts.battleContext;
 
   function answer(val: boolean) { closeModal(); resolve(val); }
+
+  // Build context line describing the battle situation
+  let contextLine: string | null = null;
+  if (bc) {
+    if (bc.triggerType === 'onOwnMonsterAttacked' && bc.attackerName && bc.defenderName) {
+      const defStat = bc.defenderPos === 'def' ? 'DEF' : 'ATK';
+      const defVal  = bc.defenderPos === 'def' ? bc.defenderDef : bc.defenderAtk;
+      contextLine = t('game.trap_ctx_attacks_monster', {
+        attacker: bc.attackerName, atk: bc.attackerAtk,
+        defender: bc.defenderName, stat: defStat, val: defVal,
+      });
+    } else if (bc.triggerType === 'onAttack' && bc.attackerName) {
+      contextLine = t('game.trap_ctx_attacks', {
+        attacker: bc.attackerName, atk: bc.attackerAtk,
+      });
+    } else if (bc.triggerType === 'onOpponentSummon' && bc.attackerName) {
+      contextLine = t('game.trap_ctx_summon', {
+        name: bc.attackerName, atk: bc.attackerAtk, def: bc.defenderDef ?? 0,
+      });
+    }
+  }
 
   return (
     <div id="trap-prompt-modal" className="modal" role="dialog" aria-modal="true">
       <h3 id="trap-prompt-title">{opts.title}</h3>
+      {contextLine && (
+        <div className="trap-battle-context">{contextLine}</div>
+      )}
       <div id="trap-prompt-card" style={{ display: 'flex', justifyContent: 'center', margin: '10px 0' }}>
         {card && <Card card={card} />}
       </div>

--- a/js/react/screens/CollectionScreen.tsx
+++ b/js/react/screens/CollectionScreen.tsx
@@ -4,7 +4,7 @@ import { useScreen }      from '../contexts/ScreenContext.js';
 import { useProgression } from '../contexts/ProgressionContext.js';
 import { useModal }        from '../contexts/ModalContext.js';
 import { CARD_DB } from '../../cards.js';
-import { Card, TYPE_CSS, ATTR_CSS } from '../components/Card.js';
+import { Card, cardTypeCss, ATTR_CSS } from '../components/Card.js';
 import { attachHover }     from '../components/hoverApi.js';
 import { Race, Rarity } from '../../types.js';
 import { getAllRaces, getAllRarities, getRarityById } from '../../type-metadata.js';
@@ -82,7 +82,7 @@ export default function CollectionScreen() {
                 onClick={() => openModal({ type: 'card-detail', card })}
               >
                 <div
-                  className={`card ${TYPE_CSS[card.type] || 'monster'}-card attr-${card.attribute ? ATTR_CSS[card.attribute] || 'spell' : 'spell'}`}
+                  className={`card ${cardTypeCss(card)}-card attr-${card.attribute ? ATTR_CSS[card.attribute] || 'spell' : 'spell'}`}
                 >
                   <Card card={card} small />
                 </div>

--- a/js/react/screens/DeckbuilderScreen.module.css
+++ b/js/react/screens/DeckbuilderScreen.module.css
@@ -44,25 +44,27 @@
 }
 
 .filterBar {
-  display: flex; gap: 6px; padding: 8px 12px;
+  display: flex; gap: 4px; padding: 6px 8px;
   background: var(--panel);
   border-bottom: 1px solid var(--border);
   flex-shrink: 0; flex-wrap: wrap; align-items: center;
 }
 
 .filterGroup {
-  display: flex; gap: 4px; align-items: center; flex-wrap: wrap;
+  display: flex; gap: 2px; align-items: center;
+  flex-wrap: nowrap; overflow-x: auto; -webkit-overflow-scrolling: touch;
 }
 
 .filterGroup + .filterGroup {
-  padding-left: 8px;
+  padding-left: 6px;
   border-left: 1px solid var(--border);
 }
 
 .filterBtn {
   background: #141e3c; color: var(--text-dim);
-  padding: 4px 12px; border: 1px solid var(--border);
-  border-radius: 0; font-size: 0.75rem; cursor: pointer;
+  padding: 3px 8px; border: 1px solid var(--border);
+  border-radius: 0; font-size: 0.65rem; cursor: pointer;
+  white-space: nowrap;
 }
 
 .filterBtn:hover  { border-color: var(--gold); color: var(--gold); }
@@ -72,12 +74,12 @@
   background: #283c78;
 }
 
-.raceBtn { padding: 4px 7px; font-size: 13px; }
+.raceBtn { padding: 3px 5px; font-size: 11px; }
 
 .raritySelect {
   background: #141e3c; color: var(--text-dim);
   border: 1px solid var(--border); border-radius: 0;
-  font-size: 12px; padding: 4px 8px; cursor: pointer;
+  font-size: 11px; padding: 3px 6px; cursor: pointer;
 }
 
 .raritySelect:focus { outline: none; border-color: var(--gold); }
@@ -86,7 +88,7 @@
   background: #141e3c; color: var(--text);
   border: 2px solid; border-color: #182860 #4068c8 #4068c8 #182860;
   border-radius: 0;
-  font-size: 12px; padding: 4px 8px; width: 130px;
+  font-size: 11px; padding: 3px 6px; width: 100px;
 }
 
 .nameSearch::placeholder { color: var(--text-dim); }
@@ -281,14 +283,21 @@
 
 /* Mobile default: stacked layout */
 .body { flex-direction: column; }
-.deckPanel { width: 100%; flex-shrink: 0; max-height: 200px; }
+.deckPanel { width: 100%; flex-shrink: 0; max-height: 140px; }
 .collectionPanel { border-right: none; border-bottom: 1px solid var(--border); }
 .collectionGrid { gap: 6px; padding: 8px; }
 
-/* Tablet/Desktop: side-by-side layout */
+/* Tablet/Desktop: side-by-side layout + larger filter controls */
 @media (min-width: 700px) {
   .body { flex-direction: row; }
   .deckPanel { width: 280px; max-height: none; }
   .collectionPanel { border-right: 1px solid var(--border); border-bottom: none; }
   .collectionGrid { gap: 8px; padding: 12px; }
+  .filterBar { gap: 6px; padding: 8px 12px; }
+  .filterGroup { gap: 4px; flex-wrap: wrap; overflow-x: visible; }
+  .filterGroup + .filterGroup { padding-left: 8px; }
+  .filterBtn { padding: 4px 12px; font-size: 0.75rem; }
+  .raceBtn { padding: 4px 7px; font-size: 13px; }
+  .raritySelect { font-size: 12px; padding: 4px 8px; }
+  .nameSearch { width: 130px; font-size: 12px; padding: 4px 8px; }
 }

--- a/js/react/screens/DeckbuilderScreen.tsx
+++ b/js/react/screens/DeckbuilderScreen.tsx
@@ -5,7 +5,7 @@ import { useProgression } from '../contexts/ProgressionContext.js';
 import { useModal }        from '../contexts/ModalContext.js';
 import { CARD_DB } from '../../cards.js';
 import { Progression }     from '../../progression.js';
-import { Card, TYPE_CSS, ATTR_CSS } from '../components/Card.js';
+import { Card, cardTypeCss, ATTR_CSS } from '../components/Card.js';
 import { attachHover }     from '../components/hoverApi.js';
 import { CardType, Race, Rarity, isMonsterType } from '../../types.js';
 import { getAllRaces, getAllRarities, getRarityById, getCardTypeById } from '../../type-metadata.js';
@@ -147,7 +147,7 @@ export default function DeckbuilderScreen() {
                 return (
                   <div key={id} className={styles.deckCardWrap} onClick={() => removeCard(id)}>
                     <div
-                      className={`card ${TYPE_CSS[card.type] || 'monster'}-card attr-${card.attribute ? ATTR_CSS[card.attribute] || 'spell' : 'spell'}`}
+                      className={`card ${cardTypeCss(card)}-card attr-${card.attribute ? ATTR_CSS[card.attribute] || 'spell' : 'spell'}`}
                       ref={el => { if (el) attachHover(el, card, null); }}
                     >
                       <Card card={card} />
@@ -164,7 +164,7 @@ export default function DeckbuilderScreen() {
                 return (
                   <div key={id} className={styles.deckRow} onClick={() => removeCard(id)}>
                     <div
-                      className={`card ${styles.deckRowMini} ${TYPE_CSS[card.type] || 'monster'}-card attr-${card.attribute ? ATTR_CSS[card.attribute] || 'spell' : 'spell'}`}
+                      className={`card ${styles.deckRowMini} ${cardTypeCss(card)}-card attr-${card.attribute ? ATTR_CSS[card.attribute] || 'spell' : 'spell'}`}
                       ref={el => { if (el) attachHover(el, card, null); }}
                     >
                       <Card card={card} />
@@ -257,7 +257,7 @@ export default function DeckbuilderScreen() {
                     onClick={!atMax && !full ? () => addCard(card.id) : undefined}
                   >
                     <div
-                      className={`card ${TYPE_CSS[card.type] || 'monster'}-card attr-${card.attribute ? ATTR_CSS[card.attribute] || 'spell' : 'spell'}`}
+                      className={`card ${cardTypeCss(card)}-card attr-${card.attribute ? ATTR_CSS[card.attribute] || 'spell' : 'spell'}`}
                       ref={el => { if (el) attachHover(el, card, null); }}
                     >
                       <Card card={card} />

--- a/js/react/screens/GameScreen.tsx
+++ b/js/react/screens/GameScreen.tsx
@@ -176,6 +176,20 @@ export default function GameScreen() {
 
       <HandArea />
 
+      {/* Floating phase button — visible only on portrait mobile via CSS */}
+      <button
+        id="floating-phase-btn"
+        className={`floating-phase-btn phase-${phase}${!isMyTurn ? ' waiting' : ''}`}
+        disabled={!isMyTurn}
+        onClick={onPortraitPhase}
+        aria-label={t('game.aria_next_phase')}
+      >
+        {!isMyTurn ? '⏸'
+          : phase === 'main'   ? '⚔ BATTLE'
+          : phase === 'battle' ? '→ END'
+          : '⏭ NEXT'}
+      </button>
+
       {/* Battle log — hidden, accessible via options later */}
       <div id="battle-log" style={{ display: 'none' }}>
         <div className="log-header">📜 Protokoll</div>

--- a/js/react/screens/PackOpeningScreen.tsx
+++ b/js/react/screens/PackOpeningScreen.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { useEffect }   from 'react';
 import { useScreen }   from '../contexts/ScreenContext.js';
 import { getRarityById } from '../../type-metadata.js';
-import { TYPE_CSS, ATTR_CSS } from '../components/Card.js';
+import { cardTypeCss, ATTR_CSS } from '../components/Card.js';
 import { Audio }        from '../../audio.js';
 import { CardType, isEffectMonster } from '../../types.js';
 import type { CardData }          from '../../types.js';
@@ -44,7 +44,7 @@ export default function PackOpeningScreen() {
               style={{ animationDelay: `${i * 0.08}s` }}
             >
               <div
-                className={`${styles.cardInner} card ${TYPE_CSS[card.type] || 'monster'}-card attr-${card.attribute ? ATTR_CSS[card.attribute] || 'spell' : 'spell'}`}
+                className={`${styles.cardInner} card ${cardTypeCss(card)}-card attr-${card.attribute ? ATTR_CSS[card.attribute] || 'spell' : 'spell'}`}
                 style={{ '--rarity-color': rarColor } as React.CSSProperties}
               >
                 {isNew && <div className={styles.newBadge}>{t('pack_opening.new_badge')}</div>}

--- a/js/types.ts
+++ b/js/types.ts
@@ -271,12 +271,23 @@ export interface GameState {
 
 // ── UI callbacks ─────────────────────────────────────────────
 
+export interface BattleContext {
+  triggerType: string;
+  attackerName?: string;
+  attackerAtk?: number;
+  defenderName?: string;
+  defenderDef?: number;
+  defenderAtk?: number;
+  defenderPos?: string;
+}
+
 export interface PromptOptions {
   title:   string;
   cardId:  string;
   message: string;
   yes:     string;
   no:      string;
+  battleContext?: BattleContext;
 }
 
 export interface UICallbacks {

--- a/locales/de.json
+++ b/locales/de.json
@@ -164,7 +164,10 @@
     "surrender": "⚑ Aufgeben",
     "surrender_confirm": "Wirklich aufgeben? Das Duell wird als Niederlage gewertet.",
     "surrender_yes": "⚑ Ja, aufgeben",
-    "surrender_cancel": "← Zurück"
+    "surrender_cancel": "← Zurück",
+    "trap_ctx_attacks_monster": "{{attacker}} (ATK {{atk}}) greift dein {{defender}} ({{stat}} {{val}}) an!",
+    "trap_ctx_attacks": "{{attacker}} (ATK {{atk}}) greift an!",
+    "trap_ctx_summon": "Gegner beschwört {{name}} (ATK {{atk}})"
   },
   "card_action": {
     "already_played": "⛔ Monster bereits gespielt",

--- a/locales/en.json
+++ b/locales/en.json
@@ -164,7 +164,10 @@
     "surrender": "⚑ Surrender",
     "surrender_confirm": "Really surrender? The duel will be counted as a defeat.",
     "surrender_yes": "⚑ Yes, surrender",
-    "surrender_cancel": "← Back"
+    "surrender_cancel": "← Back",
+    "trap_ctx_attacks_monster": "{{attacker}} (ATK {{atk}}) attacks your {{defender}} ({{stat}} {{val}})",
+    "trap_ctx_attacks": "{{attacker}} (ATK {{atk}}) is attacking!",
+    "trap_ctx_summon": "Opponent summoned {{name}} (ATK {{atk}})"
   },
   "card_action": {
     "already_played": "⛔ Monster already played",


### PR DESCRIPTION
## Summary

- **Fix normal vs effect monster card colors** — `typeCss()` returned `"monster"` for all monsters, but CSS only defines `.normal-card` (yellow/tan) and `.effect-card` (orange). Now correctly distinguishes between them across all components (Hand, Field, Deckbuilder, Collection, PackOpening, Graveyard, CardList).
- **Add battle context to trap prompt** — When asked to activate a trap, the modal now shows who is attacking and with what stats (e.g. "Klingenläufer (ATK 1050) greift dein Schildgardist (DEF 450) an!"). Added i18n keys for DE/EN.
- **Remove trap activation timeout** — Previously 8 seconds, now waits indefinitely for player input so the attack never goes through before the player can decide.
- **Add floating phase button on mobile** — Fixed position bottom-right, 48px tall, within thumb reach. Uses same phase-specific color scheme. Portrait-bar button dimmed as secondary indicator.
- **Improve deckbuilder mobile layout** — Compact filter bar (smaller buttons, horizontal scroll for race icons instead of wrapping), reduced deck panel max-height (200→140px), smaller font sizes for filters on mobile with desktop sizes restored via media query.

## Test plan

- [x] `npm run build` passes
- [x] All 395 Vitest tests pass
- [ ] Verify Normal monsters show yellow/tan borders, Effect monsters show orange borders
- [ ] Open a battle on mobile, let opponent attack with a trap set — verify battle context banner appears in trap prompt
- [ ] Verify trap prompt stays open indefinitely (no auto-skip after 8s)
- [ ] Verify floating phase button appears bottom-right on mobile portrait (540px or narrower)
- [ ] Open deckbuilder on mobile — verify compact filter bar and reduced deck panel height

https://claude.ai/code/session_01Q9LFS2t3xUzTJnF65TtATU