### PR TITLE
fix(types): resolve TypeScript errors and cleanup unused imports

### DIFF
--- a/js/cards.ts
+++ b/js/cards.ts
@@ -3,10 +3,10 @@
 // Runtime data store — populated at startup by loading base.tcg
 // ============================================================
 import type { CardData, FusionRecipe, OpponentConfig } from './types.js';
-import { CardType, Attribute, Race, Rarity } from './types.js';
+import { CardType, Rarity } from './types.js';
 import {
   getRaceByKey, getAttrByKey, getRarityById,
-  getAllRaces, getAllRarities, TYPE_META,
+  TYPE_META,
 } from './type-metadata.js';
 
 export const TYPE = CardType;

--- a/js/effect-registry.ts
+++ b/js/effect-registry.ts
@@ -4,9 +4,9 @@
 // ============================================================
 
 import {
-  Attribute, Race, CardType,
+  Attribute, CardType,
   type CardData, type CardFilter,
-  type EffectDescriptor, type EffectContext, type EffectSignal, type CardEffectBlock,
+  type EffectContext, type EffectSignal, type CardEffectBlock,
   type ValueExpr, type StatTarget, type Owner, type FieldCard,
 } from './types.js';
 
@@ -37,15 +37,6 @@ function filterFieldMonsters(monsters: Array<FieldCard | null>, filter?: CardFil
   return result;
 }
 
-/** Filter CardData array by CardFilter */
-function filterCards(cards: CardData[], filter: CardFilter): CardData[] {
-  let result = cards.filter(c => matchesFilter(c, filter));
-  if (filter.random !== undefined && filter.random < result.length) {
-    const shuffled = [...result].sort(() => Math.random() - 0.5);
-    result = shuffled.slice(0, filter.random);
-  }
-  return result;
-}
 
 /** Get opponent Owner */
 function oppOf(owner: Owner): Owner {

--- a/js/progression.ts
+++ b/js/progression.ts
@@ -255,7 +255,7 @@ export const Progression = (() => {
 
   function getCampaignProgress(): CampaignProgress {
     return _load(KEYS.campaignProgress, { completedNodes: [], currentChapter: 'ch1' },
-      v => v !== null && typeof v === 'object' && Array.isArray(v.completedNodes));
+      v => v !== null && typeof v === 'object' && Array.isArray((v as Record<string, unknown>).completedNodes));
   }
 
   function saveCampaignProgress(progress: CampaignProgress): void {

--- a/js/react/contexts/CampaignContext.tsx
+++ b/js/react/contexts/CampaignContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState, useCallback, useMemo, useEffect } from 'react';
-import type { CampaignData, CampaignProgress, CampaignNode, NodeRewards } from '../../campaign-types.js';
+import type { CampaignData, CampaignProgress, NodeRewards } from '../../campaign-types.js';
 import { CAMPAIGN_DATA, isNodeUnlocked as storeIsNodeUnlocked, getNode, hasCampaignData } from '../../campaign-store.js';
 import { Progression } from '../../progression.js';
 import { useProgression } from './ProgressionContext.js';

--- a/js/react/contexts/GameContext.tsx
+++ b/js/react/contexts/GameContext.tsx
@@ -33,7 +33,7 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
 
   const { openModal }     = useModal();
   const { resetSel }      = useSelection();
-  const { currentDeck, loadDeck, refresh } = useProgression();
+  const { loadDeck, refresh } = useProgression();
   const { setScreen, navigateTo } = useScreen();
   const { pendingDuel, setPendingDuel, refreshCampaignProgress } = useCampaign();
 

--- a/js/react/contexts/ScreenContext.tsx
+++ b/js/react/contexts/ScreenContext.tsx
@@ -13,7 +13,8 @@ export type Screen =
   | 'collection'
   | 'deckbuilder'
   | 'save-point'
-  | 'campaign';
+  | 'campaign'
+  | 'dialogue';
 
 interface ScreenCtx {
   screen: Screen;

--- a/js/react/modals/CardListModal.tsx
+++ b/js/react/modals/CardListModal.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { useModal }        from '../contexts/ModalContext.js';
 import { Card }            from '../components/Card.js';
 import { CARD_DB, FUSION_RECIPES } from '../../cards.js';
-import { CardType, isEffectMonster } from '../../types.js';
+import { CardType } from '../../types.js';
 import { cardTypeCss, ATTR_CSS } from '../components/Card.js';
 
 export function CardListModal() {

--- a/js/react/screens/DeckbuilderScreen.tsx
+++ b/js/react/screens/DeckbuilderScreen.tsx
@@ -1,14 +1,13 @@
-import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useScreen }      from '../contexts/ScreenContext.js';
 import { useProgression } from '../contexts/ProgressionContext.js';
-import { useModal }        from '../contexts/ModalContext.js';
 import { CARD_DB } from '../../cards.js';
 import { Progression }     from '../../progression.js';
 import { Card, cardTypeCss, ATTR_CSS } from '../components/Card.js';
 import { attachHover }     from '../components/hoverApi.js';
-import { CardType, Race, Rarity, isMonsterType } from '../../types.js';
-import { getAllRaces, getAllRarities, getRarityById, getCardTypeById } from '../../type-metadata.js';
+import { CardType, Race, Rarity } from '../../types.js';
+import { getAllRaces, getAllRarities, getRarityById } from '../../type-metadata.js';
 import type { CardData }   from '../../types.js';
 import styles from './DeckbuilderScreen.module.css';
 import { GAME_RULES } from '../../rules.js';
@@ -20,8 +19,7 @@ type ViewMode = 'large' | 'small' | 'table';
 
 export default function DeckbuilderScreen() {
   const { navigateTo }                        = useScreen();
-  const { collection, currentDeck, setCurrentDeck, loadDeck } = useProgression();
-  const { openModal }                         = useModal();
+  const { collection, currentDeck, setCurrentDeck } = useProgression();
   const { t } = useTranslation();
   const [typeFilter, setTypeFilter]           = useState<'all' | 'monster' | 'effect' | 'spell' | 'trap'>('all');
   const [raceFilter, setRaceFilter]           = useState<'all' | Race>('all');

--- a/js/react/screens/DialogueScreen.tsx
+++ b/js/react/screens/DialogueScreen.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import { useScreen }   from '../contexts/ScreenContext.js';
 import { useGame }     from '../contexts/GameContext.js';
 import { CAMPAIGN_IMAGES, CAMPAIGN_I18N } from '../../campaign.js';
-import { OPPONENT_CONFIGS } from '../../cards.js';
 import { Progression } from '../../progression.js';
 import type { DialogueScene, ForegroundSprite } from '../../tcg-format/types.js';
 import type { Screen } from '../contexts/ScreenContext.js';

--- a/js/react/screens/PackOpeningScreen.tsx
+++ b/js/react/screens/PackOpeningScreen.tsx
@@ -4,7 +4,7 @@ import { useScreen }   from '../contexts/ScreenContext.js';
 import { getRarityById } from '../../type-metadata.js';
 import { cardTypeCss, ATTR_CSS } from '../components/Card.js';
 import { Audio }        from '../../audio.js';
-import { CardType, isEffectMonster } from '../../types.js';
+import { CardType } from '../../types.js';
 import type { CardData }          from '../../types.js';
 import type { CollectionEntry }   from '../../types.js';
 import styles from './PackOpeningScreen.module.css';

--- a/js/tcg-format/card-validator.ts
+++ b/js/tcg-format/card-validator.ts
@@ -3,7 +3,7 @@
 // Validates TcgCard[] from cards.json
 // ============================================================
 
-import type { TcgCard, ValidationResult } from './types.js';
+import type { ValidationResult } from './types.js';
 import { TCG_TYPES, TCG_ATTRIBUTES, TCG_RACES, TCG_RARITIES, TCG_TYPE_SPELL, TCG_TYPE_TRAP, TCG_TYPE_MONSTER, TCG_TYPE_FUSION } from './types.js';
 import { isValidEffectString } from './effect-serializer.js';
 

--- a/js/tcg-format/effect-serializer.ts
+++ b/js/tcg-format/effect-serializer.ts
@@ -10,7 +10,7 @@
 //   "onAttack:dealDamage(opponent,attacker.effectiveATK*0.5f);cancelAttack()"
 // ============================================================
 
-import { type CardEffectBlock, type CardFilter, type EffectDescriptor, type EffectTrigger, type TrapTrigger, type ValueExpr, Attribute, Race, CardType, type StatTarget } from '../types.js';
+import { type CardEffectBlock, type CardFilter, type EffectDescriptor, type EffectTrigger, type TrapTrigger, type ValueExpr, type StatTarget } from '../types.js';
 import { isValidTrigger, intToAttribute, intToRace, attributeToInt, raceToInt, cardTypeToInt, intToCardType } from './enums.js';
 
 // ── ValueExpr Serialization ──────────────────────────────────

--- a/js/tcg-format/index.ts
+++ b/js/tcg-format/index.ts
@@ -39,4 +39,4 @@ export type { TcgArchiveContents } from './tcg-validator.js';
 export { cardDataToTcgCard, cardDataToTcgDef, buildManifest, buildRacesJson, buildAttributesJson, buildCardTypesJson, buildRaritiesJson } from './tcg-builder.js';
 
 // Loader
-export { loadTcgFile, loadTcgFolder, revokeTcgImages } from './tcg-loader.js';
+export { loadTcgFile, revokeTcgImages } from './tcg-loader.js';

--- a/js/tcg-format/tcg-validator.ts
+++ b/js/tcg-format/tcg-validator.ts
@@ -4,7 +4,7 @@
 // ============================================================
 
 import type JSZip from 'jszip';
-import type { TcgCard, TcgCardDefinition, TcgOpponentDescription, TcgManifest, TcgCampaignJson, ValidationResult } from './types.js';
+import type { TcgCard, TcgCardDefinition, TcgOpponentDescription, TcgManifest, ValidationResult } from './types.js';
 import { validateTcgCards } from './card-validator.js';
 import { validateTcgDefinitions } from './def-validator.js';
 import { validateTcgOpponentDescriptions } from './opp-desc-validator.js';

--- a/js/types.ts
+++ b/js/types.ts
@@ -275,12 +275,12 @@ export interface BattleContext {
   triggerType: string;
   attackerName?: string;
   attackerAtk?: number;
-  attackerCardId?: number;
+  attackerCardId?: string;
   defenderName?: string;
   defenderDef?: number;
   defenderAtk?: number;
   defenderPos?: string;
-  defenderCardId?: number;
+  defenderCardId?: string;
 }
 
 export interface PromptOptions {
@@ -363,8 +363,8 @@ export declare class GameEngine {
   dealDamage(target: Owner, amount: number): void;
   gainLP(target: Owner, amount: number): void;
   drawCard(owner: Owner, count?: number): void;
-  specialSummon(owner: Owner, card: CardData, zone?: number): boolean;
-  specialSummonFromGrave(owner: Owner, card: CardData): boolean;
+  specialSummon(owner: Owner, card: CardData, zone?: number): Promise<boolean>;
+  specialSummonFromGrave(owner: Owner, card: CardData): Promise<boolean>;
   endTurn(): void;
   advancePhase(): void;
 }


### PR DESCRIPTION
## Summary

- **Fix 9 pre-existing TypeScript errors**: `specialSummon` return type mismatch (`boolean` → `Promise<boolean>`), `BattleContext.cardId` type mismatch, missing `'dialogue'` in `Screen` union, invalid `loadTcgFolder` re-export, `CampaignProgress` validator cast
- **Remove unused imports across 13 files**: `Attribute`, `Race`, `CardType`, `isEffectMonster`, `isMonsterType`, `getCardTypeById`, `useCallback`, `OPPONENT_CONFIGS`, `TcgCard`, `TcgCampaignJson`, `CampaignNode`, etc.
- **Remove unused code**: `filterCards` function in effect-registry, unused destructured variables (`currentDeck`, `loadDeck`, `openModal`)

## Test plan

- [x] `npx tsc --noEmit` passes with zero errors
- [x] `npx tsc --noEmit --noUnusedLocals` passes with zero errors
- [x] All 395 unit tests pass (`npm test`)

https://claude.ai/code/session_01TzZbBFPmbAvp362rXR9cpx