### PR TITLE
fix(ui): reposition back button to upper left in deckbuilder

### DIFF
--- a/js/react/screens/DeckbuilderScreen.module.css
+++ b/js/react/screens/DeckbuilderScreen.module.css
@@ -30,7 +30,7 @@
 /* ── Tabs ── */
 
 .tabs {
-  display: flex; gap: 0; margin-left: 8px;
+  display: flex; gap: 0;
 }
 
 .tabBtn {

--- a/js/react/screens/DeckbuilderScreen.tsx
+++ b/js/react/screens/DeckbuilderScreen.tsx
@@ -216,17 +216,7 @@ export default function DeckbuilderScreen() {
       <div className={styles.header}>
         <div className={styles.title}>{t('deckbuilder.title')}</div>
         <div className={styles.count}>{t('deckbuilder.cards_count', { current: currentDeck.length, max: MAX_DECK })}</div>
-        <div className={styles.tabs}>
-          <button
-            className={`${styles.tabBtn}${activeTab === 'collection' ? ` ${styles.activeTab}` : ''}`}
-            onClick={() => setActiveTab('collection')}
-          >{t('deckbuilder.tab_collection')}</button>
-          <button
-            className={`${styles.tabBtn}${activeTab === 'deck' ? ` ${styles.activeTab}` : ''}`}
-            onClick={() => setActiveTab('deck')}
-          >{t('deckbuilder.tab_deck')}</button>
-        </div>
-        <div className="ml-auto flex gap-2">
+        <div className="flex gap-2">
           <button
             id="btn-db-save"
             className="btn-primary"
@@ -235,6 +225,16 @@ export default function DeckbuilderScreen() {
             onClick={saveDeck}
           >{t('deckbuilder.save_btn')}</button>
           <button id="btn-db-back" className="btn-secondary" onClick={() => navigateTo('save-point')}>{t('deckbuilder.back')}</button>
+        </div>
+        <div className={`${styles.tabs} ml-auto`}>
+          <button
+            className={`${styles.tabBtn}${activeTab === 'collection' ? ` ${styles.activeTab}` : ''}`}
+            onClick={() => setActiveTab('collection')}
+          >{t('deckbuilder.tab_collection')}</button>
+          <button
+            className={`${styles.tabBtn}${activeTab === 'deck' ? ` ${styles.activeTab}` : ''}`}
+            onClick={() => setActiveTab('deck')}
+          >{t('deckbuilder.tab_deck')}</button>
         </div>
       </div>
 


### PR DESCRIPTION
Swap the tab component and action buttons so the Save Deck and Back
buttons appear on the left side of the header, with the Collection/Deck
tabs pushed to the right via ml-auto. This keeps the Back button
consistently in the upper-left corner, matching the shop screen layout.

https://claude.ai/code/session_01BzSJus2r62aNx6HoeqabwW