### PR TITLE
feat(ui): add dark background frame to save point menu

### DIFF
--- a/js/react/screens/SavePointScreen.module.css
+++ b/js/react/screens/SavePointScreen.module.css
@@ -7,7 +7,14 @@
 
 .content {
   position: relative; z-index: 1;
-  text-align: center; padding: 40px;
+  text-align: center; padding: 30px 40px;
+  background: rgba(0, 10, 5, 0.55);
+  border: 1px solid rgba(40, 160, 80, 0.25);
+  border-radius: 6px;
+  backdrop-filter: blur(3px);
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.6), inset 0 1px 0 rgba(255, 255, 255, 0.04);
+  max-width: 420px;
+  width: 90vw;
 }
 
 .title {


### PR DESCRIPTION
## Summary
- Adds a semi-transparent dark background frame to the SavePointScreen content area
- Includes border, backdrop blur, and box shadow matching the title screen menu style
- Improves readability and visual consistency across menu screens

## Test plan
- [ ] Open the save point screen and verify the dark background frame is visible behind the menu
- [ ] Compare with the title screen to ensure visual consistency
- [ ] Test on mobile viewport to confirm responsive sizing (90vw, max 420px)

https://claude.ai/code/session_0148A5CSMbRLiJqvFPDfF4MH