### PR TITLE
fix(ui): improve savepoint screen UX and navigation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -840,6 +840,7 @@ button { cursor: pointer; border: none; font-family: inherit; transition: none; 
   margin-top: 20px; padding-top: 16px;
   border-top: 1px solid var(--border);
 }
+.options-buttons .btn-cancel { margin-top: 0; }
 
 /* Surrender section */
 .options-surrender {

--- a/js/react/modals/ResultModal.tsx
+++ b/js/react/modals/ResultModal.tsx
@@ -45,7 +45,7 @@ export function ResultModal({ modal }: Props) {
   function backToTitle() {
     closeModal();
     refresh();
-    navigateTo('title');
+    navigateTo('save-point');
   }
 
   return (

--- a/js/react/screens/CollectionScreen.tsx
+++ b/js/react/screens/CollectionScreen.tsx
@@ -36,7 +36,7 @@ export default function CollectionScreen() {
         <div className={styles.stats}>
           <span id="collection-count">{t('collection.cards_count', { owned: ownedCount, total: totalCards })}</span>
         </div>
-        <button className={`btn-secondary ${styles.backBtn}`} onClick={() => navigateTo('title')}>{t('collection.back')}</button>
+        <button className={`btn-secondary ${styles.backBtn}`} onClick={() => navigateTo('save-point')}>{t('collection.back')}</button>
       </div>
 
       <div className={styles.filters}>

--- a/js/react/screens/DeckbuilderScreen.tsx
+++ b/js/react/screens/DeckbuilderScreen.tsx
@@ -126,7 +126,7 @@ export default function DeckbuilderScreen() {
             style={{ opacity: deckFull ? 1 : 0.4, cursor: deckFull ? 'pointer' : 'not-allowed' }}
             onClick={saveDeck}
           >{t('deckbuilder.save_btn')}</button>
-          <button id="btn-db-back" className="btn-secondary" onClick={() => navigateTo('title')}>{t('deckbuilder.back')}</button>
+          <button id="btn-db-back" className="btn-secondary" onClick={() => navigateTo('save-point')}>{t('deckbuilder.back')}</button>
         </div>
       </div>
 

--- a/js/react/screens/OpponentScreen.tsx
+++ b/js/react/screens/OpponentScreen.tsx
@@ -9,11 +9,12 @@ import type { OpponentConfig } from '../../types.js';
 import styles from './OpponentScreen.module.css';
 
 export default function OpponentScreen() {
-  const { setScreen, navigateTo } = useScreen();
+  const { setScreen, navigateTo, screenData } = useScreen();
   const { opponents }   = useProgression();
   const { startGame }   = useGame();
   const [hovered, setHovered] = useState<OpponentConfig | null>(null);
   const { t } = useTranslation();
+  const mode = (screenData?.mode as string) ?? 'free-duel';
 
   function selectOpponent(cfg: OpponentConfig) {
     startGame(cfg);
@@ -25,32 +26,34 @@ export default function OpponentScreen() {
       <div className={styles.header}>
         <h2 className={styles.title}>{t('opponent.headline')}</h2>
         <p className={styles.subtitle}>{t('opponent.subtitle')}</p>
-        <button className={`btn-secondary ${styles.backBtn}`} onClick={() => navigateTo('title')}>{t('opponent.back')}</button>
+        <button className={`btn-secondary ${styles.backBtn}`} onClick={() => navigateTo('save-point')}>{t('opponent.back')}</button>
       </div>
 
       <div className={styles.grid}>
         {(OPPONENT_CONFIGS as OpponentConfig[]).map(cfg => {
           const oppData = opponents[cfg.id] || { unlocked: cfg.id === 1, wins: 0, losses: 0 };
           const isUnlocked = oppData.unlocked;
+          const hasBeenBeaten = (oppData.wins ?? 0) > 0;
+          const isAvailable = mode === 'free-duel' ? (isUnlocked && hasBeenBeaten) : isUnlocked;
           const raceMeta = getRaceById(cfg.race);
           const accent = raceMeta?.color ?? '#888';
 
           return (
             <div
               key={cfg.id}
-              className={`${styles.tile}${isUnlocked ? '' : ` ${styles.locked}`}`}
-              onClick={() => isUnlocked && selectOpponent(cfg)}
-              onMouseEnter={() => isUnlocked && setHovered(cfg)}
+              className={`${styles.tile}${isAvailable ? '' : ` ${styles.locked}`}`}
+              onClick={() => isAvailable && selectOpponent(cfg)}
+              onMouseEnter={() => isAvailable && setHovered(cfg)}
               onMouseLeave={() => setHovered(null)}
             >
               <div className={styles.frame} style={{ borderColor: accent }}>
                 <div className={styles.art} style={{ background: `linear-gradient(135deg,${accent}44,#111830)` }}>
                   <div className={styles.symbol}>{raceMeta?.icon ?? '?'}</div>
                 </div>
-                {!isUnlocked && <div className={styles.lockedOverlay}>🔒</div>}
+                {!isAvailable && <div className={styles.lockedOverlay}>🔒</div>}
               </div>
-              <div className={styles.name}>{isUnlocked ? cfg.name : '???'}</div>
-              {isUnlocked && (
+              <div className={styles.name}>{isAvailable ? cfg.name : '???'}</div>
+              {isAvailable && (
                 <div className={styles.record}>{(oppData as any).wins ?? 0}W / {(oppData as any).losses ?? 0}L</div>
               )}
             </div>

--- a/js/react/screens/PackOpeningScreen.tsx
+++ b/js/react/screens/PackOpeningScreen.tsx
@@ -73,7 +73,7 @@ export default function PackOpeningScreen() {
 
       <div className={styles.buttons}>
         <button className="btn-secondary" onClick={() => navigateTo('shop')}>{t('pack_opening.back_shop')}</button>
-        <button className="btn-primary"   onClick={() => navigateTo('title')}>{t('pack_opening.home')}</button>
+        <button className="btn-primary"   onClick={() => navigateTo('save-point')}>{t('pack_opening.home')}</button>
       </div>
     </div>
   );

--- a/js/react/screens/SavePointScreen.tsx
+++ b/js/react/screens/SavePointScreen.tsx
@@ -47,16 +47,16 @@ export default function SavePointScreen() {
           <p className={styles.backupWarning}>{t('save.backup_warning')}</p>
         )}
         <div className={styles.menu}>
-          <button className="btn-primary" onClick={handleSave}>
-            {savedMsg ? t('save.btn_saved') : t('save.btn_save')}
-          </button>
-          <button className="btn-secondary" onClick={() => navigateTo('opponent')}>{t('save.btn_story')}</button>
-          <button className="btn-secondary" onClick={() => navigateTo('opponent')}>{t('save.btn_duel')}</button>
+          <button className="btn-secondary" onClick={() => navigateTo('opponent', { mode: 'story' })}>{t('save.btn_story')}</button>
+          <button className="btn-secondary" onClick={() => navigateTo('opponent', { mode: 'free-duel' })}>{t('save.btn_duel')}</button>
           <button className="btn-secondary" onClick={() => navigateTo('shop')}>{t('save.btn_shop')}</button>
           <button className="btn-secondary" onClick={() => navigateTo('collection')}>{t('save.btn_collection')}</button>
           <button className="btn-secondary" onClick={() => navigateTo('deckbuilder')}>{t('save.btn_deckbuilder')}</button>
           <button className="btn-secondary" onClick={() => openModal({ type: 'card-list' })}>{t('save.btn_cardlist')}</button>
           <button className="btn-secondary" onClick={handleToMainMenu}>{t('save.btn_mainmenu')}</button>
+          <button className="btn-primary" onClick={handleSave}>
+            {savedMsg ? t('save.btn_saved') : t('save.btn_save')}
+          </button>
         </div>
       </div>
     </div>

--- a/js/react/screens/ShopScreen.tsx
+++ b/js/react/screens/ShopScreen.tsx
@@ -51,7 +51,7 @@ export default function ShopScreen() {
           <span id="shop-coin-display">{coins.toLocaleString()}</span>
           <span className="coins-label">{t('common.coins')}</span>
         </div>
-        <button className={`btn-secondary ${styles.backBtn}`} onClick={() => navigateTo('title')}>{t('shop.back')}</button>
+        <button className={`btn-secondary ${styles.backBtn}`} onClick={() => navigateTo('save-point')}>{t('shop.back')}</button>
       </div>
 
       <div className={styles.grid}>

--- a/locales/de.json
+++ b/locales/de.json
@@ -47,20 +47,20 @@
   "opponent": {
     "headline": "FREIES DUELL",
     "subtitle": "Wähle deinen Gegner",
-    "back": "← Hauptmenü"
+    "back": "← Zurück"
   },
   "save": {
     "headline": "SPEICHERPUNKT",
     "backup_warning": "Neues Spiel aktiv — speichere um den alten Stand zu überschreiben, oder kehre zurück um abzubrechen.",
-    "btn_save": "💾 Speichern",
-    "btn_saved": "✓ Gespeichert!",
-    "btn_story": "📖 Story",
-    "btn_duel": "⚔ Freies Duell Beginnen",
-    "btn_shop": "🛒 Shop",
-    "btn_collection": "📚 Sammlung",
-    "btn_deckbuilder": "🃏 Deckbuilder",
-    "btn_cardlist": "📋 Kartenliste",
-    "btn_mainmenu": "🏠 Zum Hauptmenü",
+    "btn_save": "Speichern",
+    "btn_saved": "Gespeichert!",
+    "btn_story": "Story",
+    "btn_duel": "Freies Duell",
+    "btn_shop": "Shop",
+    "btn_collection": "Sammlung",
+    "btn_deckbuilder": "Deckbuilder",
+    "btn_cardlist": "Kartenliste",
+    "btn_mainmenu": "Zum Hauptmenü",
     "confirm_overwrite": "Das alte Spiel wird überschrieben. Fortfahren?"
   },
   "options": {
@@ -72,7 +72,7 @@
   },
   "shop": {
     "title": "◈ JADE-SHOP",
-    "back": "← Hauptmenü",
+    "back": "← Zurück",
     "buy_btn": "Pack kaufen",
     "packages_title": "◈ Kartenpakete",
     "locked": "🔒 Gesperrt"
@@ -101,7 +101,7 @@
   "collection": {
     "title": "📚 MEINE SAMMLUNG",
     "cards_count": "{{owned}} / {{total}} Karten",
-    "back": "← Hauptmenü",
+    "back": "← Zurück",
     "rarity_all": "Alle Seltenheiten"
   },
   "deckbuilder": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -47,20 +47,20 @@
   "opponent": {
     "headline": "FREE DUEL",
     "subtitle": "Choose your opponent",
-    "back": "← Main Menu"
+    "back": "← Back"
   },
   "save": {
     "headline": "SAVE POINT",
     "backup_warning": "New game active — save to overwrite the old state, or go back to cancel.",
-    "btn_save": "💾 Save",
-    "btn_saved": "✓ Saved!",
-    "btn_story": "📖 Story",
-    "btn_duel": "⚔ Start Free Duel",
-    "btn_shop": "🛒 Shop",
-    "btn_collection": "📚 Collection",
-    "btn_deckbuilder": "🃏 Deckbuilder",
-    "btn_cardlist": "📋 Card List",
-    "btn_mainmenu": "🏠 Main Menu",
+    "btn_save": "Save",
+    "btn_saved": "Saved!",
+    "btn_story": "Story",
+    "btn_duel": "Free Duel",
+    "btn_shop": "Shop",
+    "btn_collection": "Collection",
+    "btn_deckbuilder": "Deckbuilder",
+    "btn_cardlist": "Card List",
+    "btn_mainmenu": "Main Menu",
     "confirm_overwrite": "Old game will be overwritten. Continue?"
   },
   "options": {
@@ -72,7 +72,7 @@
   },
   "shop": {
     "title": "◈ JADE SHOP",
-    "back": "← Main Menu",
+    "back": "← Back",
     "buy_btn": "Buy Pack",
     "packages_title": "◈ Card Packages",
     "locked": "🔒 Locked"
@@ -101,7 +101,7 @@
   "collection": {
     "title": "📚 MY COLLECTION",
     "cards_count": "{{owned}} / {{total}} Cards",
-    "back": "← Main Menu",
+    "back": "← Back",
     "rarity_all": "All Rarities"
   },
   "deckbuilder": {


### PR DESCRIPTION
## Summary
- Remove emoji icons from all savepoint screen buttons (en + de)
- Move "Save" button to last position in the savepoint menu
- All sub-screens (Shop, Collection, Deckbuilder, Opponent, Pack Opening, Result) now navigate back to save-point instead of main menu
- Free Duel mode only shows opponents that have been beaten at least once in story mode
- Fix cancel button vertical misalignment in options modal (removed inherited `margin-top`)

## Test plan
- [ ] Verify savepoint buttons no longer show emoji icons
- [ ] Verify "Save" is the last button in the savepoint menu
- [ ] Verify "Back" from Shop/Collection/Deckbuilder/Opponent returns to savepoint
- [ ] Verify Story mode shows all unlocked opponents as before
- [ ] Verify Free Duel only shows opponents with at least 1 win
- [ ] Verify cancel button in options modal aligns properly with OK/Apply

https://claude.ai/code/session_01JnETB3cr5i38TypY7BTkv7