### PR TITLE
feat(ui): show card names in card list and collection grid

### DIFF
--- a/js/react/components/Card.module.css
+++ b/js/react/components/Card.module.css
@@ -10,9 +10,10 @@
 }
 
 .nameShort {
-  font-size: 10px; font-weight: bold; color: var(--gold-light);
+  font-size: 8px; font-weight: bold; color: var(--gold-light);
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-  max-width: 68px;
+  min-width: 0;
+  flex: 1;
 }
 
 .attrOrb {
@@ -137,7 +138,7 @@
 :global(.opponent-side) .atkVal,
 :global(.opponent-side) .defVal       { font-size: 7px; }
 
-/* ── Small-card layout (art + ATK/DEF only) ─────────────────────── */
+/* ── Small-card layout (art + ATK/DEF + name) ───────────────────── */
 :global(.small-card) .cardArt { max-height: 80px; }
 :global(.small-card) .cardHeader { display: none; }
 :global(.small-card) .cardLevel  { display: none; }
@@ -153,11 +154,31 @@
 :global(.small-card) .defVal {
   flex: 1; text-align: center; padding: 3px 0; font-size: 9px;
 }
+
+/* Card name shown below stats in small layout */
+.cardNameSmall {
+  font-size: 7px;
+  font-weight: bold;
+  color: var(--gold-light, #e0c870);
+  text-align: center;
+  padding: 2px 3px 3px;
+  background: #000;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.3;
+}
+
+/* Spell/Trap type label in small card stats row */
+.typeLabel {
+  flex: 1; text-align: center; padding: 3px 0; font-size: 8px;
+  color: #7090b0; font-weight: bold;
+}
 :global(.opponent-side) :global(.small-card) .atkVal,
 :global(.opponent-side) :global(.small-card) .defVal { font-size: 7px; padding: 2px 0; }
 
 /* ── Big-card overrides (180×248px) ─────────────────────────────── */
-:global(.big-card) .nameShort   { font-size: 13px; max-width: 120px; }
+:global(.big-card) .nameShort   { font-size: 11px; }
 :global(.big-card) .attrOrb     { width: 20px; height: 20px; font-size: 12px; }
 :global(.big-card) .cardLevel   { font-size: 12px; min-height: 15px; letter-spacing: -0.5px; }
 :global(.big-card) .rarityText  { font-size: 9px; }

--- a/js/react/components/Card.tsx
+++ b/js/react/components/Card.tsx
@@ -94,17 +94,22 @@ export function Card({ card, fc = null, dimmed = false, rotated = false, big = f
     extraClass,
   ].filter(Boolean).join(' ');
 
-  // Small layout: only artwork area + ATK/DEF
+  // Small layout: artwork + ATK/DEF + name
   if (small) {
     return (
       <div className={cls}>
-        <div className={styles.cardArt} />
+        <div className={styles.cardArt}>
+          {raceBadge}
+        </div>
         {isMonster
           ? <div className={styles.cardStats}>
               <span className={styles.atkVal}>{effATK}</span>
               <span className={styles.defVal}>{effDEF}</span>
             </div>
-          : null}
+          : <div className={styles.cardStats}>
+              <span className={styles.typeLabel}>{typeLabel}</span>
+            </div>}
+        <div className={styles.cardNameSmall}>{card.name}</div>
       </div>
     );
   }

--- a/js/react/screens/CollectionScreen.module.css
+++ b/js/react/screens/CollectionScreen.module.css
@@ -70,8 +70,8 @@
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(var(--card-w, 104px), 1fr));
-  gap: 8px;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 10px;
   width: 100%;
   max-width: 1200px;
 }


### PR DESCRIPTION
- Add card name below ATK/DEF stats in small card layout
- Show race badge and type label for spells/traps in small cards
- Remove max-width constraint on card name, use flex layout instead
- Reduce name font size (10px→8px) so longer names fit without truncation
- Widen collection grid columns (104px→120px) for better readability

https://claude.ai/code/session_01S5rbUaTtgnk21tYiFmB4sD