### PR TITLE
feat(ui): add options button to save-point screen and volume control tests

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -171,6 +171,29 @@ button { cursor: pointer; border: none; font-family: inherit; transition: none; 
   .btn-options-desktop { display: none; }
   #btn-options { min-width: 44px; padding: 0; font-size: 20px; }
 }
+/* ── Floating options button (reusable across screens) ───── */
+.options-btn-floating {
+  position: fixed;
+  top: 8px; left: 8px;
+  background: #156040;
+  border: 2px solid; border-color: #2a7848 #0e1e14 #0e1e14 #2a7848;
+  border-radius: 0;
+  color: #a8d8b8;
+  font-size: 18px;
+  min-width: 44px; height: 44px;
+  padding: 0 8px;
+  display: flex; align-items: center; justify-content: center;
+  cursor: pointer;
+  transition: none;
+  box-shadow: none;
+  font-family: inherit;
+  z-index: 200;
+  white-space: nowrap;
+}
+.options-btn-floating:hover { background: #1a6848; box-shadow: none; border-color: #288050 #0a2418 #0a2418 #288050; }
+@media (pointer: coarse), (max-width: 900px) {
+  .options-btn-floating { min-width: 44px; padding: 0; font-size: 20px; }
+}
 #field-effect-slot {
   position: absolute;
   top: 50%; left: 50%;

--- a/js/react/screens/SavePointScreen.tsx
+++ b/js/react/screens/SavePointScreen.tsx
@@ -34,6 +34,14 @@ export default function SavePointScreen() {
 
   return (
     <div className={styles.screen}>
+      <button
+        className="options-btn-floating"
+        title={t('title.options')}
+        onClick={() => openModal({ type: 'main-options' })}
+      >
+        <span className="btn-options-mobile">☰</span>
+        <span className="btn-options-desktop">OPTIONS</span>
+      </button>
       <div className="title-bg"></div>
       <div className={styles.content}>
         <div className="title-rune">★</div>

--- a/tests/audio-volume.test.js
+++ b/tests/audio-volume.test.js
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ── Web Audio API mocks ──────────────────────────────────
+
+let gainNodes;
+
+function createMockGainNode() {
+  return {
+    gain: { value: 1, setValueAtTime: vi.fn(), linearRampToValueAtTime: vi.fn() },
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  };
+}
+
+function createMockAudioContext() {
+  return {
+    createGain: vi.fn(() => {
+      const node = createMockGainNode();
+      gainNodes.push(node);
+      return node;
+    }),
+    createBufferSource: vi.fn(() => ({
+      connect: vi.fn(),
+      start: vi.fn(),
+      stop: vi.fn(),
+      buffer: null,
+      loop: false,
+      onended: null,
+    })),
+    decodeAudioData: vi.fn(async () => ({})),
+    destination: {},
+    currentTime: 0,
+    state: 'running',
+    resume: vi.fn(),
+    suspend: vi.fn(),
+  };
+}
+
+// ── Test suite ───────────────────────────────────────────
+
+describe('Audio.setVolumes', () => {
+  let Audio;
+
+  beforeEach(async () => {
+    gainNodes = [];
+    vi.resetModules();
+    localStorage.clear();
+
+    // Provide AudioContext globally before importing the module
+    // Must use function() not arrow — AudioContext is called with `new`
+    globalThis.AudioContext = vi.fn(function () { return createMockAudioContext(); });
+
+    // Mock fetch so _loadBuffer can trigger _ensureContext
+    globalThis.fetch = vi.fn(async function () {
+      return { ok: true, arrayBuffer: async () => new ArrayBuffer(8) };
+    });
+
+    const mod = await import('../js/audio.ts');
+    Audio = mod.Audio;
+  });
+
+  async function initContext() {
+    // playSfx triggers _ensureContext → creates gain nodes
+    await Audio.playSfx('sfx_button');
+  }
+
+  it('updates gain node values correctly', async () => {
+    await initContext();
+    // gainNodes: [0] = master, [1] = music, [2] = sfx
+    Audio.setVolumes(80, 60, 40);
+    expect(gainNodes[0].gain.value).toBeCloseTo(0.8);
+    expect(gainNodes[1].gain.value).toBeCloseTo(0.6);
+    expect(gainNodes[2].gain.value).toBeCloseTo(0.4);
+  });
+
+  it('sets all gains to 0 when volumes are 0 (effective mute)', async () => {
+    await initContext();
+    Audio.setVolumes(0, 0, 0);
+    expect(gainNodes[0].gain.value).toBe(0);
+    expect(gainNodes[1].gain.value).toBe(0);
+    expect(gainNodes[2].gain.value).toBe(0);
+  });
+
+  it('sets all gains to 1 when volumes are 100', async () => {
+    await initContext();
+    Audio.setVolumes(100, 100, 100);
+    expect(gainNodes[0].gain.value).toBe(1);
+    expect(gainNodes[1].gain.value).toBe(1);
+    expect(gainNodes[2].gain.value).toBe(1);
+  });
+
+  it('does not crash when called before context is initialized', () => {
+    // No initContext call — gain nodes are null
+    expect(() => Audio.setVolumes(50, 50, 50)).not.toThrow();
+  });
+
+  it('reads initial volumes from saved Progression settings', async () => {
+    // Save custom settings BEFORE importing (already reset above)
+    localStorage.setItem('tcg_settings', JSON.stringify({
+      lang: 'en', volMaster: 75, volMusic: 25, volSfx: 90, refillHand: true,
+    }));
+
+    // Re-import to pick up the saved settings during _ensureContext
+    vi.resetModules();
+    gainNodes = [];
+    globalThis.AudioContext = vi.fn(function () { return createMockAudioContext(); });
+    globalThis.fetch = vi.fn(async function () {
+      return { ok: true, arrayBuffer: async () => new ArrayBuffer(8) };
+    });
+
+    const mod2 = await import('../js/audio.ts');
+    await mod2.Audio.playSfx('sfx_button');
+
+    // _ensureContext applies saved volumes on first init
+    expect(gainNodes[0].gain.value).toBeCloseTo(0.75);
+    expect(gainNodes[1].gain.value).toBeCloseTo(0.25);
+    expect(gainNodes[2].gain.value).toBeCloseTo(0.9);
+  });
+});

--- a/tests/volume-settings.test.js
+++ b/tests/volume-settings.test.js
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Progression } from '../js/progression.ts';
+
+beforeEach(() => {
+  localStorage.clear();
+  Progression.init();
+});
+
+describe('volume settings – defaults', () => {
+  it('returns default volumes when nothing is saved', () => {
+    const s = Progression.getSettings();
+    expect(s.volMaster).toBe(50);
+    expect(s.volMusic).toBe(50);
+    expect(s.volSfx).toBe(50);
+  });
+
+  it('returns default language and refillHand', () => {
+    const s = Progression.getSettings();
+    expect(s.lang).toBe('en');
+    expect(s.refillHand).toBe(true);
+  });
+});
+
+describe('volume settings – save / load round-trip', () => {
+  it('persists custom volume values', () => {
+    Progression.saveSettings({ lang: 'de', volMaster: 80, volMusic: 60, volSfx: 40, refillHand: false });
+    const s = Progression.getSettings();
+    expect(s.volMaster).toBe(80);
+    expect(s.volMusic).toBe(60);
+    expect(s.volSfx).toBe(40);
+    expect(s.lang).toBe('de');
+    expect(s.refillHand).toBe(false);
+  });
+
+  it('handles volume at minimum (0)', () => {
+    Progression.saveSettings({ lang: 'en', volMaster: 0, volMusic: 0, volSfx: 0, refillHand: true });
+    const s = Progression.getSettings();
+    expect(s.volMaster).toBe(0);
+    expect(s.volMusic).toBe(0);
+    expect(s.volSfx).toBe(0);
+  });
+
+  it('handles volume at maximum (100)', () => {
+    Progression.saveSettings({ lang: 'en', volMaster: 100, volMusic: 100, volSfx: 100, refillHand: true });
+    const s = Progression.getSettings();
+    expect(s.volMaster).toBe(100);
+    expect(s.volMusic).toBe(100);
+    expect(s.volSfx).toBe(100);
+  });
+});
+
+describe('volume settings – edge cases', () => {
+  it('merges partial saved data with defaults', () => {
+    localStorage.setItem('tcg_settings', JSON.stringify({ lang: 'de' }));
+    const s = Progression.getSettings();
+    expect(s.lang).toBe('de');
+    expect(s.volMaster).toBe(50);
+    expect(s.volMusic).toBe(50);
+    expect(s.volSfx).toBe(50);
+    expect(s.refillHand).toBe(true);
+  });
+
+  it('returns defaults when localStorage contains invalid JSON', () => {
+    localStorage.setItem('tcg_settings', '{broken json!!!');
+    const s = Progression.getSettings();
+    expect(s.volMaster).toBe(50);
+    expect(s.volMusic).toBe(50);
+    expect(s.volSfx).toBe(50);
+  });
+
+  it('overwrites previous settings completely', () => {
+    Progression.saveSettings({ lang: 'de', volMaster: 10, volMusic: 20, volSfx: 30, refillHand: false });
+    Progression.saveSettings({ lang: 'en', volMaster: 90, volMusic: 80, volSfx: 70, refillHand: true });
+    const s = Progression.getSettings();
+    expect(s.volMaster).toBe(90);
+    expect(s.volMusic).toBe(80);
+    expect(s.volSfx).toBe(70);
+  });
+});


### PR DESCRIPTION
Add a floating OPTIONS button (top-left) to SavePointScreen matching the
GameScreen pattern. Add unit tests for volume settings persistence
(Progression) and Audio gain node behavior (setVolumes, mute, max, init).

https://claude.ai/code/session_01PjYQ7pXWsgLFGa8NrMozCh