### PR TITLE
fix(game): prevent AI first-turn attack and fix mobile log download

### DIFF
--- a/js/ai-orchestrator.ts
+++ b/js/ai-orchestrator.ts
@@ -27,7 +27,14 @@ export async function aiTurn(engine: GameEngine): Promise<void> {
   await aiDrawPhase(engine);
   await aiMainPhase(engine);
   await aiPlaceTraps(engine);
-  if (await aiBattlePhase(engine)) return;
+
+  // First turn: skip battle phase entirely (FM-style rule)
+  if (engine.state.firstTurnNoAttack) {
+    engine.state.firstTurnNoAttack = false;
+    EchoesOfSanguo.log('PHASE', 'First turn – skipping AI battle phase.');
+  } else {
+    if (await aiBattlePhase(engine)) return;
+  }
 
   // End Phase
   EchoesOfSanguo.log('PHASE', 'End Phase – AI cleanup.');

--- a/js/react/modals/BattleLogModal.tsx
+++ b/js/react/modals/BattleLogModal.tsx
@@ -14,8 +14,13 @@ export function BattleLogModal() {
     const a = document.createElement('a');
     a.href = url;
     a.download = `battle-log-${new Date().toISOString().slice(0, 19).replace(/:/g, '-')}.txt`;
+    a.style.display = 'none';
+    document.body.appendChild(a);
     a.click();
-    URL.revokeObjectURL(url);
+    setTimeout(() => {
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    }, 100);
   };
 
   return (


### PR DESCRIPTION
## Summary
- **AI first-turn attack**: The AI orchestrator bypassed `engine.advancePhase()` and called `aiBattlePhase()` directly, ignoring the `firstTurnNoAttack` flag. Now the AI correctly skips its battle phase on the first turn (FM-style rule).
- **Download log on mobile**: The `<a>` element wasn't appended to the DOM before `.click()`, and the blob URL was revoked immediately — causing downloads to silently fail on mobile browsers. Fixed by appending to DOM and deferring cleanup.

## Test plan
- [x] All 395 existing tests pass
- [ ] Start a duel where opponent goes first — verify opponent skips battle phase on turn 1
- [ ] Open battle log on mobile and tap "Download Log" — verify file downloads successfully

https://claude.ai/code/session_01HR3SREdAty5Q5ngd3npV2b