### PR TITLE
fix(ui): align name and type column colors in deckbuilder table

### DIFF
--- a/js/react/screens/DeckbuilderScreen.tsx
+++ b/js/react/screens/DeckbuilderScreen.tsx
@@ -8,7 +8,7 @@ import { Progression }     from '../../progression.js';
 import { Card, cardTypeCss, ATTR_CSS } from '../components/Card.js';
 import { attachHover }     from '../components/hoverApi.js';
 import { CardType, Race, Rarity } from '../../types.js';
-import { getAllRaces, getAllRarities, getRarityById } from '../../type-metadata.js';
+import { getAllRaces, getAllRarities, getRarityById, getCardTypeById } from '../../type-metadata.js';
 import type { CardData }   from '../../types.js';
 import styles from './DeckbuilderScreen.module.css';
 import { GAME_RULES } from '../../rules.js';
@@ -378,6 +378,8 @@ export default function DeckbuilderScreen() {
                     const typeLbl    = card.type === CardType.Monster && card.effect
                       ? t('deckbuilder.type_label_effect')
                       : (TYPE_LABEL[card.type] || '');
+                    const typeMeta   = getCardTypeById(card.type as number);
+                    const typeColor  = typeMeta?.color ?? '#aaa';
                     const raceLbl    = card.race ? t(`cards.race_${card.race}`) : '';
                     return (
                       <tr
@@ -396,10 +398,10 @@ export default function DeckbuilderScreen() {
                             {rarMeta?.value ?? '\u2014'}
                           </span>
                         </td>
-                        <td>{card.name}</td>
+                        <td style={{ color: typeColor }}>{card.name}</td>
                         <td>{card.atk !== undefined ? card.atk : '\u2014'}</td>
                         <td>{card.def !== undefined ? card.def : '\u2014'}</td>
-                        <td>{typeLbl}</td>
+                        <td style={{ color: typeColor }}>{typeLbl}</td>
                         <td>{raceLbl}</td>
                         <td>{ownedCount}</td>
                         <td>{copies} / {maxCopiesFor(card.id)}</td>


### PR DESCRIPTION
## Summary
- **NAME** column now uses the card type color from `card_types.json` metadata (Monster gold, Fusion purple, Spell teal, Trap pink)
- **TYPE** column also uses the same card type color, matching the defined metadata
- Both columns are now visually aligned with consistent color coding

## Test plan
- [ ] Open the Deckbuilder screen and switch to table/list view
- [ ] Verify NAME and TYPE columns share the same color per card type
- [ ] Confirm Monster cards show gold (#c8a850), Spell cards teal (#1dc0a0), Trap cards pink (#bc2060), Fusion cards purple (#a050c0)
- [ ] Verify Effect monsters still display "EFFECT" label with Monster color

https://claude.ai/code/session_01F6ka8CQfZWSzYmU7Hwjfmk