### PR TITLE
fix(test): fix battle phase transition test

### DIFF
--- a/tests/engine.core.test.js
+++ b/tests/engine.core.test.js
@@ -412,6 +412,7 @@ describe('advancePhase', () => {
   it('main → battle', () => {
     const { engine } = makeEngine();
     engine.state.phase = 'main';
+    engine.state.firstTurnNoAttack = false;
     engine.advancePhase();
     expect(engine.state.phase).toBe('battle');
   });


### PR DESCRIPTION
## Summary
- Fixed the `main → battle` advancePhase test that was failing in CI
- The engine skips the battle phase on the first turn (`firstTurnNoAttack` flag, FM-style rule), but the test didn't account for this
- Added `engine.state.firstTurnNoAttack = false` before calling `advancePhase()` so the test exercises the normal phase transition

## Test plan
- [x] All 395 tests pass locally (11 test files)
- [x] The previously failing `advancePhase > main → battle` test now passes

https://claude.ai/code/session_01TostMnEpjVZeXhyHWeTg1A