### PR TITLE
feat(ui): show attacker & defender cards in trap prompt modal

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -643,6 +643,19 @@ button { cursor: pointer; border: none; font-family: inherit; transition: none; 
 #trap-prompt-card { display: flex; justify-content: center; margin: 10px 0; }
 #trap-prompt-msg  { font-size: 0.75rem; color: var(--text); margin: 8px 0; }
 .prompt-buttons { display: flex; gap: 10px; justify-content: center; margin-top: 12px; }
+.trap-battle-cards {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin: 8px 0;
+}
+.trap-battle-card { flex: 0 0 auto; }
+.trap-battle-vs {
+  font-size: 1.5rem;
+  color: var(--gold);
+  text-shadow: 0 0 6px rgba(255, 200, 50, 0.6);
+}
 .trap-battle-context {
   background: rgba(40, 10, 10, 0.85);
   border: 1px solid rgba(255, 80, 80, 0.5);

--- a/js/engine.ts
+++ b/js/engine.ts
@@ -579,14 +579,16 @@ export class GameEngine {
         // Build battle context so the UI can show who attacks what
         const battleContext: import('./types.js').BattleContext = { triggerType };
         if (args[0]) {
-          battleContext.attackerName = args[0].card.name;
-          battleContext.attackerAtk  = args[0].effectiveATK();
+          battleContext.attackerName   = args[0].card.name;
+          battleContext.attackerAtk    = args[0].effectiveATK();
+          battleContext.attackerCardId = args[0].card.id;
         }
         if (args[1]) {
-          battleContext.defenderName = args[1].card.name;
-          battleContext.defenderDef  = args[1].effectiveDEF();
-          battleContext.defenderAtk  = args[1].effectiveATK();
-          battleContext.defenderPos  = args[1].position;
+          battleContext.defenderName   = args[1].card.name;
+          battleContext.defenderDef    = args[1].effectiveDEF();
+          battleContext.defenderAtk    = args[1].effectiveATK();
+          battleContext.defenderPos    = args[1].position;
+          battleContext.defenderCardId = args[1].card.id;
         }
 
         const activate = await promptFn({

--- a/js/react/modals/TrapPromptModal.tsx
+++ b/js/react/modals/TrapPromptModal.tsx
@@ -36,11 +36,29 @@ export function TrapPromptModal({ modal }: Props) {
     }
   }
 
+  const attackerCard = bc?.attackerCardId != null ? (CARD_DB as any)[bc.attackerCardId] : null;
+  const defenderCard = bc?.defenderCardId != null ? (CARD_DB as any)[bc.defenderCardId] : null;
+
   return (
     <div id="trap-prompt-modal" className="modal" role="dialog" aria-modal="true">
       <h3 id="trap-prompt-title">{opts.title}</h3>
       {contextLine && (
         <div className="trap-battle-context">{contextLine}</div>
+      )}
+      {(attackerCard || defenderCard) && (
+        <div className="trap-battle-cards">
+          {attackerCard && (
+            <div className="trap-battle-card">
+              <Card card={attackerCard} small />
+            </div>
+          )}
+          <span className="trap-battle-vs">&#x2694;</span>
+          {defenderCard && (
+            <div className="trap-battle-card">
+              <Card card={defenderCard} small />
+            </div>
+          )}
+        </div>
       )}
       <div id="trap-prompt-card" style={{ display: 'flex', justifyContent: 'center', margin: '10px 0' }}>
         {card && <Card card={card} />}

--- a/js/types.ts
+++ b/js/types.ts
@@ -275,10 +275,12 @@ export interface BattleContext {
   triggerType: string;
   attackerName?: string;
   attackerAtk?: number;
+  attackerCardId?: number;
   defenderName?: string;
   defenderDef?: number;
   defenderAtk?: number;
   defenderPos?: string;
+  defenderCardId?: number;
 }
 
 export interface PromptOptions {


### PR DESCRIPTION
Display the two battling cards visually (as small card previews) in the
trap activation prompt so the player can see which monsters are involved
before deciding whether to activate their trap.

https://claude.ai/code/session_01JxinqrdtS5Z8vnDW7ozSfa