### PR TITLE
fix(build): convert manualChunks from object to function for Vite 8

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -9,10 +9,16 @@ export default defineConfig({
     chunkSizeWarningLimit: 600,
     rollupOptions: {
       output: {
-        manualChunks: {
-          'vendor-react': ['react', 'react-dom'],
-          'vendor-gsap':  ['gsap'],
-          'vendor-jszip': ['jszip'],
+        manualChunks(id) {
+          if (id.includes('node_modules/react-dom') || id.includes('node_modules/react/')) {
+            return 'vendor-react';
+          }
+          if (id.includes('node_modules/gsap')) {
+            return 'vendor-gsap';
+          }
+          if (id.includes('node_modules/jszip')) {
+            return 'vendor-jszip';
+          }
         },
       },
     },


### PR DESCRIPTION
Vite 8 uses Rolldown which requires manualChunks to be a function,
not an object. This fixes the build error:
"Invalid type: Expected Function but received Object"

https://claude.ai/code/session_0135m2EX6gVWX9CmVdG1g9f9