### PR TITLE
feat(engine): toggleable FM-style hand refill draw rule

### DIFF
--- a/js/ai-orchestrator.ts
+++ b/js/ai-orchestrator.ts
@@ -52,7 +52,7 @@ export async function aiTurn(engine: GameEngine): Promise<void> {
 
   EchoesOfSanguo.groupEnd();
 
-  engine.drawCard('player', 1);
+  engine.refillHand('player');
   engine.ui.render(engine.state);
   if(engine.checkWin()) return;
 }
@@ -64,8 +64,8 @@ async function aiDrawPhase(engine: GameEngine): Promise<void> {
   engine.state.phase = 'draw';
   engine.ui.render(engine.state);
   await _delay(300);
-  engine.drawCard('opponent', 1);
-  engine.addLog('Opponent draws a card.');
+  engine.refillHand('opponent');
+  engine.addLog('Opponent draws cards.');
   EchoesOfSanguo.log('PHASE', 'Draw Phase – Hand:', ai.hand.map(c => c.name));
   engine.ui.render(engine.state);
   await _delay(400);

--- a/js/engine.ts
+++ b/js/engine.ts
@@ -90,7 +90,7 @@ export class GameEngine {
           this.state.phase = 'main';
           this.state.turn++;
           this.addLog(`[ERROR] Opponent AI crashed. Your turn (Round ${this.state.turn}).`);
-          this.drawCard('player', 1);
+          this.refillHand('player');
           this.ui.render(this.state);
         });
       }, 600);
@@ -183,6 +183,17 @@ export class GameEngine {
     // hand limit (draw cap)
     while(st.hand.length > GAME_RULES.handLimitDraw) st.hand.shift();
     if(drawn > 0 && this.ui.onDraw) this.ui.onDraw(owner, drawn);
+  }
+
+  /** Refill hand up to handRefillSize (Forbidden Memories style) or draw 1. */
+  refillHand(owner: Owner){
+    if(GAME_RULES.refillHandEnabled){
+      const st = this.state[owner];
+      const need = GAME_RULES.handRefillSize - st.hand.length;
+      if(need > 0) this.drawCard(owner, need);
+    } else {
+      this.drawCard(owner, GAME_RULES.drawPerTurn);
+    }
   }
 
   // ───────── Summon ────────────────────────────────────────
@@ -697,7 +708,7 @@ export class GameEngine {
         this.state.phase = 'main';
         this.state.turn++;
         this.addLog(`[ERROR] Opponent AI crashed. Your turn (Round ${this.state.turn}).`);
-        this.drawCard('player', 1);
+        this.refillHand('player');
         this.ui.render(this.state);
       });
     }, 600);

--- a/js/main.js
+++ b/js/main.js
@@ -8,6 +8,11 @@ await loadTcgFile(import.meta.env.BASE_URL + 'base.tcg'); // populates CARD_DB, 
 // Call revokeTcgImages() before reloading the TCG file if needed.
 
 await import('./progression.js');
+// Apply persisted game-rule settings
+const { Progression } = await import('./progression.js');
+const { GAME_RULES }  = await import('./rules.js');
+GAME_RULES.refillHandEnabled = Progression.getSettings().refillHand ?? true;
+
 await import('./i18n.js');          // must come after progression.js (reads saved language)
 await import('./engine.js');
 await import('./react/index.js');

--- a/js/progression.ts
+++ b/js/progression.ts
@@ -227,10 +227,12 @@ export const Progression = (() => {
 
   // ── Settings ─────────────────────────────────────────────
 
-  interface Settings { lang: string; volMaster: number; volMusic: number; volSfx: number; }
+  interface Settings { lang: string; volMaster: number; volMusic: number; volSfx: number; refillHand: boolean; }
+
+  const SETTINGS_DEFAULTS: Settings = { lang: 'en', volMaster: 50, volMusic: 50, volSfx: 50, refillHand: true };
 
   function getSettings(): Settings {
-    return _load(KEYS.settings, { lang: 'en', volMaster: 50, volMusic: 50, volSfx: 50 });
+    return { ...SETTINGS_DEFAULTS, ..._load(KEYS.settings, SETTINGS_DEFAULTS) };
   }
 
   function saveSettings(s: Settings): void {

--- a/js/react/modals/OptionsModal.tsx
+++ b/js/react/modals/OptionsModal.tsx
@@ -4,6 +4,7 @@ import { useModal }     from '../contexts/ModalContext.js';
 import { useGame }      from '../contexts/GameContext.js';
 import { Progression }  from '../../progression.js';
 import { Audio }        from '../../audio.js';
+import { GAME_RULES }   from '../../rules.js';
 import i18n             from '../../i18n.js';
 
 export function OptionsModal() {
@@ -16,12 +17,14 @@ export function OptionsModal() {
   const [volMaster,   setVolMaster]   = useState(saved.volMaster);
   const [volMusic,    setVolMusic]    = useState(saved.volMusic);
   const [volSfx,      setVolSfx]      = useState(saved.volSfx);
+  const [refillHand,  setRefillHand]  = useState(saved.refillHand);
   const [showConfirm, setShowConfirm] = useState(false);
 
   function apply() {
     i18n.changeLanguage(lang);
-    Progression.saveSettings({ lang, volMaster, volMusic, volSfx });
+    Progression.saveSettings({ lang, volMaster, volMusic, volSfx, refillHand });
     Audio.setVolumes(volMaster, volMusic, volSfx);
+    GAME_RULES.refillHandEnabled = refillHand;
   }
 
   function handleSurrender() {
@@ -67,6 +70,14 @@ export function OptionsModal() {
         </label>
         <input type="range" min="0" max="100" value={volSfx}
           onChange={e => { const v = +e.target.value; setVolSfx(v); Audio.setVolumes(volMaster, volMusic, v); }} />
+      </div>
+
+      <div className="options-row">
+        <label>{t('options.refill_hand')}</label>
+        <select value={refillHand ? 'refill' : 'draw1'} onChange={e => setRefillHand(e.target.value === 'refill')}>
+          <option value="refill">{t('options.refill_hand_on')}</option>
+          <option value="draw1">{t('options.refill_hand_off')}</option>
+        </select>
       </div>
 
       <div className="options-buttons">

--- a/js/rules.ts
+++ b/js/rules.ts
@@ -12,6 +12,8 @@ export const GAME_RULES = {
   maxDeckSize: 40,
   maxCardCopies: 3,
   drawPerTurn: 1,
+  handRefillSize: 5,
+  refillHandEnabled: true,
 };
 
 export type GameRules = typeof GAME_RULES;

--- a/js/types.ts
+++ b/js/types.ts
@@ -366,6 +366,7 @@ export declare class GameEngine {
   dealDamage(target: Owner, amount: number): void;
   gainLP(target: Owner, amount: number): void;
   drawCard(owner: Owner, count?: number): void;
+  refillHand(owner: Owner): void;
   specialSummon(owner: Owner, card: CardData, zone?: number): Promise<boolean>;
   specialSummonFromGrave(owner: Owner, card: CardData): Promise<boolean>;
   endTurn(): void;

--- a/locales/de.json
+++ b/locales/de.json
@@ -69,6 +69,9 @@
     "vol_master": "Gesamtlautstärke",
     "vol_music": "Hintergrundmusik",
     "vol_sfx": "Soundeffekte",
+    "refill_hand": "Zieh-Regel",
+    "refill_hand_on": "Auffüllen auf 5 (FM)",
+    "refill_hand_off": "1 Karte pro Zug",
     "view_log": "📜 Kampfprotokoll",
     "log_empty": "Noch keine Einträge.",
     "download_log": "⬇ Protokoll herunterladen"

--- a/locales/en.json
+++ b/locales/en.json
@@ -69,6 +69,9 @@
     "vol_master": "Master Volume",
     "vol_music": "Background Music",
     "vol_sfx": "Sound Effects",
+    "refill_hand": "Draw Rule",
+    "refill_hand_on": "Refill to 5 (FM)",
+    "refill_hand_off": "Draw 1 per turn",
     "view_log": "📜 Battle Log",
     "log_empty": "No log entries yet.",
     "download_log": "⬇ Download Log"

--- a/tests/progression-edges.test.js
+++ b/tests/progression-edges.test.js
@@ -376,11 +376,11 @@ describe('opponents edge cases', () => {
 describe('settings', () => {
   it('getSettings returns defaults when no settings saved', () => {
     const s = Progression.getSettings();
-    expect(s).toEqual({ lang: 'en', volMaster: 50, volMusic: 50, volSfx: 50 });
+    expect(s).toEqual({ lang: 'en', volMaster: 50, volMusic: 50, volSfx: 50, refillHand: true });
   });
 
   it('saveSettings persists and getSettings retrieves', () => {
-    const custom = { lang: 'de', volMaster: 80, volMusic: 30, volSfx: 100 };
+    const custom = { lang: 'de', volMaster: 80, volMusic: 30, volSfx: 100, refillHand: false };
     Progression.saveSettings(custom);
     expect(Progression.getSettings()).toEqual(custom);
   });
@@ -388,7 +388,7 @@ describe('settings', () => {
   it('getSettings returns defaults for corrupted data', () => {
     localStorage.setItem('tcg_settings', '{{{bad');
     const s = Progression.getSettings();
-    expect(s).toEqual({ lang: 'en', volMaster: 50, volMusic: 50, volSfx: 50 });
+    expect(s).toEqual({ lang: 'en', volMaster: 50, volMusic: 50, volSfx: 50, refillHand: true });
   });
 });
 


### PR DESCRIPTION
## Summary

- **Hand refill to 5** (Forbidden Memories style) is now the default draw rule — instead of drawing 1 card, the hand is refilled to 5 at the start of each turn
- **Toggleable via Options menu**: players can switch between "Refill to 5 (FM)" and "Draw 1 per turn" at any time
- Setting persists in localStorage and is applied on app startup

## Changes

- `rules.ts`: Added `refillHandEnabled` and `handRefillSize` to `GAME_RULES`
- `engine.ts`: New `refillHand()` method that checks the flag and either refills to 5 or draws 1
- `ai-orchestrator.ts`: AI draw phase uses `refillHand()` instead of `drawCard(1)`
- `OptionsModal.tsx`: Draw rule dropdown (de + en translations)
- `progression.ts`: `refillHand` boolean in Settings with backwards-compatible defaults
- `main.js`: Applies persisted setting on startup

## Test plan

- [x] All 395 Vitest tests pass
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Manual: Start a duel with default setting → hand refills to 5 each turn
- [ ] Manual: Toggle to "Draw 1 per turn" in Options → only 1 card drawn next turn
- [ ] Manual: Reload app → setting persists

https://claude.ai/code/session_01T2TEfarjy81tUni3SieMsV