### PR TITLE
fix(ui): allow activating targeted spell cards from field

### DIFF
--- a/js/react/contexts/SelectionContext.tsx
+++ b/js/react/contexts/SelectionContext.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext, useState, useCallback } from 'react';
 import type { CardData } from '../../types.js';
 
 export type SelMode =
-  | 'hand' | 'attack' | 'fusion1' | 'spell-target'
+  | 'hand' | 'attack' | 'fusion1' | 'spell-target' | 'field-spell-target'
   | 'grave-target' | 'trap-target' | null;
 
 export interface Selection {
@@ -11,6 +11,7 @@ export interface Selection {
   attackerZone:   number | null;
   fusion1:        { handIndex: number } | null;
   spellHandIndex: number | null;
+  spellFieldZone: number | null;
   spellCard:      CardData | null;
   trapFieldZone:  number | null;
   callback:       ((card: CardData) => void) | null;
@@ -19,7 +20,7 @@ export interface Selection {
 
 const EMPTY: Selection = {
   mode: null, handIndex: null, attackerZone: null, fusion1: null,
-  spellHandIndex: null, spellCard: null, trapFieldZone: null, callback: null, hint: '',
+  spellHandIndex: null, spellFieldZone: null, spellCard: null, trapFieldZone: null, callback: null, hint: '',
 };
 
 interface SelectionCtx {

--- a/js/react/modals/CardDetailModal.tsx
+++ b/js/react/modals/CardDetailModal.tsx
@@ -68,7 +68,11 @@ export function CardDetailModal({ modal }: Props) {
     }
 
     if (isSp && phase === 'main' && source === 'field-spell') {
-      if (card.spellType !== 'targeted' && card.spellType !== 'fromGrave') {
+      if (card.spellType === 'targeted' || card.spellType === 'fromGrave') {
+        actions.push(actionBtn(t('card_action.activate'), () => {
+          startFieldSpellTargeting(card, index, state, game, setSel, openModal, closeModal, t);
+        }));
+      } else {
         actions.push(actionBtn(t('card_action.activate'), () => {
           game.activateSpellFromField('player', index);
           closeModal();
@@ -155,6 +159,25 @@ function startSpellTargeting(card: any, handIndex: number, state: any, game: any
     const monsters = state.player.graveyard.filter((c: any) => isMonsterType(c.type));
     if (!monsters.length) return;
     openModal({ type: 'grave-select', cards: monsters, resolve: (chosen: any) => game.activateSpell('player', handIndex, chosen) });
+  }
+}
+
+function startFieldSpellTargeting(card: any, zone: number, state: any, game: any, setSel: any, openModal: any, close: any, t: any) {
+  if (card.spellType === 'targeted' && card.target === 'ownMonster') {
+    const targets = state.player.field.monsters
+      .map((fc: any, i: number) => ({ fc, zone: i }))
+      .filter(({ fc }: any) => fc);
+    if (!targets.length) return;
+    if (targets.length === 1) { game.activateSpellFromField('player', zone, targets[0].fc); close(); return; }
+    setSel({ mode: 'field-spell-target', spellFieldZone: zone, spellCard: card, hint: t('card_action.hint_spell_own') });
+    close();
+  } else if (card.spellType === 'targeted' && card.target === 'ownDarkMonster') {
+    const fc = state.player.field.monsters.find((m: any) => m && m.card.attribute === Attribute.Dark);
+    if (fc) { game.activateSpellFromField('player', zone, fc); close(); }
+  } else if (card.spellType === 'fromGrave') {
+    const monsters = state.player.graveyard.filter((c: any) => isMonsterType(c.type));
+    if (!monsters.length) return;
+    openModal({ type: 'grave-select', cards: monsters, resolve: (chosen: any) => game.activateSpellFromField('player', zone, chosen) });
   }
 }
 

--- a/js/react/screens/game/PlayerField.tsx
+++ b/js/react/screens/game/PlayerField.tsx
@@ -48,7 +48,7 @@ export function PlayerField({ showDirect, setShowDirect }: Props) {
   }
 
   function isPlayerMonsterSpellTarget(zone: number) {
-    return selMode === 'spell-target' && !!player.field.monsters[zone];
+    return (selMode === 'spell-target' || selMode === 'field-spell-target') && !!player.field.monsters[zone];
   }
 
   const onOwnFieldCardClick = useCallback((fc: any, zone: number) => {
@@ -70,12 +70,18 @@ export function PlayerField({ showDirect, setShowDirect }: Props) {
 
   const onSpellTargetSelect = useCallback((zone: number) => {
     const game = gameRef.current;
-    if (!game || selMode !== 'spell-target') return;
+    if (!game) return;
     const target = player.field.monsters[zone];
     if (!target) return;
-    game.activateSpell('player', sel.spellHandIndex, target);
+    if (selMode === 'spell-target') {
+      game.activateSpell('player', sel.spellHandIndex, target);
+    } else if (selMode === 'field-spell-target') {
+      game.activateSpellFromField('player', sel.spellFieldZone!, target);
+    } else {
+      return;
+    }
     resetSel();
-  }, [gameRef, selMode, player.field.monsters, sel.spellHandIndex, resetSel]);
+  }, [gameRef, selMode, player.field.monsters, sel.spellHandIndex, sel.spellFieldZone, resetSel]);
 
   const onFieldSpellTrapClick = useCallback((zone: number, fst: any) => {
     const game = gameRef.current;


### PR DESCRIPTION
## Summary

- **Bug**: Targeted and `fromGrave` spell cards set on the field could no longer be activated on subsequent turns. The CardDetailModal opened but showed no "Aktivieren" button — only "Close".
- **Root cause**: When the CardActionMenu was merged into CardDetailModal, targeted/fromGrave spell types were explicitly excluded from the field-spell activation path (`card.spellType !== 'targeted' && card.spellType !== 'fromGrave'`) without providing an alternative targeting flow.
- **Fix**: Added `startFieldSpellTargeting()` helper and a new `field-spell-target` selection mode so players can pick a monster target when activating targeted spells from the field, mirroring the existing hand-spell targeting flow but using `activateSpellFromField()`.

## Changed files
- `js/react/modals/CardDetailModal.tsx` — Add activate button + targeting flow for targeted/fromGrave field spells
- `js/react/contexts/SelectionContext.tsx` — Add `field-spell-target` selection mode and `spellFieldZone` field
- `js/react/screens/game/PlayerField.tsx` — Handle `field-spell-target` mode in target selection and interactivity checks

## Test plan
- [x] All 395 unit tests pass
- [x] Vite production build succeeds
- [ ] Manual: Set a targeted spell card (e.g. Kraftschub) face-down, next turn click it → detail modal should show "Aktivieren" button
- [ ] Manual: Clicking "Aktivieren" should enter targeting mode, clicking a monster should apply the spell effect
- [ ] Manual: Non-targeted spells set on field still activate correctly

https://claude.ai/code/session_01RfSYrupj3PYBEt9PpFBqgk