### PR TITLE
feat(ui): add fusion animation effect

### DIFF
--- a/css/animations.css
+++ b/css/animations.css
@@ -102,6 +102,25 @@
   35%      { outline: 3px solid #ff8c00; }
 }
 
+/* ── Fusion animation ────────────────────────────────────── */
+@keyframes fusionBurst {
+  0%   { transform: translate(-50%,-50%) scale(0.1); opacity: 1; }
+  30%  { transform: translate(-50%,-50%) scale(1.2);  opacity: 1; }
+  60%  { transform: translate(-50%,-50%) scale(2.0);  opacity: 0.7; }
+  100% { transform: translate(-50%,-50%) scale(3.0);  opacity: 0; }
+}
+@keyframes fusionSpark {
+  0%   { transform: translate(-50%,-50%) rotate(var(--fusion-angle)) translateY(0) scale(1); opacity: 1; }
+  50%  { opacity: 1; }
+  100% { transform: translate(-50%,-50%) rotate(var(--fusion-angle)) translateY(-80px) scale(0.3); opacity: 0; }
+}
+@keyframes fusionResultPop {
+  0%   { transform: scale(0.3); opacity: 0; filter: brightness(3) saturate(0.5); }
+  40%  { transform: scale(1.2); opacity: 1; filter: brightness(2) saturate(0.7); }
+  70%  { transform: scale(0.95); filter: brightness(1.3); }
+  100% { transform: scale(1);   opacity: 1; filter: brightness(1); }
+}
+
 /* ── Progression / Shop ───────────────────────────────────── */
 @keyframes coinsPop {
   0%   { transform: scale(0.7); opacity: 0; }

--- a/css/style.css
+++ b/css/style.css
@@ -787,6 +787,28 @@ button { cursor: pointer; border: none; font-family: inherit; transition: none; 
   animation: cardDraw 0.38s cubic-bezier(0.22,1,0.36,1) both;
 }
 
+/* ── Fusion Animation ──────────────────────────────────────── */
+.fusion-burst {
+  position: fixed;
+  width: 160px; height: 160px;
+  z-index: 450; pointer-events: none; border-radius: 50%;
+  background: radial-gradient(circle at center,
+    #ffffff 0%, #ffe880 20%, #ffcc00 45%, #ff8800 65%, rgba(255,120,0,0) 85%);
+  box-shadow: 0 0 40px rgba(255,200,60,0.8), 0 0 80px rgba(255,150,0,0.4);
+  animation: fusionBurst 0.55s ease-out forwards;
+}
+.fusion-spark {
+  position: fixed;
+  width: 8px; height: 8px;
+  z-index: 451; pointer-events: none; border-radius: 50%;
+  background: radial-gradient(circle, #fff 0%, #ffe060 50%, #ff8800 100%);
+  box-shadow: 0 0 6px rgba(255,220,60,0.9);
+  animation: fusionSpark 0.5s ease-out forwards;
+}
+.fusion-result-pop {
+  animation: fusionResultPop 0.45s cubic-bezier(0.22,1,0.36,1) both !important;
+}
+
 /* ── Touch / Coarse Pointer ──────────────────────────────── */
 @media (pointer: coarse) {
   .hand-card:hover,

--- a/js/engine.ts
+++ b/js/engine.ts
@@ -340,6 +340,12 @@ export class GameEngine {
     const zone = st.field.monsters.findIndex(z => z === null);
     if(zone === -1){ this.addLog('No free zone for fusion monster!'); return false; }
 
+    this.addLog(`${ownerLabel(owner)}: FUSION! ${card1.name} + ${card2.name} = ${CARD_DB[recipe.result].name}!`);
+    this.ui.playSfx?.('sfx_fusion');
+
+    // Play merge animation before removing cards from hand
+    await this.ui.playFusionAnimation?.(owner, handIdx1, handIdx2, zone);
+
     // remove materials
     hand.splice(hi, 1);
     hand.splice(lo, 1);
@@ -352,10 +358,8 @@ export class GameEngine {
     st.field.monsters[zone] = fc;
     st.normalSummonUsed = true;
 
-    this.addLog(`${ownerLabel(owner)}: FUSION! ${card1.name} + ${card2.name} = ${fusionCard.name}!`);
-    this.ui.playSfx?.('sfx_fusion');
-    await this._triggerEffect(fc, owner, 'onSummon', zone);
     this.ui.render(this.state);
+    await this._triggerEffect(fc, owner, 'onSummon', zone);
     return true;
   }
 

--- a/js/react/contexts/GameContext.tsx
+++ b/js/react/contexts/GameContext.tsx
@@ -63,6 +63,9 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
     playAttackAnimation: (ao, az, dO, dZ) => {
       return import('../hooks/useAttackAnimation.js').then(m => m.playAttackAnim(ao, az, dO, dZ));
     },
+    playFusionAnimation: (owner, handIdx1, handIdx2, resultZone) => {
+      return import('../hooks/useFusionAnimation.js').then(m => m.playFusionAnim(owner, handIdx1, handIdx2, resultZone));
+    },
     playVFX: (type, owner, zone) => {
       return import('../components/vfxApi.js').then(m => m.playVFXAtZone(type, owner, zone));
     },

--- a/js/react/hooks/useFusionAnimation.ts
+++ b/js/react/hooks/useFusionAnimation.ts
@@ -1,0 +1,167 @@
+import { gsap } from 'gsap';
+
+/**
+ * Module-level imperative fusion animation.
+ * Shows both material cards flying to the center, merging with a flash,
+ * then the fusion result card popping out on the field.
+ */
+export function playFusionAnim(
+  owner: string,
+  handIdx1: number,
+  handIdx2: number,
+  resultZone: number,
+): Promise<void> {
+  return new Promise(resolve => {
+    // ── Locate material cards in hand ──
+    const handEl = document.getElementById(owner === 'player' ? 'player-hand' : 'opponent-hand');
+    const handCards = handEl?.querySelectorAll<HTMLElement>('.hand-card') ?? [];
+    const card1El = handCards[handIdx1] ?? null;
+    const card2El = handCards[handIdx2] ?? null;
+
+    if (!card1El && !card2El) { resolve(); return; }
+
+    // ── Merge point: center of the viewport ──
+    const mergeX = window.innerWidth / 2;
+    const mergeY = window.innerHeight / 2;
+
+    // ── Clone both material cards for animation ──
+    function cloneCard(el: HTMLElement | null): HTMLElement | null {
+      if (!el) return null;
+      const rect = el.getBoundingClientRect();
+      const clone = el.cloneNode(true) as HTMLElement;
+      Object.assign(clone.style, {
+        position: 'fixed',
+        margin: '0', padding: '0', boxSizing: 'border-box',
+        left: rect.left + 'px', top: rect.top + 'px',
+        width: rect.width + 'px', height: rect.height + 'px',
+        zIndex: '430', pointerEvents: 'none',
+        transformOrigin: 'center center',
+      });
+      document.body.appendChild(clone);
+      el.style.opacity = '0.15';
+      return clone;
+    }
+
+    const clone1 = cloneCard(card1El);
+    const clone2 = cloneCard(card2El);
+
+    // Calculate travel deltas for each clone
+    function getDelta(el: HTMLElement | null) {
+      if (!el) return { dx: 0, dy: 0 };
+      const r = el.getBoundingClientRect();
+      return {
+        dx: mergeX - (r.left + r.width / 2),
+        dy: mergeY - (r.top + r.height / 2),
+      };
+    }
+    const d1 = getDelta(card1El);
+    const d2 = getDelta(card2El);
+
+    // ── Create fusion burst element ──
+    function spawnFusionBurst() {
+      const burst = document.createElement('div');
+      burst.className = 'fusion-burst';
+      burst.style.left = mergeX + 'px';
+      burst.style.top = mergeY + 'px';
+      document.body.appendChild(burst);
+      burst.addEventListener('animationend', () => burst.remove(), { once: true });
+      setTimeout(() => { if (burst.parentNode) burst.remove(); }, 1200);
+    }
+
+    // ── Spawn fusion sparks around the merge point ──
+    function spawnSparks() {
+      const count = 10;
+      for (let i = 0; i < count; i++) {
+        const spark = document.createElement('div');
+        spark.className = 'fusion-spark';
+        const angle = (i / count) * 360;
+        spark.style.left = mergeX + 'px';
+        spark.style.top = mergeY + 'px';
+        spark.style.setProperty('--fusion-angle', `${angle}deg`);
+        document.body.appendChild(spark);
+        spark.addEventListener('animationend', () => spark.remove(), { once: true });
+        setTimeout(() => { if (spark.parentNode) spark.remove(); }, 1000);
+      }
+    }
+
+    // ── Timeline ──
+    const tl = gsap.timeline({
+      onComplete() {
+        clone1?.remove();
+        clone2?.remove();
+        if (card1El) card1El.style.opacity = '';
+        if (card2El) card2El.style.opacity = '';
+        resolve();
+      },
+    });
+
+    // Phase 1: Both cards fly toward center (converge)
+    if (clone1) {
+      tl.to(clone1, {
+        duration: 0.35,
+        ease: 'steps(8)',
+        x: d1.dx, y: d1.dy,
+        scale: 0.85,
+        rotation: -15,
+      }, 0);
+    }
+    if (clone2) {
+      tl.to(clone2, {
+        duration: 0.35,
+        ease: 'steps(8)',
+        x: d2.dx, y: d2.dy,
+        scale: 0.85,
+        rotation: 15,
+      }, 0);
+    }
+
+    // Phase 2: Cards overlap and glow intensifies
+    if (clone1) {
+      tl.to(clone1, {
+        duration: 0.2,
+        ease: 'steps(6)',
+        scale: 0.6,
+        rotation: 0,
+        opacity: 0.7,
+        boxShadow: '0 0 30px rgba(255,220,80,0.9)',
+      });
+    }
+    if (clone2) {
+      tl.to(clone2, {
+        duration: 0.2,
+        ease: 'steps(6)',
+        scale: 0.6,
+        rotation: 0,
+        opacity: 0.7,
+        boxShadow: '0 0 30px rgba(255,220,80,0.9)',
+      }, '<'); // align with clone1
+    }
+
+    // Phase 3: Flash burst — cards vanish, sparks fly
+    tl.call(() => {
+      spawnFusionBurst();
+      spawnSparks();
+      if (clone1) clone1.style.opacity = '0';
+      if (clone2) clone2.style.opacity = '0';
+    });
+
+    // Phase 4: Brief pause for the burst to be visible
+    tl.to({}, { duration: 0.35 });
+
+    // Phase 5: Highlight the result card on the field
+    tl.call(() => {
+      const zoneContId = owner === 'player' ? 'player-monster-zone' : 'opponent-monster-zone';
+      const slot = document.querySelectorAll(`#${zoneContId} .zone-slot`)[resultZone];
+      const resultCard = slot?.querySelector<HTMLElement>('.card') ?? (slot as HTMLElement);
+      if (resultCard) {
+        resultCard.classList.add('fusion-result-pop');
+        resultCard.addEventListener('animationend', () => {
+          resultCard.classList.remove('fusion-result-pop');
+        }, { once: true });
+      }
+    });
+
+    // Phase 6: Let the result pop animation play out
+    tl.to({}, { duration: 0.4 });
+  });
+}

--- a/js/types.ts
+++ b/js/types.ts
@@ -299,6 +299,7 @@ export interface UICallbacks {
   showResult?:          (result: 'victory' | 'defeat') => void;
   showActivation?:      (card: CardData, text: string) => Promise<void> | void;
   playAttackAnimation?: (atkOwner: Owner, atkZone: number, defOwner: Owner, defZone: number | null) => Promise<void>;
+  playFusionAnimation?: (owner: Owner, handIdx1: number, handIdx2: number, resultZone: number) => Promise<void>;
   playVFX?:             (type: 'buff' | 'heal' | 'damage', owner: Owner, zone?: number) => Promise<void>;
   playSfx?:             (sfxId: string) => void;
   onDraw?:              (owner: Owner, count: number) => void;


### PR DESCRIPTION
## Summary
- Both material cards animate from hand to screen center, converging with stepped pixel-art easing (GSAP timeline)
- Cards merge with a radial golden burst and 10 spark particles flying outward
- Fusion result card pops onto the field with a bright flash scale-in animation
- Follows existing attack animation pattern: imperative module, Promise-based `UICallback`, lazy-imported in `GameContext`

## Changes
- **`js/types.ts`** — Added `playFusionAnimation` to `UICallbacks` interface
- **`js/engine.ts`** — Calls `playFusionAnimation` in `performFusion()` before removing materials from hand
- **`js/react/hooks/useFusionAnimation.ts`** — New GSAP-based animation module (clone cards → fly to center → burst → result pop)
- **`css/animations.css`** — Added `fusionBurst`, `fusionSpark`, `fusionResultPop` keyframes
- **`css/style.css`** — Added `.fusion-burst`, `.fusion-spark`, `.fusion-result-pop` classes
- **`js/react/contexts/GameContext.tsx`** — Wired up lazy import for the new callback

## Test plan
- [x] `npm run build` succeeds
- [x] All 395 unit tests pass
- [ ] Manual: Perform a fusion in-game and verify both material cards fly to center
- [ ] Manual: Verify golden burst and sparks appear at merge point
- [ ] Manual: Verify fusion result card pops onto the field with flash effect
- [ ] Manual: Verify AI fusions also trigger the animation

https://claude.ai/code/session_01N4RrFJajUN1p6Vg9nR22QE