### PR TITLE
fix(vfx): position effects on field, limit damage VFX to spell/trap

### DIFF
--- a/js/effect-registry.ts
+++ b/js/effect-registry.ts
@@ -108,6 +108,7 @@ const IMPL: Record<string, EffectImpl> = {
   dealDamage(desc: { target: 'opponent' | 'self'; value: ValueExpr }, ctx) {
     const amount = resolveValue(desc.value, ctx);
     const target = resolveTarget(desc.target, ctx.owner);
+    ctx.engine.ui?.playVFX?.('damage', target);
     ctx.engine.dealDamage(target, amount);
     return {};
   },

--- a/js/engine.ts
+++ b/js/engine.ts
@@ -119,7 +119,6 @@ export class GameEngine {
     this.state[target].lp = Math.max(0, this.state[target].lp - amount);
     this.addLog(`${ownerLabel(target)} takes ${amount} damage. (LP: ${this.state[target].lp})`);
     this.ui.playSfx?.('sfx_damage');
-    this.ui.playVFX?.('damage', target);
     this.ui.render(this.state);
     if(this.checkWin()) return;
   }

--- a/js/react/components/vfxApi.ts
+++ b/js/react/components/vfxApi.ts
@@ -47,6 +47,11 @@ export function playVFXAtZone(
     el = (slot?.querySelector<HTMLElement>('.card') ?? slot as HTMLElement) || null;
   }
 
+  // Fallback: monster zone area (center of the field)
+  if (!el) {
+    const zoneId = owner === 'player' ? 'player-monster-zone' : 'opponent-monster-zone';
+    el = document.getElementById(zoneId);
+  }
   // Fallback: LP panel area
   if (!el) {
     const lpId = owner === 'player' ? 'player-lp' : 'opp-lp';


### PR DESCRIPTION
## Summary

- **VFX positioning**: Effects (heal, damage, buff) now fall back to the monster zone area (field center) instead of the LP panel, so particles appear on the field rather than in the top-right corner
- **Damage VFX scope**: Fireball VFX now only triggers for spell/trap direct damage effects (via effect-registry), no longer for battle damage or direct attacks

## Test plan

- [ ] Activate a spell/trap card with `dealDamage` effect → fireballs should appear centered on the field
- [ ] Use a healing spell/trap → green stars should appear on the field, not the LP panel corner
- [ ] Attack directly with a monster → no fireball VFX, only the existing attack animation
- [ ] Win a monster battle → no fireball VFX on the losing side
- [ ] Verify buff VFX still plays on the correct monster zone slot

https://claude.ai/code/session_01Eo3fdquEicG6GC1watBaGq