### PR TITLE
fix(campaign): wire up campaign duel completion and free duel sync

### DIFF
--- a/js/react/contexts/CampaignContext.tsx
+++ b/js/react/contexts/CampaignContext.tsx
@@ -1,10 +1,17 @@
 import { createContext, useContext, useState, useCallback, useMemo, useEffect } from 'react';
-import type { CampaignData, CampaignProgress, CampaignNode } from '../../campaign-types.js';
+import type { CampaignData, CampaignProgress, CampaignNode, NodeRewards } from '../../campaign-types.js';
 import { CAMPAIGN_DATA, isNodeUnlocked as storeIsNodeUnlocked, getNode, hasCampaignData } from '../../campaign-store.js';
 import { Progression } from '../../progression.js';
 import { useProgression } from './ProgressionContext.js';
 import { OPPONENT_CONFIGS } from '../../cards.js';
 import type { OpponentConfig } from '../../types.js';
+
+export interface PendingDuel {
+  nodeId: string;
+  completeOnLoss?: boolean;
+  rewards?: NodeRewards;
+  postDialogue?: string[];
+}
 
 interface CampaignCtx {
   campaignData: CampaignData;
@@ -13,6 +20,9 @@ interface CampaignCtx {
   completeNode: (nodeId: string) => void;
   hasCampaign: boolean;
   getOpponentForNode: (nodeId: string) => OpponentConfig | undefined;
+  pendingDuel: PendingDuel | null;
+  setPendingDuel: (duel: PendingDuel | null) => void;
+  refreshCampaignProgress: () => void;
 }
 
 const CampaignContext = createContext<CampaignCtx>({
@@ -22,10 +32,14 @@ const CampaignContext = createContext<CampaignCtx>({
   completeNode: () => {},
   hasCampaign: false,
   getOpponentForNode: () => undefined,
+  pendingDuel: null,
+  setPendingDuel: () => {},
+  refreshCampaignProgress: () => {},
 });
 
 export function CampaignProvider({ children }: { children: React.ReactNode }) {
   const [progress, setProgress] = useState<CampaignProgress>(Progression.getCampaignProgress());
+  const [pendingDuel, setPendingDuel] = useState<PendingDuel | null>(null);
   const { refresh } = useProgression();
 
   // Re-read campaign data on mount (it may have been loaded after initial render)
@@ -44,6 +58,10 @@ export function CampaignProvider({ children }: { children: React.ReactNode }) {
     const node = getNode(nodeId);
     if (!node || node.type !== 'duel' || node.opponentId === undefined) return undefined;
     return (OPPONENT_CONFIGS as OpponentConfig[]).find(c => c.id === node.opponentId);
+  }, []);
+
+  const refreshCampaignProgress = useCallback(() => {
+    setProgress({ ...Progression.getCampaignProgress() });
   }, []);
 
   const completeNode = useCallback((nodeId: string) => {
@@ -68,8 +86,8 @@ export function CampaignProvider({ children }: { children: React.ReactNode }) {
   }, [refresh]);
 
   const value = useMemo(
-    () => ({ campaignData, progress, isNodeUnlocked: isNodeUnlockedFn, completeNode, hasCampaign, getOpponentForNode }),
-    [campaignData, progress, isNodeUnlockedFn, completeNode, hasCampaign, getOpponentForNode],
+    () => ({ campaignData, progress, isNodeUnlocked: isNodeUnlockedFn, completeNode, hasCampaign, getOpponentForNode, pendingDuel, setPendingDuel, refreshCampaignProgress }),
+    [campaignData, progress, isNodeUnlockedFn, completeNode, hasCampaign, getOpponentForNode, pendingDuel, refreshCampaignProgress],
   );
 
   return (

--- a/js/react/contexts/GameContext.tsx
+++ b/js/react/contexts/GameContext.tsx
@@ -35,7 +35,7 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
   const { resetSel }      = useSelection();
   const { currentDeck, loadDeck, refresh } = useProgression();
   const { setScreen, navigateTo } = useScreen();
-  const { pendingDuel, setPendingDuel } = useCampaign();
+  const { pendingDuel, setPendingDuel, refreshCampaignProgress } = useCampaign();
 
   // Stable refs so useMemo(() => uiCallbacks, []) can safely use current values
   const openModalRef      = useRef(openModal);      openModalRef.current      = openModal;
@@ -45,6 +45,7 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
   const refreshRef        = useRef(refresh);        refreshRef.current        = refresh;
   const pendingDuelRef    = useRef(pendingDuel);    pendingDuelRef.current    = pendingDuel;
   const setPendingDuelRef = useRef(setPendingDuel); setPendingDuelRef.current = setPendingDuel;
+  const refreshCampaignRef = useRef(refreshCampaignProgress); refreshCampaignRef.current = refreshCampaignProgress;
   const lastOppRef        = useRef<OpponentConfig | null>(null);
 
   const uiCallbacks = useMemo<UICallbacks>(() => ({
@@ -80,21 +81,24 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
         setPendingDuelRef.current(null);
         import('../../progression.js').then(({ Progression }) => {
           const isComplete = result === 'victory' || !!pending.completeOnLoss;
-          Progression.setNodeStatus(pending.nodeId, isComplete ? 'complete' : 'available');
           if (isComplete) {
+            Progression.markNodeComplete(pending.nodeId);
             if (pending.rewards) {
               if (pending.rewards.coins) Progression.addCoins(pending.rewards.coins);
               if (pending.rewards.cards?.length) Progression.addCardsToCollection(pending.rewards.cards);
             }
-            refreshRef.current();
-            if (pending.postDialogue) {
-              navigateToRef.current('dialogue', {
-                scene: pending.postDialogue as unknown as Record<string, unknown>,
-                nextScreen: 'campaign',
-              });
-            } else {
-              navigateToRef.current('campaign');
-            }
+          }
+          // Also record the duel result for win/loss stats
+          if (opponentId) {
+            Progression.recordDuelResult(opponentId, result === 'victory');
+          }
+          refreshRef.current();
+          refreshCampaignRef.current();
+          if (isComplete && pending.postDialogue && pending.postDialogue.length > 0) {
+            navigateToRef.current('dialogue', {
+              scene: pending.postDialogue as unknown as Record<string, unknown>,
+              nextScreen: 'campaign',
+            });
           } else {
             navigateToRef.current('campaign');
           }

--- a/js/react/screens/CampaignScreen.tsx
+++ b/js/react/screens/CampaignScreen.tsx
@@ -17,7 +17,7 @@ const NODE_ICONS: Record<CampaignNode['type'], string> = {
 export default function CampaignScreen() {
   const { t } = useTranslation();
   const { navigateTo } = useScreen();
-  const { campaignData, progress, isNodeUnlocked, completeNode, getOpponentForNode } = useCampaign();
+  const { campaignData, progress, isNodeUnlocked, completeNode, getOpponentForNode, setPendingDuel } = useCampaign();
   const { startGame } = useGame();
   const [activeChapterIdx, setActiveChapterIdx] = useState(0);
   const [dialogueNode, setDialogueNode] = useState<CampaignNode | null>(null);
@@ -51,6 +51,12 @@ export default function CampaignScreen() {
       case 'duel': {
         const opponent = getOpponentForNode(node.id);
         if (opponent) {
+          setPendingDuel({
+            nodeId: node.id,
+            completeOnLoss: node.completeOnLoss,
+            rewards: node.rewards,
+            postDialogue: node.dialogueKeys,
+          });
           startGame(opponent);
           navigateTo('game');
         }


### PR DESCRIPTION
## Summary

- **Campaign duels now properly complete nodes after victory** — previously `GameContext` referenced `pendingDuel`/`setPendingDuel` that didn't exist in `CampaignContext`, and called the non-existent `Progression.setNodeStatus()` method, so campaign never progressed
- **Free Duel opponents now unlock correctly** — `OpponentScreen` checks `progress.completedNodes` to determine which opponents are available, which now gets populated when campaign duels are won
- **Campaign context state stays in sync** — added `refreshCampaignProgress()` so the React state updates after `Progression.markNodeComplete()` is called from `onDuelEnd`

## Test plan

- [ ] Start a campaign duel and win — verify the node is marked as completed on the campaign map
- [ ] After winning a campaign duel, check Free Duel — the beaten opponent should be unlocked
- [ ] Test a `completeOnLoss` node (e.g. duel_8) — verify it completes even on defeat
- [ ] Verify story/reward/branch nodes still complete correctly when clicked
- [ ] Run `npm test` — all 395 tests pass

https://claude.ai/code/session_01BAzoEu6Xt9VaPhMHc9fmFG