### PR TITLE
feat(ui): add download button to battle log modal

### DIFF
--- a/js/react/modals/BattleLogModal.tsx
+++ b/js/react/modals/BattleLogModal.tsx
@@ -7,6 +7,17 @@ export function BattleLogModal() {
   const { t } = useTranslation();
   const { logEntries } = useGame();
 
+  const handleDownload = () => {
+    const text = logEntries.join('\n');
+    const blob = new Blob([text], { type: 'text/plain' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `battle-log-${new Date().toISOString().slice(0, 19).replace(/:/g, '-')}.txt`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
   return (
     <div className="modal" id="battle-log-modal">
       <h2>{t('options.view_log')}</h2>
@@ -19,6 +30,13 @@ export function BattleLogModal() {
         }
       </div>
       <div className="options-buttons">
+        <button
+          className="btn-secondary"
+          onClick={handleDownload}
+          disabled={logEntries.length === 0}
+        >
+          {t('options.download_log')}
+        </button>
         <button className="btn-primary" onClick={closeModal}>{t('common.ok')}</button>
       </div>
     </div>

--- a/locales/de.json
+++ b/locales/de.json
@@ -70,7 +70,8 @@
     "vol_music": "Hintergrundmusik",
     "vol_sfx": "Soundeffekte",
     "view_log": "📜 Kampfprotokoll",
-    "log_empty": "Noch keine Einträge."
+    "log_empty": "Noch keine Einträge.",
+    "download_log": "⬇ Protokoll herunterladen"
   },
   "shop": {
     "title": "◈ JADE-SHOP",

--- a/locales/en.json
+++ b/locales/en.json
@@ -70,7 +70,8 @@
     "vol_music": "Background Music",
     "vol_sfx": "Sound Effects",
     "view_log": "📜 Battle Log",
-    "log_empty": "No log entries yet."
+    "log_empty": "No log entries yet.",
+    "download_log": "⬇ Download Log"
   },
   "shop": {
     "title": "◈ JADE SHOP",


### PR DESCRIPTION
## Summary\n- Adds a download button to the BattleLogModal that exports all log entries as a timestamped `.txt` file\n- Button is disabled when the log is empty\n- Includes i18n translations for both English and German\n\n## Test plan\n- [ ] Open a game and play a few turns to generate log entries\n- [ ] Open Options → View Log and verify the download button appears\n- [ ] Click the download button and confirm a `.txt` file is downloaded with correct log content\n- [ ] Verify the button is disabled when there are no log entries\n- [ ] Test in German locale to verify translation\n\nhttps://claude.ai/code/session_01Naps7D3CJ8VoMkkumoLLEm