### PR TITLE
fix(ui): use type-metadata for race/attribute translations

### DIFF
--- a/js/react/modals/CardDetailModal.tsx
+++ b/js/react/modals/CardDetailModal.tsx
@@ -4,6 +4,7 @@ import { useGame }   from '../contexts/GameContext.js';
 import { useSelection } from '../contexts/SelectionContext.js';
 import { Card }       from '../components/Card.js';
 import { CardType, Attribute, isMonsterType } from '../../types.js';
+import { getAttrById } from '../../type-metadata.js';
 import type { ModalState } from '../contexts/ModalContext.js';
 
 interface Props { modal: Extract<ModalState, { type: 'card-detail' }>; }
@@ -17,7 +18,7 @@ export function CardDetailModal({ modal }: Props) {
 
   const game = gameRef.current;
 
-  const attrName = card.attribute ? t(`cards.attr_${card.attribute}`) : '';
+  const attrName = card.attribute ? (getAttrById(card.attribute)?.value ?? '') : '';
   const typeLabels: Record<number, string> = {
     [CardType.Monster]: card.effect ? t('card_detail.type_effect') : t('card_detail.type_normal'),
     [CardType.Fusion]:  t('card_detail.type_fusion'),

--- a/js/react/screens/CollectionScreen.tsx
+++ b/js/react/screens/CollectionScreen.tsx
@@ -7,7 +7,7 @@ import { CARD_DB } from '../../cards.js';
 import { Card, cardTypeCss, ATTR_CSS } from '../components/Card.js';
 import { attachHover }     from '../components/hoverApi.js';
 import { Race, Rarity } from '../../types.js';
-import { getAllRaces, getAllRarities, getRarityById } from '../../type-metadata.js';
+import { getAllRaces, getAllRarities, getRarityById, getRaceById } from '../../type-metadata.js';
 import type { CardData } from '../../types.js';
 import styles from './CollectionScreen.module.css';
 
@@ -95,7 +95,7 @@ export default function CollectionScreen() {
             <div key={card.id} className={`${styles.card} ${styles.unowned}`}>
               <div className={styles.unknownLabel}>???</div>
               <div className={styles.cardMeta} style={{ textAlign: 'center', opacity: 0.4 }}>
-                {t(`cards.race_${(card as any).race}`) || ''}
+                {(card as any).race ? (getRaceById((card as any).race)?.value ?? '') : ''}
               </div>
             </div>
           );

--- a/js/react/screens/DeckbuilderScreen.tsx
+++ b/js/react/screens/DeckbuilderScreen.tsx
@@ -8,7 +8,7 @@ import { Progression }     from '../../progression.js';
 import { Card, cardTypeCss, ATTR_CSS } from '../components/Card.js';
 import { attachHover }     from '../components/hoverApi.js';
 import { CardType, Race, Rarity } from '../../types.js';
-import { getAllRaces, getAllRarities, getRarityById, getCardTypeById } from '../../type-metadata.js';
+import { getAllRaces, getAllRarities, getRarityById, getCardTypeById, getRaceById } from '../../type-metadata.js';
 import type { CardData }   from '../../types.js';
 import styles from './DeckbuilderScreen.module.css';
 import { GAME_RULES } from '../../rules.js';
@@ -380,7 +380,7 @@ export default function DeckbuilderScreen() {
                       : (TYPE_LABEL[card.type] || '');
                     const typeMeta   = getCardTypeById(card.type as number);
                     const typeColor  = typeMeta?.color ?? '#aaa';
-                    const raceLbl    = card.race ? t(`cards.race_${card.race}`) : '';
+                    const raceLbl    = card.race ? (getRaceById(card.race)?.value ?? '') : '';
                     return (
                       <tr
                         key={card.id}


### PR DESCRIPTION
## Summary

- **DeckbuilderScreen**, **CollectionScreen**, and **CardDetailModal** were using i18n keys with numeric IDs (e.g. `cards.race_3`, `cards.attr_5`) which don't exist in the locale files — the actual keys use German string identifiers like `cards.race_krieger`
- Replaced `t('cards.race_${card.race}')` / `t('cards.attr_${card.attribute}')` with `getRaceById()` / `getAttrById()` from `type-metadata.ts`, which returns properly localized display names from the TCG loader
- This matches the pattern already used correctly in `Card.tsx`, `HoverPreview.tsx`, and `OpponentScreen.tsx`

## Test plan

- [x] All 395 unit tests pass
- [x] Production build succeeds
- [ ] Verify race column in Deckbuilder table view shows translated names (e.g. "Dragon", "Warrior") instead of "CARDS.RACE_3"
- [ ] Verify attribute label in CardDetailModal shows translated names (e.g. "Earth", "Fire") instead of "CARDS.ATTR_5"
- [ ] Verify race label on unowned cards in CollectionScreen shows correctly

https://claude.ai/code/session_013LQ3gYiioqMFDXw6SQjjoz