### PR TITLE
fix(ui): make secondary buttons look enabled

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -74,11 +74,11 @@ button { cursor: pointer; border: none; font-family: inherit; transition: none; 
 }
 .btn-primary:hover { background: #1e6848; box-shadow: none; }
 .btn-secondary {
-  background: #0e2e1c; color: var(--text);
-  padding: 12px 28px; border: 2px solid; border-color: #1e4830 #061810 #061810 #1e4830;
+  background: #185838; color: var(--gold-light);
+  padding: 12px 28px; border: 2px solid; border-color: #2a9858 #0a2c18 #0a2c18 #2a9858;
   border-radius: 0; font-size: 0.9375rem;
 }
-.btn-secondary:hover { border-color: var(--gold); color: var(--gold); box-shadow: none; }
+.btn-secondary:hover { background: #1c6440; border-color: var(--gold); color: var(--gold); box-shadow: none; }
 .btn-cancel {
   background: #3c1414; color: #ff8888;
   padding: 8px 20px; border: 2px solid; border-color: #602020 #200808 #200808 #602020;

--- a/js/react/screens/TitleScreen.module.css
+++ b/js/react/screens/TitleScreen.module.css
@@ -53,9 +53,9 @@
 }
 .menu :global(.btn-secondary) {
   width: 220px; text-align: center;
-  background: rgba(10, 55, 25, 0.5);
-  border-color: rgba(20, 90, 45, 0.7) rgba(5, 25, 12, 0.7) rgba(5, 25, 12, 0.7) rgba(20, 90, 45, 0.7);
+  background: rgba(18, 85, 45, 0.55);
+  border-color: rgba(35, 145, 70, 0.7) rgba(8, 40, 20, 0.7) rgba(8, 40, 20, 0.7) rgba(35, 145, 70, 0.7);
 }
 .menu :global(.btn-secondary):hover {
-  background: rgba(15, 70, 35, 0.65);
+  background: rgba(22, 100, 55, 0.7);
 }


### PR DESCRIPTION
## Summary
- Brightened `.btn-secondary` background from `#0e2e1c` to `#185838` and borders from `#1e4830` to `#2a9858` so they no longer look disabled/muted
- Changed secondary button text color from `var(--text)` to `var(--gold-light)` to match primary buttons
- Updated TitleScreen module CSS overrides to use matching brighter rgba values

## Test plan
- [ ] Open Title Screen on mobile — all buttons (New Game, Load Game, Options, Quit) should look equally enabled
- [ ] Open Save Point screen — all menu buttons should look active, not grayed out
- [ ] Hover states still work correctly on both button types

https://claude.ai/code/session_012gQt9eU22P4k6H7HPQozAq