### PR TITLE
Fix music overlap, add defeat screen, restore deck count

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -384,7 +384,7 @@ button { cursor: pointer; border: none; font-family: inherit; transition: none; 
 .lp-bottom { display: flex; align-items: center; gap: 4px; }
 .lp-bottom .io-bar-bg { flex: 1; }
 .lp-value { font-size: 0.875rem; font-weight: bold; color: var(--gold-light); line-height: 1; white-space: nowrap; }
-.lp-deck  { font-size: 9px; color: var(--text-dim); white-space: nowrap; }
+.lp-deck  { font-size: 10px; color: var(--gold-light); white-space: nowrap; opacity: 0.8; }
 .io-bar-bg { width: 100%; height: 6px; background: #101c12; border-radius: 0; overflow: hidden; }
 .opp-lp-bar { background: #a82020 !important; }
 .lp-bar { height: 100%; width: 100%; background: #1e6840; border-radius: 0; transition: width 0.3s steps(8); }

--- a/js/audio.ts
+++ b/js/audio.ts
@@ -34,6 +34,7 @@ let _sfxGain: GainNode | null = null;
 
 const _bufferCache = new Map<string, AudioBuffer>();
 let _currentMusic: { source: AudioBufferSourceNode; id: string } | null = null;
+let _musicRequestId = 0;
 
 function _ensureContext(): AudioContext {
   if (!_ctx) {
@@ -91,8 +92,10 @@ async function playMusic(trackId: string): Promise<void> {
   if (_currentMusic?.id === trackId) return;
   stopMusic();
 
+  const requestId = ++_musicRequestId;
   const buf = await _loadBuffer(trackId);
-  if (!buf) return;
+  // Another playMusic call was made while loading — abort this one
+  if (!buf || requestId !== _musicRequestId) return;
 
   const ctx = _ensureContext();
   const source = ctx.createBufferSource();

--- a/js/react/contexts/GameContext.tsx
+++ b/js/react/contexts/GameContext.tsx
@@ -86,7 +86,7 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
     onDuelEnd: (result, opponentId) => {
       Audio.playMusic(result === 'victory' ? 'music_victory' : 'music_defeat');
 
-      // Campaign duel: skip normal result modal, route to dialogue/campaign
+      // Campaign duel
       const pending = pendingDuelRef.current;
       if (pending) {
         setPendingDuelRef.current(null);
@@ -110,8 +110,11 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
               scene: pending.postDialogue as unknown as Record<string, unknown>,
               nextScreen: 'campaign',
             });
-          } else {
+          } else if (isComplete) {
             navigateToRef.current('campaign');
+          } else {
+            // Defeat in campaign: show result modal so the player sees the defeat screen
+            openModalRef.current({ type: 'result', resultType: result, coinsEarned: 0 });
           }
         });
         return;

--- a/js/react/screens/game/LPPanel.tsx
+++ b/js/react/screens/game/LPPanel.tsx
@@ -23,7 +23,7 @@ export function LPPanel({ playerLp, oppLp, playerDeck, oppDeck }: Props) {
             <div id="opp-lp-bar" className="lp-bar opp-lp-bar" style={{ width: lpPct(oppLp) }}></div>
           </div>
           <span className="lp-value" id="opp-lp">{oppLpDisplay}</span>
-          <span className="lp-deck" id="opp-deck-count">{oppDeck}</span>
+          <span className="lp-deck" id="opp-deck-count">🂠{oppDeck}</span>
         </div>
       </div>
       <div className="lp-row player-lp-row">
@@ -33,7 +33,7 @@ export function LPPanel({ playerLp, oppLp, playerDeck, oppDeck }: Props) {
             <div id="player-lp-bar" className="lp-bar" style={{ width: lpPct(playerLp) }}></div>
           </div>
           <span className="lp-value" id="player-lp">{playerLpDisplay}</span>
-          <span className="lp-deck" id="player-deck-count">{playerDeck}</span>
+          <span className="lp-deck" id="player-deck-count">🂠{playerDeck}</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- **Music overlapping**: Added a request token to `playMusic()` in `audio.ts` so that when a new track is requested while a previous one is still loading, the stale load is discarded instead of starting a second concurrent audio source
- **No defeat screen**: Campaign duels on loss (without `completeOnLoss`) were silently navigating back to the campaign map. Now the result modal is shown so the player sees the defeat screen with options to retry
- **Deck count invisible**: Changed deck count display from a bare number in dim 9px text to a gold-colored label with a deck icon (🂠) so it's clearly visible during gameplay

## Test plan

- [ ] Rapidly navigate between screens (title → opponent → game) and verify only one music track plays
- [ ] Lose a campaign duel and verify the defeat modal appears with Play Again / Choose Opponent / Home buttons
- [ ] During a duel, verify both player and opponent deck counts are visible with the card icon

https://claude.ai/code/session_01BWzZu25B79ab4VrLCyvnNK