### PR TITLE
feat(fusion): FM-style multi-card fusion chain system

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -522,6 +522,57 @@ button { cursor: pointer; border: none; font-family: inherit; transition: none; 
   pointer-events: none;
 }
 
+/* FM-style fusion chain selection */
+.hand-card.chain-selected {
+  border-color: #ffd700 !important;
+  outline: 2px solid #ffd700;
+  box-shadow: 0 0 8px rgba(255, 215, 0, 0.6);
+}
+.chain-badge {
+  position: absolute; top: 2px; right: 3px;
+  background: #ffd700; color: #000;
+  font-size: 9px; font-weight: bold; line-height: 1;
+  width: 16px; height: 16px;
+  display: flex; align-items: center; justify-content: center;
+  border-radius: 50%;
+  pointer-events: none;
+  z-index: 10;
+  font-family: 'Press Start 2P', monospace;
+}
+
+/* Fusion chain bar */
+.fusion-chain-bar {
+  display: flex; flex-direction: column; align-items: center; gap: 4px;
+  padding: 6px 10px;
+  background: rgba(0, 0, 0, 0.75);
+  border: 1px solid #ffd700;
+  border-radius: 6px;
+  margin-bottom: 6px;
+  font-family: 'Silkscreen', 'Press Start 2P', monospace;
+  font-size: 10px;
+  color: #eee;
+}
+.fusion-chain-cards {
+  display: flex; align-items: center; gap: 4px; flex-wrap: wrap; justify-content: center;
+}
+.chain-card-name { color: #ccc; }
+.chain-arrow { color: #ffd700; margin: 0 2px; font-weight: bold; }
+.chain-result-name { color: #ffd700; font-weight: bold; }
+.chain-result-stats { color: #aaa; margin-left: 4px; }
+.fusion-chain-steps {
+  display: flex; gap: 6px; flex-wrap: wrap; justify-content: center;
+  font-size: 9px;
+}
+.chain-step-fused { color: #4caf50; }
+.chain-step-fallback { color: #ff9800; }
+.fusion-chain-actions {
+  display: flex; gap: 8px; margin-top: 4px;
+}
+.chain-confirm-btn {
+  background: #ffd700 !important; color: #000 !important;
+  font-weight: bold;
+}
+
 /* Big card for detail view — internal overrides live in Card.module.css */
 .big-card {
   width: var(--card-w-big);

--- a/js/ai-orchestrator.ts
+++ b/js/ai-orchestrator.ts
@@ -9,8 +9,9 @@
 
 import { EchoesOfSanguo } from './debug-logger.js';
 import { CardType, Attribute, isMonsterType } from './types.js';
-import type { AIBehavior } from './types.js';
+import type { AIBehavior, CardData } from './types.js';
 import type { FieldCard } from './field.js';
+import { checkFusion, CARD_DB } from './cards.js';
 // Use import type to avoid circular dependency (engine.ts → ai-orchestrator.ts → engine.ts)
 import type { GameEngine } from './engine.js';
 import { pickSummonCandidate, decideSummonPosition } from './ai-behaviors.js';
@@ -82,22 +83,19 @@ async function aiMainPhase(engine: GameEngine): Promise<void> {
   engine.ui.render(engine.state);
   await _delay(400);
 
-  // Try fusion first (max. 1 per turn)
+  // Try fusion chain first (FM-style: greedy 2-card + extend)
   const bh = engine._aiBehavior;
-  EchoesOfSanguo.log('AI', 'Main Phase – checking fusion...');
+  EchoesOfSanguo.log('AI', 'Main Phase – checking fusion chain...');
   if(!ai.normalSummonUsed && bh.fusionFirst){
-    const opts = engine.getAllFusionOptions('opponent');
-    if(opts.length > 0){
-      const best = opts.sort((a,b) => (b.result.atk ?? 0) - (a.result.atk ?? 0))[0];
-      const bestATKValue = best.result.atk ?? 0;
-      const zone = ai.field.monsters.findIndex(z => z === null);
-      if(zone !== -1 && bestATKValue >= bh.fusionMinATK){
-        EchoesOfSanguo.log('AI', `Fusion: ${best.card1.name} + ${best.card2.name} → ${best.result.name} (Zone ${zone})`);
-        await _delay(500);
-        await engine.performFusion('opponent', best.i1, best.i2);
-      }
+    const bestChain = _findBestFusionChain(ai.hand, bh.fusionMinATK);
+    const zone = ai.field.monsters.findIndex(z => z === null);
+    if(bestChain && zone !== -1){
+      const names = bestChain.indices.map(i => ai.hand[i].name);
+      EchoesOfSanguo.log('AI', `Fusion chain: ${names.join(' + ')} → ${bestChain.resultName} (Zone ${zone})`);
+      await _delay(500);
+      await engine.performFusionChain('opponent', bestChain.indices);
     } else {
-      EchoesOfSanguo.log('AI', 'No fusion available.');
+      EchoesOfSanguo.log('AI', 'No fusion chain available.');
     }
   }
 
@@ -302,4 +300,67 @@ export function aiBattlePickTarget(atk: FieldCard, plrMonsters: Array<FieldCard 
     if (atk.effectiveATK() >= defVal && defVal < safeVal) { safeVal = defVal; safeTarget = dz; }
   }
   return safeTarget;
+}
+
+// ── AI Fusion Chain (greedy 2-card + extend) ─────────────
+
+function _findBestFusionChain(hand: CardData[], minATK: number): { indices: number[]; resultName: string } | null {
+  let bestChain: number[] | null = null;
+  let bestATK = -1;
+  let bestName = '';
+
+  // Try all 2-card starting pairs
+  for (let i = 0; i < hand.length; i++) {
+    for (let j = i + 1; j < hand.length; j++) {
+      const recipe = checkFusion(hand[i].id, hand[j].id);
+      if (!recipe) continue;
+      const resultCard = CARD_DB[recipe.result];
+      if (!resultCard) continue;
+
+      let chain = [i, j];
+      let currentId = recipe.result;
+      let currentATK = resultCard.atk ?? 0;
+
+      // Greedily try to extend with remaining hand cards
+      const used = new Set(chain);
+      let improved = true;
+      while (improved) {
+        improved = false;
+        let bestExtIdx = -1;
+        let bestExtATK = currentATK;
+        let bestExtId = currentId;
+
+        for (let k = 0; k < hand.length; k++) {
+          if (used.has(k)) continue;
+          const extRecipe = checkFusion(currentId, hand[k].id);
+          if (!extRecipe) continue;
+          const extCard = CARD_DB[extRecipe.result];
+          if (!extCard) continue;
+          const extATK = extCard.atk ?? 0;
+          if (extATK > bestExtATK) {
+            bestExtATK = extATK;
+            bestExtIdx = k;
+            bestExtId = extRecipe.result;
+          }
+        }
+
+        if (bestExtIdx !== -1) {
+          chain = [...chain, bestExtIdx];
+          used.add(bestExtIdx);
+          currentId = bestExtId;
+          currentATK = bestExtATK;
+          improved = true;
+        }
+      }
+
+      if (currentATK > bestATK) {
+        bestATK = currentATK;
+        bestChain = chain;
+        bestName = CARD_DB[currentId]?.name ?? '?';
+      }
+    }
+  }
+
+  if (!bestChain || bestATK < minATK) return null;
+  return { indices: bestChain, resultName: bestName };
 }

--- a/js/cards.ts
+++ b/js/cards.ts
@@ -3,7 +3,7 @@
 // Runtime data store — populated at startup by loading base.tcg
 // ============================================================
 import type { CardData, FusionRecipe, FusionFormula, OpponentConfig } from './types.js';
-import { CardType, Rarity } from './types.js';
+import { CardType, Rarity, isMonsterType } from './types.js';
 import {
   getRaceByKey, getAttrByKey, getRarityById,
   TYPE_META,
@@ -133,4 +133,81 @@ function selectFusionResult(pool: string[], threshold: number): string | null {
 
   if (candidates.length === 0) return null;
   return candidates[0].id;
+}
+
+// ── Multi-Card Fusion Chain (FM-style) ───────────────────
+
+export interface FusionChainStep {
+  inputA: string;           // current result card ID
+  inputB: string;           // next card ID being combined
+  output: string;           // surviving card ID after this step
+  fused: boolean;           // true if a real fusion occurred
+  discardedId: string | null; // card discarded at this step (null if fused — both consumed into result)
+}
+
+export interface FusionChainResult {
+  finalCardId: string;
+  steps: FusionChainStep[];
+  consumedIds: string[];    // all original input card IDs that were consumed (not the final result)
+}
+
+/**
+ * Resolve a multi-card fusion chain using FM rules.
+ * Cards are combined in order: card[0]+card[1], then result+card[2], etc.
+ *
+ * At each step:
+ * 1. If legitimate fusion → combine into fusion result
+ * 2. If not a fusion and exactly one is a monster → keep the monster, discard the other
+ * 3. If not a fusion and neither/both are monsters → discard inputA (current result), keep inputB
+ *
+ * Pure function — no state mutation. Safe for preview.
+ */
+export function resolveFusionChain(cardIds: string[]): FusionChainResult {
+  if (cardIds.length === 0) {
+    return { finalCardId: '', steps: [], consumedIds: [] };
+  }
+  if (cardIds.length === 1) {
+    return { finalCardId: cardIds[0], steps: [], consumedIds: [] };
+  }
+
+  const steps: FusionChainStep[] = [];
+  const consumedIds: string[] = [];
+  let currentId = cardIds[0];
+
+  for (let i = 1; i < cardIds.length; i++) {
+    const nextId = cardIds[i];
+    const recipe = checkFusion(currentId, nextId);
+
+    if (recipe) {
+      // Legitimate fusion — both consumed, result replaces current
+      steps.push({ inputA: currentId, inputB: nextId, output: recipe.result, fused: true, discardedId: null });
+      consumedIds.push(currentId, nextId);
+      currentId = recipe.result;
+    } else {
+      // No fusion — apply fallback rules
+      const cardA = CARD_DB[currentId];
+      const cardB = CARD_DB[nextId];
+      const aIsMon = cardA && isMonsterType(cardA.type);
+      const bIsMon = cardB && isMonsterType(cardB.type);
+
+      if (aIsMon && !bIsMon) {
+        // Keep monster (A), discard non-monster (B)
+        steps.push({ inputA: currentId, inputB: nextId, output: currentId, fused: false, discardedId: nextId });
+        consumedIds.push(nextId);
+        // currentId stays the same
+      } else if (!aIsMon && bIsMon) {
+        // Keep monster (B), discard non-monster (A)
+        steps.push({ inputA: currentId, inputB: nextId, output: nextId, fused: false, discardedId: currentId });
+        consumedIds.push(currentId);
+        currentId = nextId;
+      } else {
+        // Neither or both are monsters — discard first (A), keep second (B)
+        steps.push({ inputA: currentId, inputB: nextId, output: nextId, fused: false, discardedId: currentId });
+        consumedIds.push(currentId);
+        currentId = nextId;
+      }
+    }
+  }
+
+  return { finalCardId: currentId, steps, consumedIds };
 }

--- a/js/engine.ts
+++ b/js/engine.ts
@@ -2,7 +2,7 @@
 // ECHOES OF SANGUO - Game Engine
 // ============================================================
 
-import { CARD_DB, OPPONENT_DECK_IDS, PLAYER_DECK_IDS, makeDeck, checkFusion } from './cards.js';
+import { CARD_DB, OPPONENT_DECK_IDS, PLAYER_DECK_IDS, makeDeck, checkFusion, resolveFusionChain } from './cards.js';
 import { executeEffectBlock } from './effect-registry.js';
 import { CardType } from './types.js';
 import type { Owner, Phase, Position, CardData, EffectContext, EffectSignal, GameState, UICallbacks, OpponentConfig, AIBehavior } from './types.js';
@@ -392,6 +392,79 @@ export class GameEngine {
     const fusionCard = Object.assign({}, CARD_DB[recipe.result]);
     const fc = new FieldCard(fusionCard, 'atk');
     fc.summonedThisTurn = false; // fusion monsters can attack immediately
+    st.field.monsters[zone] = fc;
+    st.normalSummonUsed = true;
+
+    this.ui.render(this.state);
+    await this._triggerEffect(fc, owner, 'onSummon', zone);
+    return true;
+  }
+
+  /**
+   * FM-style multi-card fusion chain.
+   * If 1 card: normal summon in ATK position.
+   * If 2+ cards: resolve chain, place final result on field.
+   */
+  async performFusionChain(owner: Owner, handIndices: number[]): Promise<boolean> {
+    const st = this.state[owner];
+    const hand = st.hand;
+
+    if (handIndices.length === 0) return false;
+
+    // Single card = normal summon shortcut
+    if (handIndices.length === 1) {
+      const zone = st.field.monsters.findIndex(z => z === null);
+      if (zone === -1) { this.addLog('No free zone!'); return false; }
+      return this.summonMonster(owner, handIndices[0], zone, 'atk');
+    }
+
+    const zone = st.field.monsters.findIndex(z => z === null);
+    if (zone === -1) { this.addLog('No free zone for fusion monster!'); return false; }
+
+    // Resolve chain using FM rules
+    const cardIds = handIndices.map(i => hand[i].id);
+    const chain = resolveFusionChain(cardIds);
+
+    const finalCard = CARD_DB[chain.finalCardId];
+    if (!finalCard) { this.addLog('Fusion chain failed!'); return false; }
+
+    // Build log message showing the chain
+    const cardNames = handIndices.map(i => hand[i].name);
+    this.addLog(`${ownerLabel(owner)}: FUSION! ${cardNames.join(' + ')} = ${finalCard.name}!`);
+    this.ui.playSfx?.('sfx_fusion');
+
+    // Play animation
+    if (this.ui.playFusionChainAnimation) {
+      await this.ui.playFusionChainAnimation(owner, handIndices, zone);
+    } else if (this.ui.playFusionAnimation && handIndices.length >= 2) {
+      await this.ui.playFusionAnimation(owner, handIndices[0], handIndices[1], zone);
+    }
+
+    // Collect the actual CardData objects before removing from hand
+    const removedCards = handIndices.map(i => hand[i]);
+
+    // Remove cards from hand in descending index order to avoid shift issues
+    const sortedDesc = [...handIndices].sort((a, b) => b - a);
+    for (const idx of sortedDesc) {
+      hand.splice(idx, 1);
+    }
+
+    // Send consumed cards to graveyard (all original cards except: if the final result
+    // is one of the original hand cards, don't graveyard it — it stays as the result)
+    for (const card of removedCards) {
+      if (chain.consumedIds.includes(card.id)) {
+        st.graveyard.push(card);
+      } else {
+        // This is the surviving card from fallback rules — also goes to graveyard
+        // since we replace it with the CARD_DB version on the field
+        st.graveyard.push(card);
+      }
+    }
+
+    // Place final result on field
+    const resultCard = Object.assign({}, finalCard);
+    const fc = new FieldCard(resultCard, 'atk');
+    fc.summonedThisTurn = false; // fusion result can attack immediately
     st.field.monsters[zone] = fc;
     st.normalSummonUsed = true;
 

--- a/js/react/components/FusionChainBar.tsx
+++ b/js/react/components/FusionChainBar.tsx
@@ -1,0 +1,75 @@
+import { useTranslation } from 'react-i18next';
+import { CARD_DB } from '../../cards.js';
+import type { FusionChainResult } from '../../cards.js';
+import type { CardData } from '../../types.js';
+
+interface Props {
+  hand: CardData[];
+  chain: number[];
+  preview: FusionChainResult | null;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function FusionChainBar({ hand, chain, preview, onConfirm, onCancel }: Props) {
+  const { t } = useTranslation();
+
+  const finalCard = preview ? CARD_DB[preview.finalCardId] : (chain.length === 1 ? hand[chain[0]] : null);
+
+  return (
+    <div className="fusion-chain-bar">
+      <div className="fusion-chain-cards">
+        {chain.map((handIdx, i) => {
+          const card = hand[handIdx];
+          if (!card) return null;
+          return (
+            <span key={i} className="chain-card-name">
+              {i > 0 && <span className="chain-arrow">+</span>}
+              {card.name}
+            </span>
+          );
+        })}
+        {finalCard && chain.length >= 1 && (
+          <>
+            <span className="chain-arrow">=</span>
+            <span className="chain-result-name">{finalCard.name}</span>
+            {finalCard.atk !== undefined && (
+              <span className="chain-result-stats">
+                (ATK {finalCard.atk})
+              </span>
+            )}
+          </>
+        )}
+      </div>
+      {preview && preview.steps.length > 0 && (
+        <div className="fusion-chain-steps">
+          {preview.steps.map((step, i) => {
+            const stepClass = step.fused ? 'chain-step-fused' : 'chain-step-fallback';
+            const label = step.fused
+              ? t('fusion_chain.step_fused')
+              : step.discardedId
+                ? t('fusion_chain.step_discarded', { name: CARD_DB[step.discardedId]?.name ?? '?' })
+                : '';
+            return (
+              <span key={i} className={`chain-step ${stepClass}`}>
+                {label}
+              </span>
+            );
+          })}
+        </div>
+      )}
+      <div className="fusion-chain-actions">
+        <button
+          className="menu-action-btn chain-confirm-btn"
+          disabled={chain.length === 0}
+          onClick={onConfirm}
+        >
+          {chain.length >= 2 ? t('fusion_chain.confirm') : t('fusion_chain.summon')}
+        </button>
+        <button className="btn-cancel" onClick={onCancel}>
+          {t('fusion_chain.cancel')}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/js/react/components/HandCard.tsx
+++ b/js/react/components/HandCard.tsx
@@ -8,22 +8,25 @@ interface Props {
   playable: boolean;
   fusionable: boolean;
   targetable: boolean;
+  chainSelected?: boolean;
+  chainIndex?: number;
   newlyDrawn: boolean;
   drawDelay: number;
   onClick: () => void;
 }
 
-export function HandCard({ card, index, playable, fusionable, targetable, newlyDrawn, drawDelay, onClick }: Props) {
+export function HandCard({ card, index, playable, fusionable, targetable, chainSelected, chainIndex, newlyDrawn, drawDelay, onClick }: Props) {
   const ref = useRef<HTMLDivElement>(null);
 
   const cls = [
     'card hand-card',
     `${cardTypeCss(card)}-card`,
     `attr-${card.attribute ? ATTR_CSS[card.attribute] || 'spell' : 'spell'}`,
-    playable   ? 'playable'   : '',
-    fusionable ? 'fusionable' : '',
-    targetable ? 'targetable' : '',
-    newlyDrawn ? 'newly-drawn' : '',
+    playable      ? 'playable'       : '',
+    fusionable    ? 'fusionable'     : '',
+    targetable    ? 'targetable'     : '',
+    chainSelected ? 'chain-selected' : '',
+    newlyDrawn    ? 'newly-drawn'    : '',
   ].filter(Boolean).join(' ');
 
   return (
@@ -38,6 +41,9 @@ export function HandCard({ card, index, playable, fusionable, targetable, newlyD
       onClick={playable || targetable ? onClick : undefined}
     >
       <Card card={card} small />
+      {chainIndex !== undefined && (
+        <span className="chain-badge">{chainIndex + 1}</span>
+      )}
     </div>
   );
 }

--- a/js/react/contexts/SelectionContext.tsx
+++ b/js/react/contexts/SelectionContext.tsx
@@ -1,8 +1,9 @@
 import { createContext, useContext, useState, useCallback } from 'react';
 import type { CardData } from '../../types.js';
+import type { FusionChainResult } from '../../cards.js';
 
 export type SelMode =
-  | 'hand' | 'attack' | 'fusion1' | 'spell-target' | 'field-spell-target'
+  | 'hand' | 'attack' | 'fusion1' | 'play-chain' | 'spell-target' | 'field-spell-target'
   | 'grave-target' | 'trap-target' | null;
 
 export interface Selection {
@@ -10,6 +11,8 @@ export interface Selection {
   handIndex:      number | null;
   attackerZone:   number | null;
   fusion1:        { handIndex: number } | null;
+  playChain:      number[];
+  playChainPreview: FusionChainResult | null;
   spellHandIndex: number | null;
   spellFieldZone: number | null;
   spellCard:      CardData | null;
@@ -20,6 +23,7 @@ export interface Selection {
 
 const EMPTY: Selection = {
   mode: null, handIndex: null, attackerZone: null, fusion1: null,
+  playChain: [], playChainPreview: null,
   spellHandIndex: null, spellFieldZone: null, spellCard: null, trapFieldZone: null, callback: null, hint: '',
 };
 

--- a/js/react/modals/CardDetailModal.tsx
+++ b/js/react/modals/CardDetailModal.tsx
@@ -43,7 +43,6 @@ export function CardDetailModal({ modal }: Props) {
     const isSp  = card.type === CardType.Spell;
     const isTr  = card.type === CardType.Trap;
     const freeZone = state.player.field.monsters.findIndex((z: any) => z === null);
-    const fusionOpts = game.getAllFusionOptions('player').filter((o: any) => o.i1 === index || o.i2 === index);
 
     if (isMon && phase === 'main' && source === 'field') {
       const fieldCard = state.player.field.monsters[index];
@@ -57,17 +56,13 @@ export function CardDetailModal({ modal }: Props) {
     } else if (isMon && phase === 'main') {
       if (state.player.normalSummonUsed) {
         actions.push(actionBtn(t('card_action.already_played'), null, true));
-      } else {
-        if (freeZone !== -1) {
-          actions.push(actionBtn(t('card_action.summon_atk'), () => { game.summonMonster('player', index, freeZone, 'atk'); closeModal(); }));
-          actions.push(actionBtn(t('card_action.set_def'), () => { game.setMonster('player', index, freeZone); closeModal(); }));
-        }
-      }
-      if (fusionOpts.length > 0 && !state.player.normalSummonUsed) {
-        actions.push(actionBtn(t('card_action.fusion'), () => {
-          setSel({ mode: 'fusion1', fusion1: { handIndex: index }, hint: t('card_action.hint_fusion') });
+      } else if (freeZone !== -1) {
+        // FM-style "Play" — starts a fusion chain selection (single card = summon, 2+ = fusion)
+        actions.push(actionBtn(t('card_action.play'), () => {
+          setSel({ mode: 'play-chain', playChain: [index], playChainPreview: null, hint: t('card_action.hint_play_chain') });
           closeModal();
         }));
+        actions.push(actionBtn(t('card_action.set_def'), () => { game.setMonster('player', index, freeZone); closeModal(); }));
       }
     }
 

--- a/js/react/screens/game/HandArea.tsx
+++ b/js/react/screens/game/HandArea.tsx
@@ -3,12 +3,13 @@ import { useGame }      from '../../contexts/GameContext.js';
 import { useModal }     from '../../contexts/ModalContext.js';
 import { useSelection } from '../../contexts/SelectionContext.js';
 import { HandCard }     from '../../components/HandCard.js';
-import { checkFusion }  from '../../../cards.js';
+import { FusionChainBar } from '../../components/FusionChainBar.js';
+import { checkFusion, resolveFusionChain } from '../../../cards.js';
 
 export function HandArea() {
   const { gameState, gameRef, pendingDraw } = useGame();
   const { openModal }                       = useModal();
-  const { sel, resetSel }                   = useSelection();
+  const { sel, setSel, resetSel }           = useSelection();
 
   if (!gameState) return null;
 
@@ -23,6 +24,8 @@ export function HandArea() {
   const onHandCardClick = useCallback((card: any, index: number) => {
     const game = gameRef.current;
     if (!game) return;
+
+    // Legacy 2-card fusion mode (kept for backward compat if needed)
     if (selMode === 'fusion1') {
       if (index === sel.fusion1!.handIndex) { resetSel(); return; }
       const firstCard = player.hand[sel.fusion1!.handIndex];
@@ -35,24 +38,74 @@ export function HandArea() {
       resetSel();
       return;
     }
+
+    // FM-style play chain mode
+    if (selMode === 'play-chain') {
+      const chain = sel.playChain;
+
+      // Clicking the last card in chain = undo
+      if (chain.length > 0 && chain[chain.length - 1] === index) {
+        const newChain = chain.slice(0, -1);
+        if (newChain.length === 0) {
+          resetSel();
+          return;
+        }
+        const cardIds = newChain.map(i => player.hand[i].id);
+        const preview = cardIds.length >= 2 ? resolveFusionChain(cardIds) : null;
+        setSel({ playChain: newChain, playChainPreview: preview });
+        return;
+      }
+
+      // Card already in chain (not last) — ignore
+      if (chain.includes(index)) return;
+
+      // Add to chain
+      const newChain = [...chain, index];
+      const cardIds = newChain.map(i => player.hand[i].id);
+      const preview = cardIds.length >= 2 ? resolveFusionChain(cardIds) : null;
+      setSel({ playChain: newChain, playChainPreview: preview });
+      return;
+    }
+
     openModal({ type: 'card-detail', card, index, state: gameState });
-  }, [gameRef, selMode, sel.fusion1, player.hand, player.field.monsters, resetSel, openModal, gameState]);
+  }, [gameRef, selMode, sel.fusion1, sel.playChain, player.hand, player.field.monsters, resetSel, setSel, openModal, gameState]);
+
+  const onConfirmChain = useCallback(() => {
+    const game = gameRef.current;
+    if (!game || sel.playChain.length === 0) return;
+    game.performFusionChain('player', sel.playChain);
+    resetSel();
+  }, [gameRef, sel.playChain, resetSel]);
 
   return (
     <div id="hand-area">
+      {selMode === 'play-chain' && (
+        <FusionChainBar
+          hand={player.hand}
+          chain={sel.playChain}
+          preview={sel.playChainPreview}
+          onConfirm={onConfirmChain}
+          onCancel={resetSel}
+        />
+      )}
       <div id="player-hand">
         {player.hand.map((card: any, i: number) => {
           const isNewlyDrawn = i >= newDrawBase;
           const playable     = isMyTurn && phase === 'main';
+          const inChain      = selMode === 'play-chain' && sel.playChain.includes(i);
+          const chainIdx     = inChain ? sel.playChain.indexOf(i) : undefined;
           const fusionable   = selMode === 'fusion1' && i !== sel.fusion1?.handIndex;
-          const targetable   = selMode === 'fusion1' && i !== sel.fusion1?.handIndex;
+          const targetable   = (selMode === 'fusion1' && i !== sel.fusion1?.handIndex) ||
+                               selMode === 'play-chain';
           return (
             <HandCard
               key={`${card.id}-${i}`}
               card={card} index={i}
               playable={playable}
               fusionable={fusionable}
-              targetable={targetable && selMode === 'fusion1'}
+              targetable={targetable}
+              chainSelected={inChain}
+              chainIndex={chainIdx}
               newlyDrawn={isNewlyDrawn}
               drawDelay={isNewlyDrawn ? (i - newDrawBase) * 80 : 0}
               onClick={() => onHandCardClick(card, i)}

--- a/js/types.ts
+++ b/js/types.ts
@@ -314,6 +314,7 @@ export interface UICallbacks {
   showActivation?:      (card: CardData, text: string) => Promise<void> | void;
   playAttackAnimation?: (atkOwner: Owner, atkZone: number, defOwner: Owner, defZone: number | null) => Promise<void>;
   playFusionAnimation?: (owner: Owner, handIdx1: number, handIdx2: number, resultZone: number) => Promise<void>;
+  playFusionChainAnimation?: (owner: Owner, handIndices: number[], resultZone: number) => Promise<void>;
   playVFX?:             (type: 'buff' | 'heal' | 'damage', owner: Owner, zone?: number) => Promise<void>;
   playSfx?:             (sfxId: string) => void;
   onDraw?:              (owner: Owner, count: number) => void;
@@ -382,6 +383,7 @@ export declare class GameEngine {
   refillHand(owner: Owner): void;
   specialSummon(owner: Owner, card: CardData, zone?: number): Promise<boolean>;
   specialSummonFromGrave(owner: Owner, card: CardData): Promise<boolean>;
+  performFusionChain(owner: Owner, handIndices: number[]): Promise<boolean>;
   endTurn(): void;
   advancePhase(): void;
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -201,7 +201,16 @@
     "hint_spell_own": "Wähle ein eigenes Monster als Ziel.",
     "hint_trap_opp": "Wähle ein Monster des Gegners als Ziel.",
     "change_to_def": "🔄 In Verteidigung wechseln",
-    "change_to_atk": "🔄 In Angriff wechseln"
+    "change_to_atk": "🔄 In Angriff wechseln",
+    "play": "⚔ Spielen",
+    "hint_play_chain": "Wähle Karten zum Kombinieren, dann bestätigen. Letzte Karte antippen zum Rückgängig machen."
+  },
+  "fusion_chain": {
+    "confirm": "✨ Fusionieren & Spielen",
+    "summon": "⚔ Beschwören",
+    "cancel": "✕ Abbrechen",
+    "step_fused": "Fusioniert!",
+    "step_discarded": "{{name}} abgeworfen"
   },
   "coin_toss": {
     "title": "Münzwurf",

--- a/locales/en.json
+++ b/locales/en.json
@@ -201,7 +201,16 @@
     "hint_spell_own": "Choose your own monster as a target.",
     "hint_trap_opp": "Choose an opponent's monster as a target.",
     "change_to_def": "🔄 Switch to Defense",
-    "change_to_atk": "🔄 Switch to Attack"
+    "change_to_atk": "🔄 Switch to Attack",
+    "play": "⚔ Play",
+    "hint_play_chain": "Select cards to combine, then confirm. Tap last card to undo."
+  },
+  "fusion_chain": {
+    "confirm": "✨ Fuse & Play",
+    "summon": "⚔ Summon",
+    "cancel": "✕ Cancel",
+    "step_fused": "Fused!",
+    "step_discarded": "{{name}} discarded"
   },
   "coin_toss": {
     "title": "Coin Toss",

--- a/tests/fusion-chain.test.js
+++ b/tests/fusion-chain.test.js
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { CARD_DB, resolveFusionChain, checkFusion } from '../js/cards.js';
+import { CardType } from '../js/types.js';
+
+// ── Helpers ────────────────────────────────────────────────
+
+/** Inject a temporary card into CARD_DB for testing. */
+function injectCard(id, overrides = {}) {
+  CARD_DB[id] = {
+    id,
+    name: overrides.name ?? `Card ${id}`,
+    type: overrides.type ?? CardType.Monster,
+    description: '',
+    atk: overrides.atk ?? 1000,
+    def: overrides.def ?? 1000,
+    race: overrides.race,
+    attribute: overrides.attribute,
+    ...overrides,
+  };
+}
+
+function cleanupCards(...ids) {
+  for (const id of ids) delete CARD_DB[id];
+}
+
+// ── resolveFusionChain tests ─────────────────────────────
+
+describe('resolveFusionChain', () => {
+
+  it('returns the single card when given 1 card', () => {
+    const result = resolveFusionChain(['1']);
+    expect(result.finalCardId).toBe('1');
+    expect(result.steps).toHaveLength(0);
+    expect(result.consumedIds).toHaveLength(0);
+  });
+
+  it('returns empty result when given 0 cards', () => {
+    const result = resolveFusionChain([]);
+    expect(result.finalCardId).toBe('');
+    expect(result.steps).toHaveLength(0);
+  });
+
+  it('resolves a 2-card fusion using explicit recipes', () => {
+    // Cards 4+5 = 246 is an existing explicit recipe
+    const result = resolveFusionChain(['4', '5']);
+    expect(result.finalCardId).toBe('246');
+    expect(result.steps).toHaveLength(1);
+    expect(result.steps[0].fused).toBe(true);
+    expect(result.consumedIds).toContain('4');
+    expect(result.consumedIds).toContain('5');
+  });
+
+  describe('fallback rules (no fusion)', () => {
+    const MON_A = '_test_mon_a';
+    const MON_B = '_test_mon_b';
+    const SPELL_A = '_test_spell_a';
+    const SPELL_B = '_test_spell_b';
+
+    beforeEach(() => {
+      injectCard(MON_A, { name: 'MonA', type: CardType.Monster, atk: 500 });
+      injectCard(MON_B, { name: 'MonB', type: CardType.Monster, atk: 800 });
+      injectCard(SPELL_A, { name: 'SpellA', type: CardType.Spell, atk: undefined, def: undefined });
+      injectCard(SPELL_B, { name: 'SpellB', type: CardType.Spell, atk: undefined, def: undefined });
+    });
+
+    afterEach(() => cleanupCards(MON_A, MON_B, SPELL_A, SPELL_B));
+
+    it('keeps monster when only one card is a monster (monster first)', () => {
+      const result = resolveFusionChain([MON_A, SPELL_A]);
+      expect(result.finalCardId).toBe(MON_A);
+      expect(result.steps[0].fused).toBe(false);
+      expect(result.steps[0].discardedId).toBe(SPELL_A);
+      expect(result.consumedIds).toContain(SPELL_A);
+      expect(result.consumedIds).not.toContain(MON_A);
+    });
+
+    it('keeps monster when only one card is a monster (spell first)', () => {
+      const result = resolveFusionChain([SPELL_A, MON_A]);
+      expect(result.finalCardId).toBe(MON_A);
+      expect(result.steps[0].fused).toBe(false);
+      expect(result.steps[0].discardedId).toBe(SPELL_A);
+    });
+
+    it('discards first card when both are monsters', () => {
+      const result = resolveFusionChain([MON_A, MON_B]);
+      expect(result.finalCardId).toBe(MON_B);
+      expect(result.steps[0].fused).toBe(false);
+      expect(result.steps[0].discardedId).toBe(MON_A);
+    });
+
+    it('discards first card when neither is a monster', () => {
+      const result = resolveFusionChain([SPELL_A, SPELL_B]);
+      expect(result.finalCardId).toBe(SPELL_B);
+      expect(result.steps[0].fused).toBe(false);
+      expect(result.steps[0].discardedId).toBe(SPELL_A);
+    });
+  });
+
+  describe('multi-card chains', () => {
+    const MON_X = '_test_chain_mon';
+    const SPELL_X = '_test_chain_spell';
+
+    beforeEach(() => {
+      injectCard(MON_X, { name: 'ChainMon', type: CardType.Monster, atk: 600 });
+      injectCard(SPELL_X, { name: 'ChainSpell', type: CardType.Spell, atk: undefined, def: undefined });
+    });
+
+    afterEach(() => cleanupCards(MON_X, SPELL_X));
+
+    it('chains multiple fallback steps correctly', () => {
+      // MON_X + SPELL_X = keep MON_X (monster kept)
+      // MON_X + SPELL_X = keep MON_X again
+      const result = resolveFusionChain([MON_X, SPELL_X, SPELL_X]);
+      // Note: same ID used twice is fine — represents two copies
+      expect(result.finalCardId).toBe(MON_X);
+      expect(result.steps).toHaveLength(2);
+      // Both spells discarded
+      expect(result.consumedIds.filter(id => id === SPELL_X)).toHaveLength(2);
+    });
+
+    it('consumedIds has the right count for fused + fallback mix', () => {
+      // Use explicit recipe: 4+5 → 246, then 246 + spell (fallback: keep 246)
+      const result = resolveFusionChain(['4', '5', SPELL_X]);
+      expect(result.finalCardId).toBe('246');
+      expect(result.steps).toHaveLength(2);
+      expect(result.steps[0].fused).toBe(true);
+      expect(result.steps[1].fused).toBe(false);
+      expect(result.steps[1].discardedId).toBe(SPELL_X);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Replace 2-card-only fusion** with Forbidden Memories-style sequential multi-card fusion chains
- **Unified "Play" action**: selecting 1 card = normal summon, selecting 2+ cards = fusion chain with step-by-step resolution
- **FM fallback rules**: if a pair doesn't fuse, keep the monster (discard non-monster), or discard the first card if both/neither are monsters
- **AI updated**: greedy 2-card fusion + extend strategy for opponent fusion chains
- **New FusionChainBar UI**: shows selected cards, intermediate results, and final outcome with confirm/cancel

### Chain resolution per step:
1. Legitimate fusion → combine into fusion result
2. No fusion, exactly one monster → keep monster, discard the other
3. No fusion, neither/both monsters → discard first (current result), keep second

### Files changed:
- `js/cards.ts` — `resolveFusionChain()` pure function + types
- `js/engine.ts` — `performFusionChain()` engine method
- `js/types.ts` — `UICallbacks.playFusionChainAnimation`, `GameEngine.performFusionChain`
- `js/react/contexts/SelectionContext.tsx` — `play-chain` mode + chain state
- `js/react/modals/CardDetailModal.tsx` — unified "Play" button replaces Summon/Fusion
- `js/react/screens/game/HandArea.tsx` — multi-card selection with undo
- `js/react/components/FusionChainBar.tsx` — new chain preview bar
- `js/react/components/HandCard.tsx` — chain badge display
- `js/ai-orchestrator.ts` — greedy chain extension AI
- `locales/en.json`, `locales/de.json` — i18n keys
- `css/style.css` — chain selection + bar styles

## Test plan

- [x] All 416 existing + new tests pass (`npx vitest run`)
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] Production build succeeds (`npx vite build`)
- [ ] Manual: select 1 monster → summons normally in ATK
- [ ] Manual: select 2+ cards → chain preview shows, confirm fuses
- [ ] Manual: tap last card in chain to undo selection
- [ ] Manual: cancel button resets chain selection
- [ ] Manual: AI opponent uses fusion chains during its turn
- [ ] Manual: non-monster cards in chain apply fallback rules correctly

https://claude.ai/code/session_01NagZubFnySmVLiQwwwJAL4