### PR TITLE
fix(ui): defense position not visually applied to field cards

### DIFF
--- a/css/animations.css
+++ b/css/animations.css
@@ -45,6 +45,11 @@
   50%  { opacity: 1; transform: scale(1.08); }
   100% { opacity: 1; transform: scale(1); }
 }
+@keyframes fieldCardInDef {
+  0%   { opacity: 0; transform: rotate(90deg) scale(0.7); }
+  50%  { opacity: 1; transform: rotate(90deg) scale(1.08); }
+  100% { opacity: 1; transform: rotate(90deg) scale(1); }
+}
 @keyframes targetPulse {
   from { outline-color: rgba(255,60,60,0.4); }
   to   { outline-color: rgba(255,60,60,1); }

--- a/css/style.css
+++ b/css/style.css
@@ -505,7 +505,7 @@ button { cursor: pointer; border: none; font-family: inherit; transition: none; 
 .exhausted { opacity: 0.6; filter: grayscale(40%); }
 
 /* Defense position */
-.pos-def { transform: rotate(90deg); }
+.pos-def { transform: rotate(90deg); animation-name: fieldCardInDef; }
 .pos-def:hover { transform: rotate(90deg) translateY(-4px) !important; }
 .pos-def.selected { transform: rotate(90deg); }
 

--- a/js/react/components/FieldCardComponent.tsx
+++ b/js/react/components/FieldCardComponent.tsx
@@ -28,9 +28,9 @@ export function FieldCardComponent({
 
   let cls: string;
   if (fc.faceDown && !isPlayer) {
-    cls = 'card field-card face-down';
+    cls = `card field-card face-down${fc.position === 'def' ? ' pos-def' : ''}`;
   } else if (fc.faceDown && isPlayer) {
-    cls = `card field-card face-down own-facedown attr-${card.attribute ? ATTR_CSS[card.attribute] || 'spell' : 'spell'}`;
+    cls = `card field-card face-down own-facedown attr-${card.attribute ? ATTR_CSS[card.attribute] || 'spell' : 'spell'}${fc.position === 'def' ? ' pos-def' : ''}`;
   } else {
     cls = `card field-card ${cardTypeCss(card)}-card attr-${card.attribute ? ATTR_CSS[card.attribute] || 'spell' : 'spell'} pos-${fc.position}`;
   }

--- a/js/react/modals/CardDetailModal.tsx
+++ b/js/react/modals/CardDetailModal.tsx
@@ -56,7 +56,7 @@ export function CardDetailModal({ modal }: Props) {
         if (freeZone !== -1) {
           actions.push(actionBtn(t('card_action.summon_atk'), () => { game.summonMonster('player', index, freeZone, 'atk'); closeModal(); }));
           actions.push(actionBtn(t('card_action.summon_def'), () => { game.summonMonster('player', index, freeZone, 'def'); closeModal(); }));
-          actions.push(actionBtn(t('card_action.set_atk'), () => { game.summonMonster('player', index, freeZone, 'atk', true); closeModal(); }));
+          actions.push(actionBtn(t('card_action.set_def'), () => { game.setMonster('player', index, freeZone); closeModal(); }));
         }
       }
       if (fusionOpts.length > 0 && !state.player.normalSummonUsed) {

--- a/locales/de.json
+++ b/locales/de.json
@@ -184,6 +184,7 @@
     "activate_trap": "⚠ Falle aktivieren",
     "flip_summon": "🔄 Flip-Beschwörung",
     "set_atk": "🔽 Verdeckt setzen (ATK)",
+    "set_def": "🔽 Verdeckt setzen (DEF)",
     "view": "🔍 Ansehen",
     "cancel": "✕ Abbrechen",
     "hint_spell_own": "Wähle ein eigenes Monster als Ziel.",

--- a/locales/en.json
+++ b/locales/en.json
@@ -184,6 +184,7 @@
     "activate_trap": "⚠ Activate Trap",
     "flip_summon": "🔄 Flip Summon",
     "set_atk": "🔽 Set Face-Down (ATK)",
+    "set_def": "🔽 Set Face-Down (DEF)",
     "view": "🔍 View",
     "cancel": "✕ Cancel",
     "hint_spell_own": "Choose your own monster as a target.",


### PR DESCRIPTION
## Summary

- **Root cause**: The `fieldCardIn` CSS animation used `animation-fill-mode: both`, causing its final keyframe (`transform: scale(1)`) to permanently override the `.pos-def` class's `transform: rotate(90deg)`. Cards summoned in DEF position appeared upright (ATK) despite the engine correctly storing the position.
- Added a `fieldCardInDef` animation that preserves the 90° rotation throughout the entrance animation
- Fixed the "Set" button to place cards face-down in DEF position (was incorrectly placing in ATK)
- Face-down cards now also display rotated when in defense position

## Test plan

- [x] All 395 unit tests pass
- [x] TypeScript compiles with no errors
- [ ] Summon a monster in DEF position — card should appear rotated 90°
- [ ] Set a monster face-down — card should appear rotated 90° (DEF)
- [ ] Verify ATK summon still works normally (upright)
- [ ] Test on mobile (touch device) to confirm rotation renders correctly

https://claude.ai/code/session_012JwvQRN5FWZUBoPCvXmoqf