### PR TITLE
fix(engine): make position change free and unlimited

### DIFF
--- a/js/engine.ts
+++ b/js/engine.ts
@@ -708,7 +708,7 @@ export class GameEngine {
     const fc = this.state[owner].field.monsters[zone];
     if(!fc || fc.summonedThisTurn){ this.addLog('Cannot change position!'); return; }
     fc.position = fc.position === 'atk' ? 'def' : 'atk';
-    fc.hasAttacked = true; // cant attack after changing
+    // position change is free and unlimited — does not consume an action
     this.addLog(`${fc.card.name} switches to ${fc.position === 'atk' ? 'attack' : 'defense'} position.`);
     this.ui.render(this.state);
   }

--- a/js/react/modals/CardDetailModal.tsx
+++ b/js/react/modals/CardDetailModal.tsx
@@ -50,7 +50,7 @@ export function CardDetailModal({ modal }: Props) {
       if (fieldCard && fieldCard.faceDown && !fieldCard.summonedThisTurn) {
         actions.push(actionBtn(t('card_action.flip_summon'), () => { game.flipSummon('player', index); closeModal(); }));
       }
-      if (fieldCard && !fieldCard.faceDown && !fieldCard.summonedThisTurn && !fieldCard.hasAttacked) {
+      if (fieldCard && !fieldCard.faceDown && !fieldCard.summonedThisTurn) {
         const label = fieldCard.position === 'atk' ? t('card_action.change_to_def') : t('card_action.change_to_atk');
         actions.push(actionBtn(label, () => { game.changePosition('player', index); closeModal(); }));
       }


### PR DESCRIPTION
## Summary
- Changing a monster's position (atk↔def) no longer consumes an action (`hasAttacked` is no longer set)
- The position change button now appears even after a monster has attacked
- Position can be toggled any number of times during the main phase

## Changes
- **`js/engine.ts`**: Removed `fc.hasAttacked = true` from `changePosition()` so it doesn't block further actions
- **`js/react/modals/CardDetailModal.tsx`**: Removed `!fieldCard.hasAttacked` condition so the button remains available regardless of attack state

## Test plan
- [x] All 395 existing tests pass
- [ ] Manual: Summon a monster, change position multiple times in one turn — should work
- [ ] Manual: Attack with a monster, then change its position — should work
- [ ] Manual: Change position, then attack — should work

https://claude.ai/code/session_01LwVpJHZj3CQXUguHFMVDqA