### PR TITLE
fix(ai): enforce summoning sickness for AI monsters

### DIFF
--- a/js/ai-orchestrator.ts
+++ b/js/ai-orchestrator.ts
@@ -213,6 +213,7 @@ async function aiBattlePhase(engine: GameEngine): Promise<boolean> {
     if(!atk){ continue; }
     if(atk.position !== 'atk'){ EchoesOfSanguo.log('AI', `Zone ${az}: ${atk.card.name} is in DEF mode – skipping`); continue; }
     if(atk.hasAttacked){       EchoesOfSanguo.log('AI', `Zone ${az}: ${atk.card.name} has already attacked`);      continue; }
+    if(atk.summonedThisTurn){  EchoesOfSanguo.log('AI', `Zone ${az}: ${atk.card.name} was just summoned – skipping`); continue; }
     await _delay(500);
 
     // Recalculate each iteration in case earlier attacks destroyed monsters


### PR DESCRIPTION
## Summary

- **Bug**: AI monsters could attack on the same turn they were summoned, while the player correctly had to wait one turn (summoning sickness)
- **Root cause**: `aiBattlePhase()` in `ai-orchestrator.ts` checked `hasAttacked` but was missing the `summonedThisTurn` check
- **Fix**: Added `summonedThisTurn` guard to the AI battle loop, matching the existing player-side check in `PlayerField.tsx`

## Test plan

- [ ] Start a game and observe AI behavior — newly summoned AI monsters should no longer attack on the same turn
- [ ] Verify player summoning sickness still works correctly
- [ ] Verify special summons, fusion summons, and graveyard summons can still attack immediately (they set `summonedThisTurn = false`)

https://claude.ai/code/session_01GBqDxpU8NJrxpNY45Z9AU8