### PR TITLE
feat(cards): add Field Spell card type with continuous buff effects

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -215,14 +215,15 @@ button { cursor: pointer; border: none; font-family: inherit; transition: none; 
   top: 50%; left: 50%;
   transform: translate(-50%, -50%);
   width: 90%; max-width: 200px;
-  aspect-ratio: 1.5 / 1;
   border: 2px solid rgba(40,140,80,0.5);
   border-radius: 0;
   display: flex; flex-direction: column;
   align-items: center; justify-content: center;
+  gap: 2px;
   background: #0e1810;
   cursor: default;
   z-index: 5;
+  padding: 4px;
 }
 .field-effect-label {
   font-size: 11px; color: rgba(100,180,120,0.7);
@@ -230,6 +231,26 @@ button { cursor: pointer; border: none; font-family: inherit; transition: none; 
   text-transform: uppercase; line-height: 1.4;
   font-weight: bold;
 }
+.field-spell-empty {
+  width: 100%; text-align: center; padding: 4px 0;
+}
+.field-spell-active {
+  width: 100%; padding: 4px 6px;
+  border: 1px solid rgba(29,192,160,0.6);
+  background: rgba(29,192,160,0.1);
+  cursor: pointer; text-align: center;
+  display: flex; flex-direction: column; align-items: center; gap: 2px;
+}
+.field-spell-active:hover { background: rgba(29,192,160,0.25); }
+.field-spell-icon { font-size: 14px; color: #1dc0a0; }
+.field-spell-name {
+  font-size: 9px; color: #b0e8d0; letter-spacing: 0.5px;
+  text-transform: uppercase; line-height: 1.2; word-break: break-word;
+}
+.field-spell-opp { border-color: rgba(188,32,96,0.5); background: rgba(188,32,96,0.1); }
+.field-spell-opp:hover { background: rgba(188,32,96,0.25); }
+.field-spell-opp .field-spell-icon { color: #bc2060; }
+.field-spell-opp .field-spell-name { color: #e8b0c0; }
 
 /* ── Center: Zone Rows ───────────────────────────────────── */
 #field-center {

--- a/js/ai-orchestrator.ts
+++ b/js/ai-orchestrator.ts
@@ -169,6 +169,11 @@ async function aiMainPhase(engine: GameEngine): Promise<void> {
             await _delay(300); await engine.activateSpell('opponent', i, t); activated = true;
           }
         }
+      } else if(card.spellType === 'field'){
+        if(!ai.field.fieldSpell){
+          EchoesOfSanguo.log('SPELL', `Activating ${card.name} (field spell)`);
+          await _delay(300); await engine.activateFieldSpell('opponent', i); activated = true;
+        }
       } else if(card.spellType === 'fromGrave'){
         const gm = ai.graveyard.find(c => isMonsterType(c.type));
         if(gm && ai.field.monsters.some(z=>z===null)){

--- a/js/engine.ts
+++ b/js/engine.ts
@@ -3,7 +3,7 @@
 // ============================================================
 
 import { CARD_DB, OPPONENT_DECK_IDS, PLAYER_DECK_IDS, makeDeck, checkFusion, resolveFusionChain } from './cards.js';
-import { executeEffectBlock } from './effect-registry.js';
+import { executeEffectBlock, matchesFilter } from './effect-registry.js';
 import { CardType } from './types.js';
 import type { Owner, Phase, Position, CardData, EffectContext, EffectSignal, GameState, UICallbacks, OpponentConfig, AIBehavior } from './types.js';
 
@@ -19,6 +19,8 @@ export interface SerializedFieldCardData {
   tempDEFBonus: number;
   permATKBonus: number;
   permDEFBonus: number;
+  fieldSpellATKBonus: number;
+  fieldSpellDEFBonus: number;
   phoenixRevivalUsed: boolean;
 }
 
@@ -38,6 +40,7 @@ export interface SerializedPlayerState {
   normalSummonUsed: boolean;
   monsters: Array<SerializedFieldCardData | null>;
   spellTraps: Array<SerializedFieldSpellTrapData | null>;
+  fieldSpell?: SerializedFieldSpellTrapData | null;
 }
 
 export interface SerializedCheckpoint {
@@ -97,7 +100,7 @@ export class GameEngine {
         lp: GAME_RULES.startingLP,
         deck: this._shuffle(makeDeck(playerDeckIds || PLAYER_DECK_IDS)),
         hand: [],
-        field: { monsters: Array(GAME_RULES.fieldZones).fill(null), spellTraps: Array(GAME_RULES.fieldZones).fill(null) },
+        field: { monsters: Array(GAME_RULES.fieldZones).fill(null), spellTraps: Array(GAME_RULES.fieldZones).fill(null), fieldSpell: null },
         graveyard: [],
         normalSummonUsed: false
       },
@@ -105,7 +108,7 @@ export class GameEngine {
         lp: GAME_RULES.startingLP,
         deck: this._shuffle(makeDeck(oppDeckIds)),
         hand: [],
-        field: { monsters: Array(GAME_RULES.fieldZones).fill(null), spellTraps: Array(GAME_RULES.fieldZones).fill(null) },
+        field: { monsters: Array(GAME_RULES.fieldZones).fill(null), spellTraps: Array(GAME_RULES.fieldZones).fill(null), fieldSpell: null },
         graveyard: [],
         normalSummonUsed: false
       },
@@ -168,6 +171,8 @@ export class GameEngine {
           fc.tempDEFBonus      = m.tempDEFBonus;
           fc.permATKBonus      = m.permATKBonus;
           fc.permDEFBonus      = m.permDEFBonus;
+          fc.fieldSpellATKBonus = m.fieldSpellATKBonus ?? 0;
+          fc.fieldSpellDEFBonus = m.fieldSpellDEFBonus ?? 0;
           fc.phoenixRevivalUsed = m.phoenixRevivalUsed;
           return fc;
         }),
@@ -179,6 +184,7 @@ export class GameEngine {
           if (st.equippedOwner !== undefined) fst.equippedOwner = st.equippedOwner;
           return fst;
         }),
+        fieldSpell: s.fieldSpell ? new FieldSpellTrap(CARD_DB[s.fieldSpell.cardId], s.fieldSpell.faceDown) : null,
       },
     });
 
@@ -335,6 +341,7 @@ export class GameEngine {
     const posStr = faceDown ? 'face-down DEF' : position.toUpperCase();
     this.addLog(`${ownerLabel(owner)}: ${card.name} (${posStr}).`);
     this.ui.playSfx?.('sfx_card_play');
+    this._applyFieldSpellToMonster(owner, fc);
     // trigger onSummon effect for every summon method
     await this._triggerEffect(fc, owner, 'onSummon', zone);
     this.ui.render(this.state);
@@ -368,6 +375,7 @@ export class GameEngine {
     st.field.monsters[zone] = fc;
     this.addLog(`${ownerLabel(owner)}: ${card.name} Special Summon!`);
     this.ui.playSfx?.('sfx_card_play');
+    this._applyFieldSpellToMonster(owner, fc);
     await this._triggerEffect(fc, owner, 'onSummon', zone);
     this.ui.render(this.state);
     return true;
@@ -385,6 +393,7 @@ export class GameEngine {
     st.field.monsters[zone] = fc;
     this.addLog(`${ownerLabel(owner)}: ${c.name} summoned from graveyard!`);
     this.ui.playSfx?.('sfx_card_play');
+    this._applyFieldSpellToMonster(owner, fc);
     await this._triggerEffect(fc, owner, 'onSummon', zone);
     this.ui.render(this.state);
     return true;
@@ -529,6 +538,79 @@ export class GameEngine {
     }
   }
 
+  // ───────── Field Spell ──────────────────────────────────
+
+  async activateFieldSpell(owner: Owner, handIndex: number): Promise<boolean> {
+    const st = this.state[owner];
+    const card = st.hand[handIndex];
+    if (!card || card.type !== CardType.Spell || card.spellType !== 'field') {
+      this.addLog('Not a field spell card!'); return false;
+    }
+    st.hand.splice(handIndex, 1);
+
+    // Destroy existing field spell if any
+    if (st.field.fieldSpell) {
+      this._removeFieldSpell(owner);
+    }
+
+    st.field.fieldSpell = new FieldSpellTrap(card, false);
+    this.addLog(`${ownerLabel(owner)}: Field Spell ${card.name} activated!`);
+    this.ui.playSfx?.('sfx_spell');
+    if (this.ui.showActivation) await this.ui.showActivation(card, card.description);
+
+    // Apply continuous buffs to all matching monsters
+    this._applyFieldSpellBuffs(owner);
+    this.ui.render(this.state);
+    return true;
+  }
+
+  _removeFieldSpell(owner: Owner): void {
+    const st = this.state[owner];
+    const fs = st.field.fieldSpell;
+    if (!fs) return;
+
+    // Remove field spell bonuses from all monsters
+    for (const fc of st.field.monsters) {
+      if (!fc) continue;
+      fc.fieldSpellATKBonus = 0;
+      fc.fieldSpellDEFBonus = 0;
+    }
+
+    st.graveyard.push(fs.card);
+    st.field.fieldSpell = null;
+    this.addLog(`${fs.card.name} was destroyed.`);
+  }
+
+  _applyFieldSpellBuffs(owner: Owner): void {
+    const st = this.state[owner];
+    const fs = st.field.fieldSpell;
+    if (!fs || !fs.card.effect) return;
+
+    for (const fc of st.field.monsters) {
+      if (!fc) continue;
+      this._applyFieldSpellToMonster(owner, fc);
+    }
+  }
+
+  _applyFieldSpellToMonster(owner: Owner, fc: FieldCard): void {
+    const fs = this.state[owner].field.fieldSpell;
+    if (!fs || !fs.card.effect) return;
+
+    let atkBuff = 0;
+    let defBuff = 0;
+    for (const action of fs.card.effect.actions) {
+      if (action.type === 'buffField') {
+        const filter = (action as any).filter;
+        if (!filter || matchesFilter(fc.card, filter)) {
+          atkBuff += (action as any).value ?? 0;
+          defBuff += (action as any).value ?? 0;
+        }
+      }
+    }
+    fc.fieldSpellATKBonus = atkBuff;
+    fc.fieldSpellDEFBonus = defBuff;
+  }
+
   // ───────── Fusion ────────────────────────────────────────
   canFuse(owner: Owner){
     const hand = this.state[owner].hand;
@@ -665,6 +747,7 @@ export class GameEngine {
     fc.summonedThisTurn = false; // fusion result can attack immediately
     st.field.monsters[zone] = fc;
     st.normalSummonUsed = true;
+    this._applyFieldSpellToMonster(owner, fc);
 
     this.ui.render(this.state);
     await this._triggerEffect(fc, owner, 'onSummon', zone);

--- a/js/field.ts
+++ b/js/field.ts
@@ -17,6 +17,8 @@ export class FieldCard {
   tempDEFBonus: number;
   permATKBonus: number;
   permDEFBonus: number;
+  fieldSpellATKBonus: number;
+  fieldSpellDEFBonus: number;
   phoenixRevivalUsed: boolean;
   piercing: boolean;
   cannotBeTargeted: boolean;
@@ -42,6 +44,8 @@ export class FieldCard {
     this.tempDEFBonus = 0;
     this.permATKBonus = 0;
     this.permDEFBonus = 0;
+    this.fieldSpellATKBonus = 0;
+    this.fieldSpellDEFBonus = 0;
     this.phoenixRevivalUsed = false;
     this.equippedCards = [];
     // passive flags from effect
@@ -67,10 +71,10 @@ export class FieldCard {
     }
   }
   effectiveATK(): number {
-    return Math.max(0, (this.card.atk ?? 0) + this.tempATKBonus + this.permATKBonus);
+    return Math.max(0, (this.card.atk ?? 0) + this.tempATKBonus + this.permATKBonus + this.fieldSpellATKBonus);
   }
   effectiveDEF(): number {
-    return Math.max(0, (this.card.def ?? 0) + this.tempDEFBonus + this.permDEFBonus);
+    return Math.max(0, (this.card.def ?? 0) + this.tempDEFBonus + this.permDEFBonus + this.fieldSpellDEFBonus);
   }
 }
 

--- a/js/react/contexts/GameContext.tsx
+++ b/js/react/contexts/GameContext.tsx
@@ -48,6 +48,8 @@ function serializePlayerState(ps: PlayerState): SerializedPlayerState {
         tempDEFBonus: fc.tempDEFBonus,
         permATKBonus: fc.permATKBonus,
         permDEFBonus: fc.permDEFBonus,
+        fieldSpellATKBonus: fc.fieldSpellATKBonus,
+        fieldSpellDEFBonus: fc.fieldSpellDEFBonus,
         phoenixRevivalUsed: fc.phoenixRevivalUsed,
       } as SerializedFieldCardData;
     }),
@@ -61,6 +63,11 @@ function serializePlayerState(ps: PlayerState): SerializedPlayerState {
         equippedOwner: st.equippedOwner,
       } as SerializedFieldSpellTrapData;
     }),
+    fieldSpell: ps.field.fieldSpell ? {
+      cardId: ps.field.fieldSpell.card.id,
+      faceDown: ps.field.fieldSpell.faceDown,
+      used: ps.field.fieldSpell.used,
+    } as SerializedFieldSpellTrapData : null,
   };
 }
 

--- a/js/react/modals/CardDetailModal.tsx
+++ b/js/react/modals/CardDetailModal.tsx
@@ -84,6 +84,11 @@ export function CardDetailModal({ modal }: Props) {
           closeModal();
         }));
       }
+    } else if (isSp && card.spellType === 'field' && phase === 'main') {
+      actions.push(actionBtn(t('card_action.activate_field_spell', 'Activate Field Spell'), () => {
+        game.activateFieldSpell('player', index);
+        closeModal();
+      }));
     } else if (isSp && phase === 'main') {
       actions.push(actionBtn(t('card_action.activate'), () => {
         if (card.spellType === 'targeted' || card.spellType === 'fromGrave') {

--- a/js/react/screens/GameScreen.tsx
+++ b/js/react/screens/GameScreen.tsx
@@ -125,7 +125,24 @@ export default function GameScreen() {
             <span className="btn-options-desktop">OPTIONS</span>
           </button>
           <div id="field-effect-slot">
-            <span className="field-effect-label">CURRENT<br />FIELD</span>
+            {gameState?.opponent.field.fieldSpell ? (
+              <div className="field-spell-active field-spell-opp" title={gameState.opponent.field.fieldSpell.card.name}
+                onClick={() => openModal({ type: 'card-detail', card: gameState.opponent.field.fieldSpell!.card })}>
+                <span className="field-spell-icon">&#x2726;</span>
+                <span className="field-spell-name">{gameState.opponent.field.fieldSpell.card.name}</span>
+              </div>
+            ) : (
+              <div className="field-spell-empty"><span className="field-effect-label">{t('game.opp_field', 'OPP')}</span></div>
+            )}
+            {gameState?.player.field.fieldSpell ? (
+              <div className="field-spell-active field-spell-own" title={gameState.player.field.fieldSpell.card.name}
+                onClick={() => openModal({ type: 'card-detail', card: gameState.player.field.fieldSpell!.card })}>
+                <span className="field-spell-icon">&#x2726;</span>
+                <span className="field-spell-name">{gameState.player.field.fieldSpell.card.name}</span>
+              </div>
+            ) : (
+              <div className="field-spell-empty"><span className="field-effect-label">{t('game.your_field', 'FIELD')}</span></div>
+            )}
           </div>
         </div>
 

--- a/js/tcg-format/enums.ts
+++ b/js/tcg-format/enums.ts
@@ -168,14 +168,14 @@ export function isValidTrigger(s: string): s is (EffectTrigger | TrapTrigger) {
 
 // ── SpellType ────────────────────────────────────────────────
 
-const SPELL_TYPE_STRINGS: ReadonlySet<string> = new Set(['normal', 'targeted', 'fromGrave']);
+const SPELL_TYPE_STRINGS: ReadonlySet<string> = new Set(['normal', 'targeted', 'fromGrave', 'field']);
 
 export function isValidSpellType(s: string): s is SpellType {
   return SPELL_TYPE_STRINGS.has(s);
 }
 
-const SPELL_TYPE_TO_INT: Record<string, number> = { normal: 1, targeted: 2, fromGrave: 3 };
-const INT_TO_SPELL_TYPE: Record<number, SpellType> = { 1: 'normal', 2: 'targeted', 3: 'fromGrave' };
+const SPELL_TYPE_TO_INT: Record<string, number> = { normal: 1, targeted: 2, fromGrave: 3, field: 4 };
+const INT_TO_SPELL_TYPE: Record<number, SpellType> = { 1: 'normal', 2: 'targeted', 3: 'fromGrave', 4: 'field' };
 
 export function spellTypeToInt(s: SpellType): number {
   const n = SPELL_TYPE_TO_INT[s];

--- a/js/types.ts
+++ b/js/types.ts
@@ -9,7 +9,7 @@ export type Phase        = 'draw' | 'main' | 'battle' | 'end';
 export type Position     = 'atk' | 'def';
 export type TrapTrigger  = 'onAttack' | 'onOwnMonsterAttacked' | 'onOpponentSummon' | 'manual';
 export type EffectTrigger= 'onSummon' | 'onDestroyByBattle' | 'onDestroyByOpponent' | 'passive' | 'onFlip';
-export type SpellType    = 'normal' | 'targeted' | 'fromGrave';
+export type SpellType    = 'normal' | 'targeted' | 'fromGrave' | 'field';
 
 // ── Int-based Enums (card data — stored in .tcg format) ────
 // Monster covers both normal and effect cards; distinction via effect field.
@@ -277,6 +277,7 @@ export interface PlayerState {
   field: {
     monsters:   Array<FieldCard | null>;
     spellTraps: Array<FieldSpellTrap | null>;
+    fieldSpell: FieldSpellTrap | null;
   };
   graveyard:        CardData[];
   normalSummonUsed: boolean;
@@ -359,6 +360,8 @@ export declare class FieldCard {
   tempDEFBonus:     number;
   permATKBonus:     number;
   permDEFBonus:     number;
+  fieldSpellATKBonus: number;
+  fieldSpellDEFBonus: number;
   phoenixRevivalUsed: boolean;
   piercing:         boolean;
   cannotBeTargeted: boolean;
@@ -400,6 +403,7 @@ export declare class GameEngine {
   specialSummonFromGrave(owner: Owner, card: CardData): Promise<boolean>;
   performFusionChain(owner: Owner, handIndices: number[]): Promise<boolean>;
   equipCard(owner: Owner, handIndex: number, targetOwner: Owner, targetMonsterZone: number): Promise<boolean>;
+  activateFieldSpell(owner: Owner, handIndex: number): Promise<boolean>;
   _removeEquipmentForMonster(monsterOwner: Owner, monsterZone: number): void;
   endTurn(): void;
   advancePhase(): void;

--- a/locales/de.json
+++ b/locales/de.json
@@ -185,7 +185,9 @@
     "surrender_cancel": "← Zurück",
     "trap_ctx_attacks_monster": "{{attacker}} (ATK {{atk}}) greift dein {{defender}} ({{stat}} {{val}}) an!",
     "trap_ctx_attacks": "{{attacker}} (ATK {{atk}}) greift an!",
-    "trap_ctx_summon": "Gegner beschwört {{name}} (ATK {{atk}})"
+    "trap_ctx_summon": "Gegner beschwört {{name}} (ATK {{atk}})",
+    "opp_field": "GEG",
+    "your_field": "FELD"
   },
   "card_action": {
     "already_played": "⛔ Monster bereits gespielt",
@@ -210,7 +212,8 @@
     "hint_play_chain": "Wähle Karten zum Kombinieren, dann bestätigen. Letzte Karte antippen zum Rückgängig machen.",
     "equip": "⚔ Ausrüsten",
     "set_equipment": "🔽 Verdeckt setzen",
-    "hint_equip": "Wähle ein Monster zum Ausrüsten."
+    "hint_equip": "Wähle ein Monster zum Ausrüsten.",
+    "activate_field_spell": "🌍 Feldzauber aktivieren"
   },
   "fusion_chain": {
     "confirm": "✨ Fusionieren & Spielen",

--- a/locales/en.json
+++ b/locales/en.json
@@ -185,7 +185,9 @@
     "surrender_cancel": "← Back",
     "trap_ctx_attacks_monster": "{{attacker}} (ATK {{atk}}) attacks your {{defender}} ({{stat}} {{val}})",
     "trap_ctx_attacks": "{{attacker}} (ATK {{atk}}) is attacking!",
-    "trap_ctx_summon": "Opponent summoned {{name}} (ATK {{atk}})"
+    "trap_ctx_summon": "Opponent summoned {{name}} (ATK {{atk}})",
+    "opp_field": "OPP",
+    "your_field": "FIELD"
   },
   "card_action": {
     "already_played": "⛔ Monster already played",
@@ -210,7 +212,8 @@
     "hint_play_chain": "Select cards to combine, then confirm. Tap last card to undo.",
     "equip": "⚔ Equip",
     "set_equipment": "🔽 Set",
-    "hint_equip": "Select a monster to equip."
+    "hint_equip": "Select a monster to equip.",
+    "activate_field_spell": "🌍 Activate Field Spell"
   },
   "fusion_chain": {
     "confirm": "✨ Fuse & Play",

--- a/public/base.tcg-src/cards.json
+++ b/public/base.tcg-src/cards.json
@@ -1,1 +1,3108 @@
-[{"id":1,"level":1,"rarity":1,"type":1,"atk":350,"def":200,"attribute":2,"race":1},{"id":2,"level":2,"rarity":1,"type":1,"atk":650,"def":500,"attribute":2,"race":1},{"id":3,"level":2,"rarity":1,"type":1,"atk":700,"def":450,"attribute":3,"race":1},{"id":4,"level":3,"rarity":1,"type":1,"atk":1000,"def":750,"attribute":2,"race":1},{"id":5,"level":3,"rarity":1,"type":1,"atk":950,"def":800,"attribute":2,"race":1},{"id":6,"level":3,"rarity":1,"type":1,"atk":1050,"def":700,"attribute":3,"race":1},{"id":7,"level":4,"rarity":1,"type":1,"atk":1250,"def":1000,"attribute":2,"race":1},{"id":8,"level":4,"rarity":1,"type":1,"atk":1300,"def":950,"attribute":2,"race":1},{"id":9,"level":4,"rarity":1,"type":1,"atk":1150,"def":1050,"attribute":3,"race":1},{"id":10,"level":4,"rarity":2,"type":1,"atk":1400,"def":1100,"attribute":2,"race":1},{"id":11,"level":5,"rarity":2,"type":1,"atk":1600,"def":1250,"attribute":2,"race":1},{"id":12,"level":5,"rarity":2,"type":1,"atk":1550,"def":1300,"attribute":3,"race":1},{"id":13,"level":5,"rarity":2,"type":1,"atk":1700,"def":1150,"attribute":2,"race":1},{"id":14,"level":5,"rarity":4,"type":1,"atk":1650,"def":1250,"attribute":2,"race":1,"effect":"onSummon:dealDamage(opponent,300)"},{"id":15,"level":6,"rarity":4,"type":1,"atk":1900,"def":1500,"attribute":2,"race":1,"effect":"onSummon:buffField(200,{r=1})"},{"id":16,"level":6,"rarity":4,"type":1,"atk":1850,"def":1550,"attribute":3,"race":1,"effect":"onSummon:dealDamage(opponent,400)"},{"id":17,"level":6,"rarity":4,"type":1,"atk":2000,"def":1450,"attribute":2,"race":1,"effect":"onDestroyByBattle:draw(self,1)"},{"id":18,"level":6,"rarity":4,"type":1,"atk":1950,"def":1600,"attribute":3,"race":1,"effect":"onSummon:buffField(300,{r=1})"},{"id":19,"level":7,"rarity":4,"type":1,"atk":2200,"def":1750,"attribute":2,"race":1,"effect":"onSummon:dealDamage(opponent,500)"},{"id":20,"level":7,"rarity":4,"type":1,"atk":2150,"def":1800,"attribute":2,"race":1,"effect":"passive:passive_piercing()"},{"id":21,"level":7,"rarity":6,"type":1,"atk":2350,"def":1900,"attribute":2,"race":1,"effect":"onSummon:buffField(400,{r=1})"},{"id":22,"level":8,"rarity":6,"type":1,"atk":2500,"def":2050,"attribute":3,"race":1,"effect":"onSummon:dealDamage(opponent,600)"},{"id":23,"level":8,"rarity":6,"type":1,"atk":2550,"def":2100,"attribute":2,"race":1,"effect":"passive:passive_piercing()"},{"id":24,"level":9,"rarity":8,"type":1,"atk":2750,"def":2300,"attribute":2,"race":1,"effect":"onSummon:dealDamage(opponent,800)"},{"id":25,"level":9,"rarity":8,"type":1,"atk":3000,"def":2500,"attribute":2,"race":1,"effect":"onSummon:buffField(500,{r=1})"},{"id":26,"level":1,"rarity":1,"type":1,"atk":300,"def":300,"attribute":5,"race":3},{"id":27,"level":2,"rarity":1,"type":1,"atk":600,"def":550,"attribute":5,"race":3},{"id":28,"level":2,"rarity":1,"type":1,"atk":550,"def":600,"attribute":1,"race":3},{"id":29,"level":3,"rarity":1,"type":1,"atk":900,"def":850,"attribute":5,"race":3},{"id":30,"level":3,"rarity":1,"type":1,"atk":950,"def":800,"attribute":5,"race":3},{"id":31,"level":3,"rarity":1,"type":1,"atk":850,"def":900,"attribute":5,"race":3},{"id":32,"level":3,"rarity":1,"type":1,"atk":1000,"def":750,"attribute":1,"race":3},{"id":33,"level":4,"rarity":1,"type":1,"atk":1200,"def":1100,"attribute":5,"race":3},{"id":34,"level":4,"rarity":1,"type":1,"atk":1250,"def":1050,"attribute":5,"race":3},{"id":35,"level":4,"rarity":2,"type":1,"atk":1300,"def":1150,"attribute":1,"race":3},{"id":36,"level":4,"rarity":2,"type":1,"atk":1350,"def":1100,"attribute":5,"race":3},{"id":37,"level":5,"rarity":2,"type":1,"atk":1500,"def":1350,"attribute":5,"race":3},{"id":38,"level":5,"rarity":2,"type":1,"atk":1550,"def":1300,"attribute":1,"race":3},{"id":39,"level":5,"rarity":4,"type":1,"atk":1600,"def":1400,"attribute":5,"race":3,"effect":"onSummon:tempAtkBonus(ownMonster,400)"},{"id":40,"level":5,"rarity":4,"type":1,"atk":1650,"def":1350,"attribute":5,"race":3,"effect":"onSummon:permAtkBonus(ownMonster,200)"},{"id":41,"level":6,"rarity":4,"type":1,"atk":1850,"def":1600,"attribute":5,"race":3,"effect":"onSummon:buffField(200,{r=3})"},{"id":42,"level":6,"rarity":4,"type":1,"atk":1900,"def":1550,"attribute":1,"race":3,"effect":"onSummon:tempAtkBonus(ownMonster,500)"},{"id":43,"level":6,"rarity":4,"type":1,"atk":1800,"def":1650,"attribute":5,"race":3,"effect":"onDestroyByBattle:draw(self,1)"},{"id":44,"level":6,"rarity":4,"type":1,"atk":1950,"def":1500,"attribute":5,"race":3,"effect":"onSummon:permAtkBonus(ownMonster,300)"},{"id":45,"level":7,"rarity":4,"type":1,"atk":2100,"def":1850,"attribute":1,"race":3,"effect":"onSummon:buffField(300,{r=3})"},{"id":46,"level":7,"rarity":4,"type":1,"atk":2200,"def":1800,"attribute":5,"race":3,"effect":"onSummon:tempAtkBonus(ownMonster,600)"},{"id":47,"level":7,"rarity":6,"type":1,"atk":2300,"def":2000,"attribute":5,"race":3,"effect":"onSummon:permAtkBonus(ownMonster,400)"},{"id":48,"level":7,"rarity":6,"type":1,"atk":2350,"def":1950,"attribute":5,"race":3,"effect":"onSummon:buffField(400,{r=3})"},{"id":49,"level":8,"rarity":6,"type":1,"atk":2500,"def":2200,"attribute":1,"race":3,"effect":"passive:passive_untargetable()"},{"id":50,"level":8,"rarity":8,"type":1,"atk":2650,"def":2300,"attribute":5,"race":3,"effect":"onSummon:permAtkBonus(ownMonster,500)"},{"id":51,"level":9,"rarity":8,"type":1,"atk":2800,"def":2500,"attribute":5,"race":3,"effect":"onSummon:buffField(500,{r=3})"},{"id":52,"level":9,"rarity":8,"type":1,"atk":3200,"def":2800,"attribute":1,"race":3,"effect":"passive:passive_piercing()"},{"id":53,"level":8,"rarity":4,"type":1,"atk":2450,"def":2100,"attribute":5,"race":3,"effect":"onSummon:tempAtkBonus(ownMonster,700)"},{"id":54,"level":1,"rarity":1,"type":1,"atk":250,"def":300,"attribute":1,"race":2},{"id":55,"level":2,"rarity":1,"type":1,"atk":500,"def":550,"attribute":1,"race":2},{"id":56,"level":2,"rarity":1,"type":1,"atk":550,"def":500,"attribute":2,"race":2},{"id":57,"level":3,"rarity":1,"type":1,"atk":800,"def":850,"attribute":1,"race":2},{"id":58,"level":3,"rarity":1,"type":1,"atk":850,"def":800,"attribute":1,"race":2},{"id":59,"level":3,"rarity":1,"type":1,"atk":750,"def":900,"attribute":2,"race":2},{"id":60,"level":4,"rarity":1,"type":1,"atk":1100,"def":1050,"attribute":1,"race":2},{"id":61,"level":4,"rarity":1,"type":1,"atk":1050,"def":1100,"attribute":1,"race":2},{"id":62,"level":4,"rarity":2,"type":1,"atk":1150,"def":1100,"attribute":2,"race":2},{"id":63,"level":5,"rarity":2,"type":1,"atk":1350,"def":1300,"attribute":1,"race":2},{"id":64,"level":5,"rarity":2,"type":1,"atk":1400,"def":1250,"attribute":1,"race":2},{"id":65,"level":5,"rarity":2,"type":1,"atk":1300,"def":1350,"attribute":2,"race":2},{"id":66,"level":5,"rarity":4,"type":1,"atk":1450,"def":1300,"attribute":1,"race":2,"effect":"onSummon:searchDeckToHand(1)"},{"id":67,"level":6,"rarity":4,"type":1,"atk":1650,"def":1500,"attribute":1,"race":2,"effect":"onSummon:debuffField(200,200)"},{"id":68,"level":6,"rarity":4,"type":1,"atk":1700,"def":1450,"attribute":2,"race":2,"effect":"onDestroyByBattle:draw(self,2)"},{"id":69,"level":6,"rarity":4,"type":1,"atk":1600,"def":1550,"attribute":1,"race":2,"effect":"onSummon:gainLP(self,500)"},{"id":70,"level":6,"rarity":4,"type":1,"atk":1750,"def":1400,"attribute":1,"race":2,"effect":"onSummon:searchDeckToHand(2)"},{"id":71,"level":7,"rarity":4,"type":1,"atk":1900,"def":1700,"attribute":2,"race":2,"effect":"onSummon:debuffField(300,300)"},{"id":72,"level":7,"rarity":4,"type":1,"atk":1950,"def":1650,"attribute":1,"race":2,"effect":"onSummon:bounceStrongestOpp()"},{"id":73,"level":7,"rarity":6,"type":1,"atk":2100,"def":1850,"attribute":1,"race":2,"effect":"onSummon:debuffField(400,300)"},{"id":74,"level":8,"rarity":6,"type":1,"atk":2300,"def":2050,"attribute":2,"race":2,"effect":"onSummon:searchDeckToHand(1)"},{"id":75,"level":8,"rarity":6,"type":1,"atk":2250,"def":2100,"attribute":1,"race":2,"effect":"onSummon:bounceStrongestOpp()"},{"id":76,"level":8,"rarity":8,"type":1,"atk":2450,"def":2200,"attribute":1,"race":2,"effect":"onSummon:debuffField(500,400)"},{"id":77,"level":9,"rarity":8,"type":1,"atk":2700,"def":2400,"attribute":1,"race":2,"effect":"passive:passive_untargetable()"},{"id":78,"level":9,"rarity":8,"type":1,"atk":2600,"def":2350,"attribute":2,"race":2,"effect":"onSummon:bounceStrongestOpp()"},{"id":79,"level":1,"rarity":1,"type":1,"atk":400,"def":200,"attribute":3,"race":4},{"id":80,"level":2,"rarity":1,"type":1,"atk":700,"def":400,"attribute":3,"race":4},{"id":81,"level":3,"rarity":1,"type":1,"atk":1050,"def":650,"attribute":5,"race":4},{"id":82,"level":3,"rarity":1,"type":1,"atk":1100,"def":600,"attribute":3,"race":4},{"id":83,"level":3,"rarity":1,"type":1,"atk":1000,"def":700,"attribute":3,"race":4},{"id":84,"level":4,"rarity":1,"type":1,"atk":1350,"def":850,"attribute":3,"race":4},{"id":85,"level":4,"rarity":2,"type":1,"atk":1400,"def":900,"attribute":5,"race":4},{"id":86,"level":4,"rarity":2,"type":1,"atk":1450,"def":850,"attribute":3,"race":4},{"id":87,"level":5,"rarity":2,"type":1,"atk":1650,"def":1050,"attribute":3,"race":4},{"id":88,"level":5,"rarity":4,"type":1,"atk":1700,"def":1100,"attribute":3,"race":4,"effect":"onSummon:dealDamage(opponent,300)"},{"id":89,"level":5,"rarity":4,"type":1,"atk":1750,"def":1050,"attribute":5,"race":4,"effect":"passive:passive_piercing()"},{"id":90,"level":6,"rarity":4,"type":1,"atk":1950,"def":1200,"attribute":3,"race":4,"effect":"onSummon:dealDamage(opponent,400)"},{"id":91,"level":6,"rarity":4,"type":1,"atk":2000,"def":1250,"attribute":3,"race":4,"effect":"passive:passive_piercing()"},{"id":92,"level":6,"rarity":4,"type":1,"atk":1900,"def":1300,"attribute":5,"race":4,"effect":"onDestroyByBattle:gainLP(self,500)"},{"id":93,"level":7,"rarity":4,"type":1,"atk":2200,"def":1450,"attribute":3,"race":4,"effect":"onSummon:dealDamage(opponent,500)"},{"id":94,"level":7,"rarity":6,"type":1,"atk":2350,"def":1550,"attribute":3,"race":4,"effect":"passive:passive_piercing()"},{"id":95,"level":7,"rarity":6,"type":1,"atk":2400,"def":1500,"attribute":5,"race":4,"effect":"onSummon:dealDamage(opponent,600)"},{"id":96,"level":8,"rarity":8,"type":1,"atk":2600,"def":1800,"attribute":3,"race":4,"effect":"passive:passive_phoenixRevival()"},{"id":97,"level":8,"rarity":8,"type":1,"atk":2900,"def":2200,"attribute":3,"race":4,"effect":"passive:passive_piercing()"},{"id":98,"level":7,"rarity":4,"type":1,"atk":2150,"def":1500,"attribute":3,"race":4,"effect":"passive:passive_directAttack()"},{"id":99,"level":1,"rarity":1,"type":1,"atk":350,"def":500,"attribute":5,"race":5},{"id":100,"level":2,"rarity":1,"type":1,"atk":550,"def":700,"attribute":5,"race":5},{"id":101,"level":3,"rarity":1,"type":1,"atk":800,"def":950,"attribute":6,"race":5},{"id":102,"level":3,"rarity":1,"type":1,"atk":900,"def":1000,"attribute":5,"race":5},{"id":103,"level":3,"rarity":1,"type":1,"atk":850,"def":1050,"attribute":5,"race":5},{"id":104,"level":4,"rarity":1,"type":1,"atk":1100,"def":1200,"attribute":5,"race":5},{"id":105,"level":4,"rarity":1,"type":1,"atk":1050,"def":1300,"attribute":6,"race":5},{"id":106,"level":4,"rarity":2,"type":1,"atk":1150,"def":1350,"attribute":5,"race":5},{"id":107,"level":4,"rarity":2,"type":1,"atk":1200,"def":1250,"attribute":5,"race":5},{"id":108,"level":5,"rarity":2,"type":1,"atk":1400,"def":1500,"attribute":6,"race":5},{"id":109,"level":5,"rarity":4,"type":1,"atk":1500,"def":1600,"attribute":5,"race":5,"effect":"onDestroyByBattle:gainLP(self,500)"},{"id":110,"level":5,"rarity":4,"type":1,"atk":1450,"def":1650,"attribute":5,"race":5,"effect":"onSummon:gainLP(self,400)"},{"id":111,"level":6,"rarity":4,"type":1,"atk":1700,"def":1850,"attribute":6,"race":5,"effect":"onDestroyByBattle:draw(self,1)"},{"id":112,"level":6,"rarity":4,"type":1,"atk":1750,"def":1900,"attribute":5,"race":5,"effect":"onSummon:tempDefBonus(ownMonster,300)"},{"id":113,"level":7,"rarity":4,"type":1,"atk":1900,"def":2100,"attribute":5,"race":5,"effect":"onDestroyByBattle:gainLP(self,800)"},{"id":114,"level":7,"rarity":6,"type":1,"atk":2100,"def":2350,"attribute":5,"race":5,"effect":"onSummon:gainLP(self,800)"},{"id":115,"level":8,"rarity":6,"type":1,"atk":2250,"def":2500,"attribute":6,"race":5,"effect":"onSummon:buffField(300,{r=5})"},{"id":116,"level":8,"rarity":8,"type":1,"atk":2400,"def":2600,"attribute":5,"race":5,"effect":"onDestroyByBattle:gainLP(self,1200)"},{"id":117,"level":1,"rarity":1,"type":1,"atk":250,"def":550,"attribute":5,"race":6},{"id":118,"level":2,"rarity":1,"type":1,"atk":450,"def":750,"attribute":5,"race":6},{"id":119,"level":3,"rarity":1,"type":1,"atk":700,"def":1050,"attribute":2,"race":6},{"id":120,"level":3,"rarity":1,"type":1,"atk":750,"def":1100,"attribute":5,"race":6},{"id":121,"level":3,"rarity":1,"type":1,"atk":800,"def":1000,"attribute":5,"race":6},{"id":122,"level":4,"rarity":1,"type":1,"atk":950,"def":1350,"attribute":5,"race":6},{"id":123,"level":4,"rarity":1,"type":1,"atk":1000,"def":1400,"attribute":2,"race":6},{"id":124,"level":4,"rarity":2,"type":1,"atk":1050,"def":1450,"attribute":5,"race":6},{"id":125,"level":5,"rarity":2,"type":1,"atk":1200,"def":1600,"attribute":5,"race":6},{"id":126,"level":5,"rarity":2,"type":1,"atk":1250,"def":1650,"attribute":2,"race":6},{"id":127,"level":5,"rarity":4,"type":1,"atk":1350,"def":1750,"attribute":5,"race":6,"effect":"passive:passive_untargetable()"},{"id":128,"level":6,"rarity":4,"type":1,"atk":1500,"def":1950,"attribute":5,"race":6,"effect":"onSummon:debuffField(200,100)"},{"id":129,"level":6,"rarity":4,"type":1,"atk":1450,"def":2000,"attribute":2,"race":6,"effect":"onSummon:tempDefBonus(ownMonster,400)"},{"id":130,"level":6,"rarity":4,"type":1,"atk":1600,"def":1900,"attribute":5,"race":6,"effect":"onDestroyByBattle:draw(self,1)"},{"id":131,"level":7,"rarity":4,"type":1,"atk":1700,"def":2200,"attribute":5,"race":6,"effect":"passive:passive_untargetable()"},{"id":132,"level":7,"rarity":4,"type":1,"atk":1750,"def":2150,"attribute":2,"race":6,"effect":"onSummon:debuffField(300,200)"},{"id":133,"level":7,"rarity":6,"type":1,"atk":1900,"def":2500,"attribute":5,"race":6,"effect":"onSummon:debuffField(400,300)"},{"id":134,"level":8,"rarity":6,"type":1,"atk":2100,"def":2750,"attribute":5,"race":6,"effect":"passive:passive_untargetable()"},{"id":135,"level":8,"rarity":8,"type":1,"atk":2300,"def":3000,"attribute":2,"race":6,"effect":"onSummon:debuffField(500,400)"},{"id":136,"level":9,"rarity":8,"type":1,"atk":2500,"def":2850,"attribute":5,"race":6,"effect":"passive:passive_untargetable()"},{"id":137,"level":1,"rarity":1,"type":1,"atk":400,"def":300,"attribute":3,"race":7},{"id":138,"level":2,"rarity":1,"type":1,"atk":700,"def":500,"attribute":3,"race":7},{"id":139,"level":3,"rarity":1,"type":1,"atk":1000,"def":750,"attribute":6,"race":7},{"id":140,"level":3,"rarity":1,"type":1,"atk":950,"def":800,"attribute":3,"race":7},{"id":141,"level":4,"rarity":1,"type":1,"atk":1250,"def":950,"attribute":3,"race":7},{"id":142,"level":4,"rarity":2,"type":1,"atk":1300,"def":1050,"attribute":3,"race":7},{"id":143,"level":5,"rarity":2,"type":1,"atk":1500,"def":1200,"attribute":6,"race":7},{"id":144,"level":5,"rarity":4,"type":1,"atk":1600,"def":1250,"attribute":3,"race":7,"effect":"onSummon:dealDamage(opponent,400)"},{"id":145,"level":6,"rarity":4,"type":1,"atk":1800,"def":1400,"attribute":3,"race":7,"effect":"passive:passive_phoenixRevival()"},{"id":146,"level":6,"rarity":4,"type":1,"atk":1750,"def":1450,"attribute":6,"race":7,"effect":"onSummon:dealDamage(opponent,500)"},{"id":147,"level":6,"rarity":4,"type":1,"atk":1850,"def":1350,"attribute":3,"race":7,"effect":"onSummon:tempAtkBonus(ownMonster,400)"},{"id":148,"level":7,"rarity":4,"type":1,"atk":2050,"def":1650,"attribute":3,"race":7,"effect":"passive:passive_phoenixRevival()"},{"id":149,"level":7,"rarity":6,"type":1,"atk":2250,"def":1800,"attribute":3,"race":7,"effect":"onSummon:dealDamage(opponent,700)"},{"id":150,"level":8,"rarity":6,"type":1,"atk":2500,"def":2000,"attribute":6,"race":7,"effect":"passive:passive_phoenixRevival()"},{"id":151,"level":9,"rarity":8,"type":1,"atk":2800,"def":2200,"attribute":3,"race":7,"effect":"onSummon:dealDamage(opponent,1000)"},{"id":152,"level":1,"rarity":1,"type":1,"atk":350,"def":300,"attribute":2,"race":8},{"id":153,"level":2,"rarity":1,"type":1,"atk":600,"def":550,"attribute":2,"race":8},{"id":154,"level":3,"rarity":1,"type":1,"atk":850,"def":800,"attribute":5,"race":8},{"id":155,"level":3,"rarity":1,"type":1,"atk":900,"def":750,"attribute":2,"race":8},{"id":156,"level":3,"rarity":1,"type":1,"atk":950,"def":700,"attribute":2,"race":8},{"id":157,"level":4,"rarity":1,"type":1,"atk":1150,"def":1000,"attribute":2,"race":8},{"id":158,"level":4,"rarity":2,"type":1,"atk":1200,"def":1050,"attribute":2,"race":8},{"id":159,"level":4,"rarity":2,"type":1,"atk":1100,"def":1100,"attribute":5,"race":8},{"id":160,"level":5,"rarity":2,"type":1,"atk":1400,"def":1250,"attribute":2,"race":8},{"id":161,"level":5,"rarity":4,"type":1,"atk":1550,"def":1350,"attribute":2,"race":8,"effect":"passive:passive_phoenixRevival()"},{"id":162,"level":5,"rarity":4,"type":1,"atk":1500,"def":1400,"attribute":5,"race":8,"effect":"onDestroyByBattle:gainLP(self,600)"},{"id":163,"level":6,"rarity":4,"type":1,"atk":1750,"def":1550,"attribute":2,"race":8,"effect":"onDestroyByBattle:draw(self,2)"},{"id":164,"level":6,"rarity":4,"type":1,"atk":1800,"def":1500,"attribute":2,"race":8,"effect":"passive:passive_phoenixRevival()"},{"id":165,"level":7,"rarity":4,"type":1,"atk":2000,"def":1700,"attribute":2,"race":8,"effect":"onSummon:gainLP(self,600)"},{"id":166,"level":7,"rarity":6,"type":1,"atk":2200,"def":1850,"attribute":5,"race":8,"effect":"passive:passive_phoenixRevival()"},{"id":167,"level":8,"rarity":6,"type":1,"atk":2450,"def":2050,"attribute":2,"race":8,"effect":"onDestroyByBattle:gainLP(self,1000)"},{"id":168,"level":8,"rarity":8,"type":1,"atk":2700,"def":2300,"attribute":2,"race":8,"effect":"passive:passive_phoenixRevival()"},{"id":169,"level":9,"rarity":8,"type":1,"atk":2600,"def":2150,"attribute":2,"race":8,"effect":"onSummon:debuffField(400,300)"},{"id":170,"level":1,"rarity":1,"type":1,"atk":300,"def":450,"attribute":4,"race":9},{"id":171,"level":2,"rarity":1,"type":1,"atk":500,"def":650,"attribute":4,"race":9},{"id":172,"level":3,"rarity":1,"type":1,"atk":800,"def":900,"attribute":6,"race":9},{"id":173,"level":3,"rarity":1,"type":1,"atk":850,"def":950,"attribute":4,"race":9},{"id":174,"level":3,"rarity":1,"type":1,"atk":750,"def":1000,"attribute":4,"race":9},{"id":175,"level":4,"rarity":1,"type":1,"atk":1050,"def":1200,"attribute":4,"race":9},{"id":176,"level":4,"rarity":1,"type":1,"atk":1100,"def":1150,"attribute":4,"race":9},{"id":177,"level":4,"rarity":2,"type":1,"atk":1150,"def":1300,"attribute":6,"race":9},{"id":178,"level":5,"rarity":2,"type":1,"atk":1350,"def":1450,"attribute":4,"race":9},{"id":179,"level":5,"rarity":2,"type":1,"atk":1300,"def":1500,"attribute":4,"race":9},{"id":180,"level":5,"rarity":4,"type":1,"atk":1450,"def":1600,"attribute":4,"race":9,"effect":"onSummon:bounceStrongestOpp()"},{"id":181,"level":5,"rarity":4,"type":1,"atk":1500,"def":1550,"attribute":6,"race":9,"effect":"onSummon:tempDefBonus(ownMonster,350)"},{"id":182,"level":6,"rarity":4,"type":1,"atk":1700,"def":1850,"attribute":4,"race":9,"effect":"onSummon:bounceStrongestOpp()"},{"id":183,"level":6,"rarity":4,"type":1,"atk":1650,"def":1900,"attribute":4,"race":9,"effect":"onSummon:searchDeckToHand(4)"},{"id":184,"level":7,"rarity":4,"type":1,"atk":1900,"def":2100,"attribute":6,"race":9,"effect":"onSummon:debuffField(300,200)"},{"id":185,"level":7,"rarity":4,"type":1,"atk":1950,"def":2050,"attribute":4,"race":9,"effect":"onSummon:bounceStrongestOpp()"},{"id":186,"level":7,"rarity":4,"type":1,"atk":1850,"def":2150,"attribute":4,"race":9,"effect":"onSummon:tempDefBonus(ownMonster,500)"},{"id":187,"level":7,"rarity":6,"type":1,"atk":2150,"def":2400,"attribute":4,"race":9,"effect":"onSummon:bounceStrongestOpp()"},{"id":188,"level":8,"rarity":6,"type":1,"atk":2350,"def":2600,"attribute":4,"race":9,"effect":"passive:passive_untargetable()"},{"id":189,"level":8,"rarity":8,"type":1,"atk":2600,"def":2800,"attribute":4,"race":9,"effect":"onSummon:bounceStrongestOpp()"},{"id":190,"level":1,"rarity":1,"type":1,"atk":300,"def":500,"attribute":6,"race":10},{"id":191,"level":2,"rarity":1,"type":1,"atk":450,"def":700,"attribute":6,"race":10},{"id":192,"level":3,"rarity":1,"type":1,"atk":700,"def":950,"attribute":5,"race":10},{"id":193,"level":3,"rarity":1,"type":1,"atk":650,"def":1000,"attribute":6,"race":10},{"id":194,"level":3,"rarity":1,"type":1,"atk":750,"def":900,"attribute":6,"race":10},{"id":195,"level":4,"rarity":1,"type":1,"atk":1050,"def":1100,"attribute":6,"race":10},{"id":196,"level":4,"rarity":2,"type":1,"atk":1100,"def":1150,"attribute":6,"race":10},{"id":197,"level":5,"rarity":2,"type":1,"atk":1350,"def":1250,"attribute":5,"race":10},{"id":198,"level":5,"rarity":2,"type":1,"atk":1400,"def":1200,"attribute":6,"race":10},{"id":199,"level":5,"rarity":4,"type":1,"atk":1500,"def":1300,"attribute":6,"race":10,"effect":"onSummon:tempAtkBonus(ownMonster,300)"},{"id":200,"level":6,"rarity":4,"type":1,"atk":1750,"def":1450,"attribute":6,"race":10,"effect":"onSummon:buffField(250,{r=10})"},{"id":201,"level":6,"rarity":4,"type":1,"atk":1700,"def":1500,"attribute":5,"race":10,"effect":"onDestroyByBattle:draw(self,2)"},{"id":202,"level":7,"rarity":4,"type":1,"atk":2000,"def":1650,"attribute":6,"race":10,"effect":"onSummon:tempAtkBonus(ownMonster,500)"},{"id":203,"level":7,"rarity":4,"type":1,"atk":2050,"def":1700,"attribute":6,"race":10,"effect":"onSummon:buffField(350,{r=10})"},{"id":204,"level":7,"rarity":6,"type":1,"atk":2250,"def":1850,"attribute":6,"race":10,"effect":"onSummon:buffField(400,{r=10})"},{"id":205,"level":8,"rarity":6,"type":1,"atk":2500,"def":2000,"attribute":5,"race":10,"effect":"onSummon:tempAtkBonus(ownMonster,600)"},{"id":206,"level":8,"rarity":8,"type":1,"atk":2700,"def":2100,"attribute":6,"race":10,"effect":"onSummon:buffField(500,{r=10})"},{"id":207,"level":9,"rarity":8,"type":1,"atk":2600,"def":1950,"attribute":6,"race":10,"effect":"passive:passive_directAttack()"},{"id":208,"level":1,"rarity":1,"type":1,"atk":300,"def":400,"attribute":1,"race":11},{"id":209,"level":2,"rarity":1,"type":1,"atk":500,"def":600,"attribute":1,"race":11},{"id":210,"level":3,"rarity":1,"type":1,"atk":750,"def":800,"attribute":5,"race":11},{"id":211,"level":3,"rarity":1,"type":1,"atk":850,"def":700,"attribute":1,"race":11},{"id":212,"level":3,"rarity":1,"type":1,"atk":900,"def":650,"attribute":1,"race":11},{"id":213,"level":4,"rarity":1,"type":1,"atk":1100,"def":900,"attribute":5,"race":11},{"id":214,"level":4,"rarity":1,"type":1,"atk":1200,"def":1000,"attribute":1,"race":11},{"id":215,"level":4,"rarity":2,"type":1,"atk":1350,"def":1100,"attribute":1,"race":11},{"id":216,"level":5,"rarity":2,"type":1,"atk":1500,"def":1300,"attribute":5,"race":11},{"id":217,"level":5,"rarity":2,"type":1,"atk":1600,"def":1200,"attribute":1,"race":11},{"id":218,"level":5,"rarity":4,"type":1,"atk":1700,"def":1400,"attribute":1,"race":11,"effect":"onSummon:buffField(200,{r=11})"},{"id":219,"level":6,"rarity":4,"type":1,"atk":1900,"def":1600,"attribute":5,"race":11,"effect":"onSummon:tempAtkBonus(ownMonster,300)"},{"id":220,"level":6,"rarity":4,"type":1,"atk":2000,"def":1500,"attribute":1,"race":11,"effect":"onSummon:buffField(300,{r=11})"},{"id":221,"level":6,"rarity":4,"type":1,"atk":2100,"def":1700,"attribute":1,"race":11,"effect":"onSummon:dealDamage(opponent,400)"},{"id":222,"level":7,"rarity":4,"type":1,"atk":2200,"def":1800,"attribute":5,"race":11,"effect":"onSummon:tempAtkBonus(ownMonster,400)"},{"id":223,"level":7,"rarity":4,"type":1,"atk":2300,"def":1900,"attribute":1,"race":11,"effect":"onSummon:buffField(400,{r=11})"},{"id":224,"level":7,"rarity":6,"type":1,"atk":2500,"def":2100,"attribute":1,"race":11,"effect":"onSummon:buffField(500,{r=11})"},{"id":225,"level":8,"rarity":6,"type":1,"atk":2600,"def":2200,"attribute":5,"race":11,"effect":"onSummon:tempAtkBonus(ownMonster,500)"},{"id":226,"level":8,"rarity":8,"type":1,"atk":2700,"def":2300,"attribute":1,"race":11,"effect":"onSummon:buffField(600,{r=11})"},{"id":227,"level":9,"rarity":8,"type":1,"atk":2800,"def":2400,"attribute":1,"race":11,"effect":"onSummon:debuffField(400,300)"},{"id":228,"level":1,"rarity":1,"type":1,"atk":400,"def":200,"attribute":3,"race":12},{"id":229,"level":2,"rarity":1,"type":1,"atk":600,"def":300,"attribute":3,"race":12},{"id":230,"level":3,"rarity":1,"type":1,"atk":850,"def":450,"attribute":1,"race":12},{"id":231,"level":3,"rarity":1,"type":1,"atk":900,"def":500,"attribute":3,"race":12},{"id":232,"level":4,"rarity":1,"type":1,"atk":1100,"def":600,"attribute":3,"race":12},{"id":233,"level":4,"rarity":1,"type":1,"atk":1200,"def":650,"attribute":1,"race":12},{"id":234,"level":4,"rarity":2,"type":1,"atk":1350,"def":700,"attribute":3,"race":12},{"id":235,"level":5,"rarity":2,"type":1,"atk":1500,"def":800,"attribute":3,"race":12},{"id":236,"level":5,"rarity":2,"type":1,"atk":1600,"def":850,"attribute":1,"race":12},{"id":237,"level":5,"rarity":4,"type":1,"atk":1750,"def":900,"attribute":3,"race":12,"effect":"onSummon:dealDamage(opponent,400)"},{"id":238,"level":6,"rarity":4,"type":1,"atk":1900,"def":1000,"attribute":3,"race":12,"effect":"onSummon:dealDamage(opponent,500)"},{"id":239,"level":6,"rarity":4,"type":1,"atk":2050,"def":1100,"attribute":1,"race":12,"effect":"onSummon:dealDamage(opponent,600)"},{"id":240,"level":6,"rarity":4,"type":1,"atk":2150,"def":1050,"attribute":3,"race":12,"effect":"onSummon:tempAtkBonus(ownMonster,400)"},{"id":241,"level":7,"rarity":4,"type":1,"atk":2300,"def":1200,"attribute":3,"race":12,"effect":"onSummon:dealDamage(opponent,700)"},{"id":242,"level":7,"rarity":6,"type":1,"atk":2500,"def":1500,"attribute":3,"race":12,"effect":"onSummon:dealDamage(opponent,800)"},{"id":243,"level":8,"rarity":6,"type":1,"atk":2650,"def":1700,"attribute":1,"race":12,"effect":"onSummon:tempAtkBonus(ownMonster,500)"},{"id":244,"level":8,"rarity":8,"type":1,"atk":2800,"def":1900,"attribute":3,"race":12,"effect":"onSummon:dealDamage(opponent,1000)"},{"id":245,"level":9,"rarity":8,"type":1,"atk":2900,"def":2000,"attribute":3,"race":12,"effect":"onDestroyByOpponent:dealDamage(opponent,1500)"},{"id":246,"level":7,"rarity":6,"type":2,"atk":2400,"def":2000,"attribute":3,"race":1,"effect":"onSummon:dealDamage(opponent,500)"},{"id":247,"level":9,"rarity":8,"type":2,"atk":3100,"def":2600,"attribute":3,"race":1,"effect":"onSummon:debuffField(500,400)"},{"id":248,"level":6,"rarity":6,"type":2,"atk":2000,"def":1800,"attribute":2,"race":2,"effect":"onSummon:draw(self,1)"},{"id":249,"level":8,"rarity":8,"type":2,"atk":2600,"def":2200,"attribute":2,"race":2,"effect":"onSummon:bounceStrongestOpp()"},{"id":250,"level":7,"rarity":6,"type":2,"atk":2500,"def":2100,"attribute":5,"race":3,"effect":"onSummon:buffField(300,{r=3})"},{"id":251,"level":8,"rarity":8,"type":2,"atk":2800,"def":2400,"attribute":5,"race":3,"effect":"onSummon:permAtkBonus(ownMonster,500)"},{"id":252,"level":6,"rarity":6,"type":2,"atk":2200,"def":1600,"attribute":5,"race":4,"effect":"onSummon:tempAtkBonus(ownMonster,400)"},{"id":253,"level":8,"rarity":8,"type":2,"atk":2700,"def":2000,"attribute":5,"race":4,"effect":"onSummon:dealDamage(opponent,600)"},{"id":254,"level":6,"rarity":6,"type":2,"atk":1800,"def":2200,"attribute":5,"race":5,"effect":"onSummon:gainLP(self,800)"},{"id":255,"level":8,"rarity":8,"type":2,"atk":2200,"def":2800,"attribute":5,"race":5,"effect":"onSummon:permDefBonus(ownMonster,500)"},{"id":256,"level":7,"rarity":6,"type":2,"atk":2000,"def":2600,"attribute":5,"race":6,"effect":"onSummon:tempDefBonus(ownMonster,500)"},{"id":257,"level":9,"rarity":8,"type":2,"atk":2400,"def":3200,"attribute":5,"race":6,"effect":"onSummon:debuffField(300,500)"},{"id":258,"level":7,"rarity":6,"type":2,"atk":2300,"def":1800,"attribute":3,"race":7,"effect":"onSummon:dealDamage(opponent,500)"},{"id":259,"level":8,"rarity":8,"type":2,"atk":2600,"def":2100,"attribute":3,"race":7,"effect":"passive:passive_phoenixRevival()"},{"id":260,"level":6,"rarity":6,"type":2,"atk":2100,"def":1900,"attribute":2,"race":8,"effect":"onSummon:tempDebuffField(400)"},{"id":261,"level":8,"rarity":8,"type":2,"atk":2500,"def":2300,"attribute":2,"race":8,"effect":"onDestroyByBattle:draw(self,2)"},{"id":262,"level":7,"rarity":6,"type":2,"atk":2200,"def":2400,"attribute":4,"race":9,"effect":"onSummon:gainLP(self,600)"},{"id":263,"level":8,"rarity":8,"type":2,"atk":2600,"def":2700,"attribute":4,"race":9,"effect":"onSummon:buffField(400,{a=4})"},{"id":264,"level":6,"rarity":6,"type":2,"atk":2000,"def":1700,"attribute":5,"race":10,"effect":"onSummon:draw(self,1)"},{"id":265,"level":8,"rarity":8,"type":2,"atk":2500,"def":2000,"attribute":5,"race":10,"effect":"onSummon:tempAtkBonus(ownMonster,600)"},{"id":266,"rarity":1,"type":3,"effect":"onSummon:dealDamage(opponent,300)","spellType":1},{"id":267,"rarity":1,"type":3,"effect":"onSummon:dealDamage(opponent,400)","spellType":1},{"id":268,"rarity":1,"type":3,"effect":"onSummon:dealDamage(opponent,500)","spellType":1},{"id":269,"rarity":1,"type":3,"effect":"onSummon:gainLP(self,300)","spellType":1},{"id":270,"rarity":1,"type":3,"effect":"onSummon:gainLP(self,500)","spellType":1},{"id":271,"rarity":1,"type":3,"effect":"onSummon:gainLP(self,800)","spellType":1},{"id":272,"rarity":1,"type":3,"effect":"onSummon:dealDamage(opponent,600)","spellType":1},{"id":273,"rarity":1,"type":3,"effect":"onSummon:dealDamage(opponent,800)","spellType":1},{"id":274,"rarity":2,"type":3,"effect":"onSummon:tempAtkBonus(ownMonster,300)","spellType":2},{"id":275,"rarity":2,"type":3,"effect":"onSummon:tempAtkBonus(ownMonster,400)","spellType":2},{"id":276,"rarity":2,"type":3,"effect":"onSummon:tempAtkBonus(ownMonster,500)","spellType":2},{"id":277,"rarity":2,"type":3,"effect":"onSummon:tempDebuffField(300)","spellType":1},{"id":278,"rarity":2,"type":3,"effect":"onSummon:draw(self,1)","spellType":1},{"id":279,"rarity":2,"type":3,"effect":"onSummon:tempDefBonus(ownMonster,400)","spellType":2},{"id":280,"rarity":2,"type":3,"effect":"onSummon:gainLP(self,600)","spellType":1},{"id":281,"rarity":4,"type":3,"effect":"onSummon:dealDamage(opponent,1000)","spellType":1},{"id":282,"rarity":4,"type":3,"effect":"onSummon:dealDamage(opponent,1200)","spellType":1},{"id":283,"rarity":4,"type":3,"effect":"onSummon:dealDamage(opponent,1500)","spellType":1},{"id":284,"rarity":4,"type":3,"effect":"onSummon:buffField(300,{a=3})","spellType":1},{"id":285,"rarity":4,"type":3,"effect":"onSummon:buffField(300,{a=4})","spellType":1},{"id":286,"rarity":4,"type":3,"effect":"onSummon:permAtkBonus(ownMonster,500)","spellType":2},{"id":287,"rarity":6,"type":3,"effect":"onSummon:bounceStrongestOpp()","spellType":1},{"id":288,"rarity":6,"type":3,"effect":"onSummon:bounceAllOppMonsters()","spellType":1},{"id":289,"rarity":6,"type":3,"effect":"onSummon:draw(self,2)","spellType":1},{"id":290,"rarity":8,"type":3,"effect":"onSummon:dealDamage(opponent,2000)","spellType":1},{"id":291,"rarity":1,"type":4,"effect":"onAttack:cancelAttack()","trapTrigger":1},{"id":292,"rarity":1,"type":4,"effect":"onAttack:cancelAttack()","trapTrigger":1},{"id":293,"rarity":1,"type":4,"effect":"onAttack:cancelAttack()","trapTrigger":1},{"id":294,"rarity":1,"type":4,"effect":"onAttack:cancelAttack()","trapTrigger":1},{"id":295,"rarity":2,"type":4,"effect":"onAttack:destroyAttacker()","trapTrigger":1},{"id":296,"rarity":2,"type":4,"effect":"onOwnMonsterAttacked:cancelAttack()","trapTrigger":2},{"id":297,"rarity":2,"type":4,"effect":"onAttack:destroyAttacker()","trapTrigger":1},{"id":298,"rarity":4,"type":4,"effect":"onOpponentSummon:destroySummonedIf(1500)","trapTrigger":3},{"id":299,"rarity":4,"type":4,"effect":"onOpponentSummon:destroySummonedIf(1500)","trapTrigger":3},{"id":300,"rarity":4,"type":4,"effect":"onAttack:destroyAttacker()","trapTrigger":1},{"id":301,"rarity":6,"type":4,"effect":"onAttack:destroyAttacker()","trapTrigger":1},{"id":302,"rarity":6,"type":4,"effect":"onAttack:destroyAttacker()","trapTrigger":1},{"id":303,"rarity":1,"type":5,"atkBonus":500},{"id":304,"rarity":1,"type":5,"defBonus":600},{"id":305,"rarity":2,"type":5,"atkBonus":300,"defBonus":200},{"id":306,"rarity":2,"type":5,"atkBonus":200,"defBonus":400},{"id":307,"rarity":4,"type":5,"atkBonus":800}]
+[
+  {
+    "id": 1,
+    "level": 1,
+    "rarity": 1,
+    "type": 1,
+    "atk": 350,
+    "def": 200,
+    "attribute": 2,
+    "race": 1
+  },
+  {
+    "id": 2,
+    "level": 2,
+    "rarity": 1,
+    "type": 1,
+    "atk": 650,
+    "def": 500,
+    "attribute": 2,
+    "race": 1
+  },
+  {
+    "id": 3,
+    "level": 2,
+    "rarity": 1,
+    "type": 1,
+    "atk": 700,
+    "def": 450,
+    "attribute": 3,
+    "race": 1
+  },
+  {
+    "id": 4,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 1000,
+    "def": 750,
+    "attribute": 2,
+    "race": 1
+  },
+  {
+    "id": 5,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 950,
+    "def": 800,
+    "attribute": 2,
+    "race": 1
+  },
+  {
+    "id": 6,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 1050,
+    "def": 700,
+    "attribute": 3,
+    "race": 1
+  },
+  {
+    "id": 7,
+    "level": 4,
+    "rarity": 1,
+    "type": 1,
+    "atk": 1250,
+    "def": 1000,
+    "attribute": 2,
+    "race": 1
+  },
+  {
+    "id": 8,
+    "level": 4,
+    "rarity": 1,
+    "type": 1,
+    "atk": 1300,
+    "def": 950,
+    "attribute": 2,
+    "race": 1
+  },
+  {
+    "id": 9,
+    "level": 4,
+    "rarity": 1,
+    "type": 1,
+    "atk": 1150,
+    "def": 1050,
+    "attribute": 3,
+    "race": 1
+  },
+  {
+    "id": 10,
+    "level": 4,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1400,
+    "def": 1100,
+    "attribute": 2,
+    "race": 1
+  },
+  {
+    "id": 11,
+    "level": 5,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1600,
+    "def": 1250,
+    "attribute": 2,
+    "race": 1
+  },
+  {
+    "id": 12,
+    "level": 5,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1550,
+    "def": 1300,
+    "attribute": 3,
+    "race": 1
+  },
+  {
+    "id": 13,
+    "level": 5,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1700,
+    "def": 1150,
+    "attribute": 2,
+    "race": 1
+  },
+  {
+    "id": 14,
+    "level": 5,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1650,
+    "def": 1250,
+    "attribute": 2,
+    "race": 1,
+    "effect": "onSummon:dealDamage(opponent,300)"
+  },
+  {
+    "id": 15,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1900,
+    "def": 1500,
+    "attribute": 2,
+    "race": 1,
+    "effect": "onSummon:buffField(200,{r=1})"
+  },
+  {
+    "id": 16,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1850,
+    "def": 1550,
+    "attribute": 3,
+    "race": 1,
+    "effect": "onSummon:dealDamage(opponent,400)"
+  },
+  {
+    "id": 17,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 2000,
+    "def": 1450,
+    "attribute": 2,
+    "race": 1,
+    "effect": "onDestroyByBattle:draw(self,1)"
+  },
+  {
+    "id": 18,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1950,
+    "def": 1600,
+    "attribute": 3,
+    "race": 1,
+    "effect": "onSummon:buffField(300,{r=1})"
+  },
+  {
+    "id": 19,
+    "level": 7,
+    "rarity": 4,
+    "type": 1,
+    "atk": 2200,
+    "def": 1750,
+    "attribute": 2,
+    "race": 1,
+    "effect": "onSummon:dealDamage(opponent,500)"
+  },
+  {
+    "id": 20,
+    "level": 7,
+    "rarity": 4,
+    "type": 1,
+    "atk": 2150,
+    "def": 1800,
+    "attribute": 2,
+    "race": 1,
+    "effect": "passive:passive_piercing()"
+  },
+  {
+    "id": 21,
+    "level": 7,
+    "rarity": 6,
+    "type": 1,
+    "atk": 2350,
+    "def": 1900,
+    "attribute": 2,
+    "race": 1,
+    "effect": "onSummon:buffField(400,{r=1})"
+  },
+  {
+    "id": 22,
+    "level": 8,
+    "rarity": 6,
+    "type": 1,
+    "atk": 2500,
+    "def": 2050,
+    "attribute": 3,
+    "race": 1,
+    "effect": "onSummon:dealDamage(opponent,600)"
+  },
+  {
+    "id": 23,
+    "level": 8,
+    "rarity": 6,
+    "type": 1,
+    "atk": 2550,
+    "def": 2100,
+    "attribute": 2,
+    "race": 1,
+    "effect": "passive:passive_piercing()"
+  },
+  {
+    "id": 24,
+    "level": 9,
+    "rarity": 8,
+    "type": 1,
+    "atk": 2750,
+    "def": 2300,
+    "attribute": 2,
+    "race": 1,
+    "effect": "onSummon:dealDamage(opponent,800)"
+  },
+  {
+    "id": 25,
+    "level": 9,
+    "rarity": 8,
+    "type": 1,
+    "atk": 3000,
+    "def": 2500,
+    "attribute": 2,
+    "race": 1,
+    "effect": "onSummon:buffField(500,{r=1})"
+  },
+  {
+    "id": 26,
+    "level": 1,
+    "rarity": 1,
+    "type": 1,
+    "atk": 300,
+    "def": 300,
+    "attribute": 5,
+    "race": 3
+  },
+  {
+    "id": 27,
+    "level": 2,
+    "rarity": 1,
+    "type": 1,
+    "atk": 600,
+    "def": 550,
+    "attribute": 5,
+    "race": 3
+  },
+  {
+    "id": 28,
+    "level": 2,
+    "rarity": 1,
+    "type": 1,
+    "atk": 550,
+    "def": 600,
+    "attribute": 1,
+    "race": 3
+  },
+  {
+    "id": 29,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 900,
+    "def": 850,
+    "attribute": 5,
+    "race": 3
+  },
+  {
+    "id": 30,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 950,
+    "def": 800,
+    "attribute": 5,
+    "race": 3
+  },
+  {
+    "id": 31,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 850,
+    "def": 900,
+    "attribute": 5,
+    "race": 3
+  },
+  {
+    "id": 32,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 1000,
+    "def": 750,
+    "attribute": 1,
+    "race": 3
+  },
+  {
+    "id": 33,
+    "level": 4,
+    "rarity": 1,
+    "type": 1,
+    "atk": 1200,
+    "def": 1100,
+    "attribute": 5,
+    "race": 3
+  },
+  {
+    "id": 34,
+    "level": 4,
+    "rarity": 1,
+    "type": 1,
+    "atk": 1250,
+    "def": 1050,
+    "attribute": 5,
+    "race": 3
+  },
+  {
+    "id": 35,
+    "level": 4,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1300,
+    "def": 1150,
+    "attribute": 1,
+    "race": 3
+  },
+  {
+    "id": 36,
+    "level": 4,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1350,
+    "def": 1100,
+    "attribute": 5,
+    "race": 3
+  },
+  {
+    "id": 37,
+    "level": 5,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1500,
+    "def": 1350,
+    "attribute": 5,
+    "race": 3
+  },
+  {
+    "id": 38,
+    "level": 5,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1550,
+    "def": 1300,
+    "attribute": 1,
+    "race": 3
+  },
+  {
+    "id": 39,
+    "level": 5,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1600,
+    "def": 1400,
+    "attribute": 5,
+    "race": 3,
+    "effect": "onSummon:tempAtkBonus(ownMonster,400)"
+  },
+  {
+    "id": 40,
+    "level": 5,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1650,
+    "def": 1350,
+    "attribute": 5,
+    "race": 3,
+    "effect": "onSummon:permAtkBonus(ownMonster,200)"
+  },
+  {
+    "id": 41,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1850,
+    "def": 1600,
+    "attribute": 5,
+    "race": 3,
+    "effect": "onSummon:buffField(200,{r=3})"
+  },
+  {
+    "id": 42,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1900,
+    "def": 1550,
+    "attribute": 1,
+    "race": 3,
+    "effect": "onSummon:tempAtkBonus(ownMonster,500)"
+  },
+  {
+    "id": 43,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1800,
+    "def": 1650,
+    "attribute": 5,
+    "race": 3,
+    "effect": "onDestroyByBattle:draw(self,1)"
+  },
+  {
+    "id": 44,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1950,
+    "def": 1500,
+    "attribute": 5,
+    "race": 3,
+    "effect": "onSummon:permAtkBonus(ownMonster,300)"
+  },
+  {
+    "id": 45,
+    "level": 7,
+    "rarity": 4,
+    "type": 1,
+    "atk": 2100,
+    "def": 1850,
+    "attribute": 1,
+    "race": 3,
+    "effect": "onSummon:buffField(300,{r=3})"
+  },
+  {
+    "id": 46,
+    "level": 7,
+    "rarity": 4,
+    "type": 1,
+    "atk": 2200,
+    "def": 1800,
+    "attribute": 5,
+    "race": 3,
+    "effect": "onSummon:tempAtkBonus(ownMonster,600)"
+  },
+  {
+    "id": 47,
+    "level": 7,
+    "rarity": 6,
+    "type": 1,
+    "atk": 2300,
+    "def": 2000,
+    "attribute": 5,
+    "race": 3,
+    "effect": "onSummon:permAtkBonus(ownMonster,400)"
+  },
+  {
+    "id": 48,
+    "level": 7,
+    "rarity": 6,
+    "type": 1,
+    "atk": 2350,
+    "def": 1950,
+    "attribute": 5,
+    "race": 3,
+    "effect": "onSummon:buffField(400,{r=3})"
+  },
+  {
+    "id": 49,
+    "level": 8,
+    "rarity": 6,
+    "type": 1,
+    "atk": 2500,
+    "def": 2200,
+    "attribute": 1,
+    "race": 3,
+    "effect": "passive:passive_untargetable()"
+  },
+  {
+    "id": 50,
+    "level": 8,
+    "rarity": 8,
+    "type": 1,
+    "atk": 2650,
+    "def": 2300,
+    "attribute": 5,
+    "race": 3,
+    "effect": "onSummon:permAtkBonus(ownMonster,500)"
+  },
+  {
+    "id": 51,
+    "level": 9,
+    "rarity": 8,
+    "type": 1,
+    "atk": 2800,
+    "def": 2500,
+    "attribute": 5,
+    "race": 3,
+    "effect": "onSummon:buffField(500,{r=3})"
+  },
+  {
+    "id": 52,
+    "level": 9,
+    "rarity": 8,
+    "type": 1,
+    "atk": 3200,
+    "def": 2800,
+    "attribute": 1,
+    "race": 3,
+    "effect": "passive:passive_piercing()"
+  },
+  {
+    "id": 53,
+    "level": 8,
+    "rarity": 4,
+    "type": 1,
+    "atk": 2450,
+    "def": 2100,
+    "attribute": 5,
+    "race": 3,
+    "effect": "onSummon:tempAtkBonus(ownMonster,700)"
+  },
+  {
+    "id": 54,
+    "level": 1,
+    "rarity": 1,
+    "type": 1,
+    "atk": 250,
+    "def": 300,
+    "attribute": 1,
+    "race": 2
+  },
+  {
+    "id": 55,
+    "level": 2,
+    "rarity": 1,
+    "type": 1,
+    "atk": 500,
+    "def": 550,
+    "attribute": 1,
+    "race": 2
+  },
+  {
+    "id": 56,
+    "level": 2,
+    "rarity": 1,
+    "type": 1,
+    "atk": 550,
+    "def": 500,
+    "attribute": 2,
+    "race": 2
+  },
+  {
+    "id": 57,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 800,
+    "def": 850,
+    "attribute": 1,
+    "race": 2
+  },
+  {
+    "id": 58,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 850,
+    "def": 800,
+    "attribute": 1,
+    "race": 2
+  },
+  {
+    "id": 59,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 750,
+    "def": 900,
+    "attribute": 2,
+    "race": 2
+  },
+  {
+    "id": 60,
+    "level": 4,
+    "rarity": 1,
+    "type": 1,
+    "atk": 1100,
+    "def": 1050,
+    "attribute": 1,
+    "race": 2
+  },
+  {
+    "id": 61,
+    "level": 4,
+    "rarity": 1,
+    "type": 1,
+    "atk": 1050,
+    "def": 1100,
+    "attribute": 1,
+    "race": 2
+  },
+  {
+    "id": 62,
+    "level": 4,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1150,
+    "def": 1100,
+    "attribute": 2,
+    "race": 2
+  },
+  {
+    "id": 63,
+    "level": 5,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1350,
+    "def": 1300,
+    "attribute": 1,
+    "race": 2
+  },
+  {
+    "id": 64,
+    "level": 5,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1400,
+    "def": 1250,
+    "attribute": 1,
+    "race": 2
+  },
+  {
+    "id": 65,
+    "level": 5,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1300,
+    "def": 1350,
+    "attribute": 2,
+    "race": 2
+  },
+  {
+    "id": 66,
+    "level": 5,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1450,
+    "def": 1300,
+    "attribute": 1,
+    "race": 2,
+    "effect": "onSummon:searchDeckToHand(1)"
+  },
+  {
+    "id": 67,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1650,
+    "def": 1500,
+    "attribute": 1,
+    "race": 2,
+    "effect": "onSummon:debuffField(200,200)"
+  },
+  {
+    "id": 68,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1700,
+    "def": 1450,
+    "attribute": 2,
+    "race": 2,
+    "effect": "onDestroyByBattle:draw(self,2)"
+  },
+  {
+    "id": 69,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1600,
+    "def": 1550,
+    "attribute": 1,
+    "race": 2,
+    "effect": "onSummon:gainLP(self,500)"
+  },
+  {
+    "id": 70,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1750,
+    "def": 1400,
+    "attribute": 1,
+    "race": 2,
+    "effect": "onSummon:searchDeckToHand(2)"
+  },
+  {
+    "id": 71,
+    "level": 7,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1900,
+    "def": 1700,
+    "attribute": 2,
+    "race": 2,
+    "effect": "onSummon:debuffField(300,300)"
+  },
+  {
+    "id": 72,
+    "level": 7,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1950,
+    "def": 1650,
+    "attribute": 1,
+    "race": 2,
+    "effect": "onSummon:bounceStrongestOpp()"
+  },
+  {
+    "id": 73,
+    "level": 7,
+    "rarity": 6,
+    "type": 1,
+    "atk": 2100,
+    "def": 1850,
+    "attribute": 1,
+    "race": 2,
+    "effect": "onSummon:debuffField(400,300)"
+  },
+  {
+    "id": 74,
+    "level": 8,
+    "rarity": 6,
+    "type": 1,
+    "atk": 2300,
+    "def": 2050,
+    "attribute": 2,
+    "race": 2,
+    "effect": "onSummon:searchDeckToHand(1)"
+  },
+  {
+    "id": 75,
+    "level": 8,
+    "rarity": 6,
+    "type": 1,
+    "atk": 2250,
+    "def": 2100,
+    "attribute": 1,
+    "race": 2,
+    "effect": "onSummon:bounceStrongestOpp()"
+  },
+  {
+    "id": 76,
+    "level": 8,
+    "rarity": 8,
+    "type": 1,
+    "atk": 2450,
+    "def": 2200,
+    "attribute": 1,
+    "race": 2,
+    "effect": "onSummon:debuffField(500,400)"
+  },
+  {
+    "id": 77,
+    "level": 9,
+    "rarity": 8,
+    "type": 1,
+    "atk": 2700,
+    "def": 2400,
+    "attribute": 1,
+    "race": 2,
+    "effect": "passive:passive_untargetable()"
+  },
+  {
+    "id": 78,
+    "level": 9,
+    "rarity": 8,
+    "type": 1,
+    "atk": 2600,
+    "def": 2350,
+    "attribute": 2,
+    "race": 2,
+    "effect": "onSummon:bounceStrongestOpp()"
+  },
+  {
+    "id": 79,
+    "level": 1,
+    "rarity": 1,
+    "type": 1,
+    "atk": 400,
+    "def": 200,
+    "attribute": 3,
+    "race": 4
+  },
+  {
+    "id": 80,
+    "level": 2,
+    "rarity": 1,
+    "type": 1,
+    "atk": 700,
+    "def": 400,
+    "attribute": 3,
+    "race": 4
+  },
+  {
+    "id": 81,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 1050,
+    "def": 650,
+    "attribute": 5,
+    "race": 4
+  },
+  {
+    "id": 82,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 1100,
+    "def": 600,
+    "attribute": 3,
+    "race": 4
+  },
+  {
+    "id": 83,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 1000,
+    "def": 700,
+    "attribute": 3,
+    "race": 4
+  },
+  {
+    "id": 84,
+    "level": 4,
+    "rarity": 1,
+    "type": 1,
+    "atk": 1350,
+    "def": 850,
+    "attribute": 3,
+    "race": 4
+  },
+  {
+    "id": 85,
+    "level": 4,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1400,
+    "def": 900,
+    "attribute": 5,
+    "race": 4
+  },
+  {
+    "id": 86,
+    "level": 4,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1450,
+    "def": 850,
+    "attribute": 3,
+    "race": 4
+  },
+  {
+    "id": 87,
+    "level": 5,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1650,
+    "def": 1050,
+    "attribute": 3,
+    "race": 4
+  },
+  {
+    "id": 88,
+    "level": 5,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1700,
+    "def": 1100,
+    "attribute": 3,
+    "race": 4,
+    "effect": "onSummon:dealDamage(opponent,300)"
+  },
+  {
+    "id": 89,
+    "level": 5,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1750,
+    "def": 1050,
+    "attribute": 5,
+    "race": 4,
+    "effect": "passive:passive_piercing()"
+  },
+  {
+    "id": 90,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1950,
+    "def": 1200,
+    "attribute": 3,
+    "race": 4,
+    "effect": "onSummon:dealDamage(opponent,400)"
+  },
+  {
+    "id": 91,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 2000,
+    "def": 1250,
+    "attribute": 3,
+    "race": 4,
+    "effect": "passive:passive_piercing()"
+  },
+  {
+    "id": 92,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1900,
+    "def": 1300,
+    "attribute": 5,
+    "race": 4,
+    "effect": "onDestroyByBattle:gainLP(self,500)"
+  },
+  {
+    "id": 93,
+    "level": 7,
+    "rarity": 4,
+    "type": 1,
+    "atk": 2200,
+    "def": 1450,
+    "attribute": 3,
+    "race": 4,
+    "effect": "onSummon:dealDamage(opponent,500)"
+  },
+  {
+    "id": 94,
+    "level": 7,
+    "rarity": 6,
+    "type": 1,
+    "atk": 2350,
+    "def": 1550,
+    "attribute": 3,
+    "race": 4,
+    "effect": "passive:passive_piercing()"
+  },
+  {
+    "id": 95,
+    "level": 7,
+    "rarity": 6,
+    "type": 1,
+    "atk": 2400,
+    "def": 1500,
+    "attribute": 5,
+    "race": 4,
+    "effect": "onSummon:dealDamage(opponent,600)"
+  },
+  {
+    "id": 96,
+    "level": 8,
+    "rarity": 8,
+    "type": 1,
+    "atk": 2600,
+    "def": 1800,
+    "attribute": 3,
+    "race": 4,
+    "effect": "passive:passive_phoenixRevival()"
+  },
+  {
+    "id": 97,
+    "level": 8,
+    "rarity": 8,
+    "type": 1,
+    "atk": 2900,
+    "def": 2200,
+    "attribute": 3,
+    "race": 4,
+    "effect": "passive:passive_piercing()"
+  },
+  {
+    "id": 98,
+    "level": 7,
+    "rarity": 4,
+    "type": 1,
+    "atk": 2150,
+    "def": 1500,
+    "attribute": 3,
+    "race": 4,
+    "effect": "passive:passive_directAttack()"
+  },
+  {
+    "id": 99,
+    "level": 1,
+    "rarity": 1,
+    "type": 1,
+    "atk": 350,
+    "def": 500,
+    "attribute": 5,
+    "race": 5
+  },
+  {
+    "id": 100,
+    "level": 2,
+    "rarity": 1,
+    "type": 1,
+    "atk": 550,
+    "def": 700,
+    "attribute": 5,
+    "race": 5
+  },
+  {
+    "id": 101,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 800,
+    "def": 950,
+    "attribute": 6,
+    "race": 5
+  },
+  {
+    "id": 102,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 900,
+    "def": 1000,
+    "attribute": 5,
+    "race": 5
+  },
+  {
+    "id": 103,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 850,
+    "def": 1050,
+    "attribute": 5,
+    "race": 5
+  },
+  {
+    "id": 104,
+    "level": 4,
+    "rarity": 1,
+    "type": 1,
+    "atk": 1100,
+    "def": 1200,
+    "attribute": 5,
+    "race": 5
+  },
+  {
+    "id": 105,
+    "level": 4,
+    "rarity": 1,
+    "type": 1,
+    "atk": 1050,
+    "def": 1300,
+    "attribute": 6,
+    "race": 5
+  },
+  {
+    "id": 106,
+    "level": 4,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1150,
+    "def": 1350,
+    "attribute": 5,
+    "race": 5
+  },
+  {
+    "id": 107,
+    "level": 4,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1200,
+    "def": 1250,
+    "attribute": 5,
+    "race": 5
+  },
+  {
+    "id": 108,
+    "level": 5,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1400,
+    "def": 1500,
+    "attribute": 6,
+    "race": 5
+  },
+  {
+    "id": 109,
+    "level": 5,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1500,
+    "def": 1600,
+    "attribute": 5,
+    "race": 5,
+    "effect": "onDestroyByBattle:gainLP(self,500)"
+  },
+  {
+    "id": 110,
+    "level": 5,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1450,
+    "def": 1650,
+    "attribute": 5,
+    "race": 5,
+    "effect": "onSummon:gainLP(self,400)"
+  },
+  {
+    "id": 111,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1700,
+    "def": 1850,
+    "attribute": 6,
+    "race": 5,
+    "effect": "onDestroyByBattle:draw(self,1)"
+  },
+  {
+    "id": 112,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1750,
+    "def": 1900,
+    "attribute": 5,
+    "race": 5,
+    "effect": "onSummon:tempDefBonus(ownMonster,300)"
+  },
+  {
+    "id": 113,
+    "level": 7,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1900,
+    "def": 2100,
+    "attribute": 5,
+    "race": 5,
+    "effect": "onDestroyByBattle:gainLP(self,800)"
+  },
+  {
+    "id": 114,
+    "level": 7,
+    "rarity": 6,
+    "type": 1,
+    "atk": 2100,
+    "def": 2350,
+    "attribute": 5,
+    "race": 5,
+    "effect": "onSummon:gainLP(self,800)"
+  },
+  {
+    "id": 115,
+    "level": 8,
+    "rarity": 6,
+    "type": 1,
+    "atk": 2250,
+    "def": 2500,
+    "attribute": 6,
+    "race": 5,
+    "effect": "onSummon:buffField(300,{r=5})"
+  },
+  {
+    "id": 116,
+    "level": 8,
+    "rarity": 8,
+    "type": 1,
+    "atk": 2400,
+    "def": 2600,
+    "attribute": 5,
+    "race": 5,
+    "effect": "onDestroyByBattle:gainLP(self,1200)"
+  },
+  {
+    "id": 117,
+    "level": 1,
+    "rarity": 1,
+    "type": 1,
+    "atk": 250,
+    "def": 550,
+    "attribute": 5,
+    "race": 6
+  },
+  {
+    "id": 118,
+    "level": 2,
+    "rarity": 1,
+    "type": 1,
+    "atk": 450,
+    "def": 750,
+    "attribute": 5,
+    "race": 6
+  },
+  {
+    "id": 119,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 700,
+    "def": 1050,
+    "attribute": 2,
+    "race": 6
+  },
+  {
+    "id": 120,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 750,
+    "def": 1100,
+    "attribute": 5,
+    "race": 6
+  },
+  {
+    "id": 121,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 800,
+    "def": 1000,
+    "attribute": 5,
+    "race": 6
+  },
+  {
+    "id": 122,
+    "level": 4,
+    "rarity": 1,
+    "type": 1,
+    "atk": 950,
+    "def": 1350,
+    "attribute": 5,
+    "race": 6
+  },
+  {
+    "id": 123,
+    "level": 4,
+    "rarity": 1,
+    "type": 1,
+    "atk": 1000,
+    "def": 1400,
+    "attribute": 2,
+    "race": 6
+  },
+  {
+    "id": 124,
+    "level": 4,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1050,
+    "def": 1450,
+    "attribute": 5,
+    "race": 6
+  },
+  {
+    "id": 125,
+    "level": 5,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1200,
+    "def": 1600,
+    "attribute": 5,
+    "race": 6
+  },
+  {
+    "id": 126,
+    "level": 5,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1250,
+    "def": 1650,
+    "attribute": 2,
+    "race": 6
+  },
+  {
+    "id": 127,
+    "level": 5,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1350,
+    "def": 1750,
+    "attribute": 5,
+    "race": 6,
+    "effect": "passive:passive_untargetable()"
+  },
+  {
+    "id": 128,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1500,
+    "def": 1950,
+    "attribute": 5,
+    "race": 6,
+    "effect": "onSummon:debuffField(200,100)"
+  },
+  {
+    "id": 129,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1450,
+    "def": 2000,
+    "attribute": 2,
+    "race": 6,
+    "effect": "onSummon:tempDefBonus(ownMonster,400)"
+  },
+  {
+    "id": 130,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1600,
+    "def": 1900,
+    "attribute": 5,
+    "race": 6,
+    "effect": "onDestroyByBattle:draw(self,1)"
+  },
+  {
+    "id": 131,
+    "level": 7,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1700,
+    "def": 2200,
+    "attribute": 5,
+    "race": 6,
+    "effect": "passive:passive_untargetable()"
+  },
+  {
+    "id": 132,
+    "level": 7,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1750,
+    "def": 2150,
+    "attribute": 2,
+    "race": 6,
+    "effect": "onSummon:debuffField(300,200)"
+  },
+  {
+    "id": 133,
+    "level": 7,
+    "rarity": 6,
+    "type": 1,
+    "atk": 1900,
+    "def": 2500,
+    "attribute": 5,
+    "race": 6,
+    "effect": "onSummon:debuffField(400,300)"
+  },
+  {
+    "id": 134,
+    "level": 8,
+    "rarity": 6,
+    "type": 1,
+    "atk": 2100,
+    "def": 2750,
+    "attribute": 5,
+    "race": 6,
+    "effect": "passive:passive_untargetable()"
+  },
+  {
+    "id": 135,
+    "level": 8,
+    "rarity": 8,
+    "type": 1,
+    "atk": 2300,
+    "def": 3000,
+    "attribute": 2,
+    "race": 6,
+    "effect": "onSummon:debuffField(500,400)"
+  },
+  {
+    "id": 136,
+    "level": 9,
+    "rarity": 8,
+    "type": 1,
+    "atk": 2500,
+    "def": 2850,
+    "attribute": 5,
+    "race": 6,
+    "effect": "passive:passive_untargetable()"
+  },
+  {
+    "id": 137,
+    "level": 1,
+    "rarity": 1,
+    "type": 1,
+    "atk": 400,
+    "def": 300,
+    "attribute": 3,
+    "race": 7
+  },
+  {
+    "id": 138,
+    "level": 2,
+    "rarity": 1,
+    "type": 1,
+    "atk": 700,
+    "def": 500,
+    "attribute": 3,
+    "race": 7
+  },
+  {
+    "id": 139,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 1000,
+    "def": 750,
+    "attribute": 6,
+    "race": 7
+  },
+  {
+    "id": 140,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 950,
+    "def": 800,
+    "attribute": 3,
+    "race": 7
+  },
+  {
+    "id": 141,
+    "level": 4,
+    "rarity": 1,
+    "type": 1,
+    "atk": 1250,
+    "def": 950,
+    "attribute": 3,
+    "race": 7
+  },
+  {
+    "id": 142,
+    "level": 4,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1300,
+    "def": 1050,
+    "attribute": 3,
+    "race": 7
+  },
+  {
+    "id": 143,
+    "level": 5,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1500,
+    "def": 1200,
+    "attribute": 6,
+    "race": 7
+  },
+  {
+    "id": 144,
+    "level": 5,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1600,
+    "def": 1250,
+    "attribute": 3,
+    "race": 7,
+    "effect": "onSummon:dealDamage(opponent,400)"
+  },
+  {
+    "id": 145,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1800,
+    "def": 1400,
+    "attribute": 3,
+    "race": 7,
+    "effect": "passive:passive_phoenixRevival()"
+  },
+  {
+    "id": 146,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1750,
+    "def": 1450,
+    "attribute": 6,
+    "race": 7,
+    "effect": "onSummon:dealDamage(opponent,500)"
+  },
+  {
+    "id": 147,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1850,
+    "def": 1350,
+    "attribute": 3,
+    "race": 7,
+    "effect": "onSummon:tempAtkBonus(ownMonster,400)"
+  },
+  {
+    "id": 148,
+    "level": 7,
+    "rarity": 4,
+    "type": 1,
+    "atk": 2050,
+    "def": 1650,
+    "attribute": 3,
+    "race": 7,
+    "effect": "passive:passive_phoenixRevival()"
+  },
+  {
+    "id": 149,
+    "level": 7,
+    "rarity": 6,
+    "type": 1,
+    "atk": 2250,
+    "def": 1800,
+    "attribute": 3,
+    "race": 7,
+    "effect": "onSummon:dealDamage(opponent,700)"
+  },
+  {
+    "id": 150,
+    "level": 8,
+    "rarity": 6,
+    "type": 1,
+    "atk": 2500,
+    "def": 2000,
+    "attribute": 6,
+    "race": 7,
+    "effect": "passive:passive_phoenixRevival()"
+  },
+  {
+    "id": 151,
+    "level": 9,
+    "rarity": 8,
+    "type": 1,
+    "atk": 2800,
+    "def": 2200,
+    "attribute": 3,
+    "race": 7,
+    "effect": "onSummon:dealDamage(opponent,1000)"
+  },
+  {
+    "id": 152,
+    "level": 1,
+    "rarity": 1,
+    "type": 1,
+    "atk": 350,
+    "def": 300,
+    "attribute": 2,
+    "race": 8
+  },
+  {
+    "id": 153,
+    "level": 2,
+    "rarity": 1,
+    "type": 1,
+    "atk": 600,
+    "def": 550,
+    "attribute": 2,
+    "race": 8
+  },
+  {
+    "id": 154,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 850,
+    "def": 800,
+    "attribute": 5,
+    "race": 8
+  },
+  {
+    "id": 155,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 900,
+    "def": 750,
+    "attribute": 2,
+    "race": 8
+  },
+  {
+    "id": 156,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 950,
+    "def": 700,
+    "attribute": 2,
+    "race": 8
+  },
+  {
+    "id": 157,
+    "level": 4,
+    "rarity": 1,
+    "type": 1,
+    "atk": 1150,
+    "def": 1000,
+    "attribute": 2,
+    "race": 8
+  },
+  {
+    "id": 158,
+    "level": 4,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1200,
+    "def": 1050,
+    "attribute": 2,
+    "race": 8
+  },
+  {
+    "id": 159,
+    "level": 4,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1100,
+    "def": 1100,
+    "attribute": 5,
+    "race": 8
+  },
+  {
+    "id": 160,
+    "level": 5,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1400,
+    "def": 1250,
+    "attribute": 2,
+    "race": 8
+  },
+  {
+    "id": 161,
+    "level": 5,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1550,
+    "def": 1350,
+    "attribute": 2,
+    "race": 8,
+    "effect": "passive:passive_phoenixRevival()"
+  },
+  {
+    "id": 162,
+    "level": 5,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1500,
+    "def": 1400,
+    "attribute": 5,
+    "race": 8,
+    "effect": "onDestroyByBattle:gainLP(self,600)"
+  },
+  {
+    "id": 163,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1750,
+    "def": 1550,
+    "attribute": 2,
+    "race": 8,
+    "effect": "onDestroyByBattle:draw(self,2)"
+  },
+  {
+    "id": 164,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1800,
+    "def": 1500,
+    "attribute": 2,
+    "race": 8,
+    "effect": "passive:passive_phoenixRevival()"
+  },
+  {
+    "id": 165,
+    "level": 7,
+    "rarity": 4,
+    "type": 1,
+    "atk": 2000,
+    "def": 1700,
+    "attribute": 2,
+    "race": 8,
+    "effect": "onSummon:gainLP(self,600)"
+  },
+  {
+    "id": 166,
+    "level": 7,
+    "rarity": 6,
+    "type": 1,
+    "atk": 2200,
+    "def": 1850,
+    "attribute": 5,
+    "race": 8,
+    "effect": "passive:passive_phoenixRevival()"
+  },
+  {
+    "id": 167,
+    "level": 8,
+    "rarity": 6,
+    "type": 1,
+    "atk": 2450,
+    "def": 2050,
+    "attribute": 2,
+    "race": 8,
+    "effect": "onDestroyByBattle:gainLP(self,1000)"
+  },
+  {
+    "id": 168,
+    "level": 8,
+    "rarity": 8,
+    "type": 1,
+    "atk": 2700,
+    "def": 2300,
+    "attribute": 2,
+    "race": 8,
+    "effect": "passive:passive_phoenixRevival()"
+  },
+  {
+    "id": 169,
+    "level": 9,
+    "rarity": 8,
+    "type": 1,
+    "atk": 2600,
+    "def": 2150,
+    "attribute": 2,
+    "race": 8,
+    "effect": "onSummon:debuffField(400,300)"
+  },
+  {
+    "id": 170,
+    "level": 1,
+    "rarity": 1,
+    "type": 1,
+    "atk": 300,
+    "def": 450,
+    "attribute": 4,
+    "race": 9
+  },
+  {
+    "id": 171,
+    "level": 2,
+    "rarity": 1,
+    "type": 1,
+    "atk": 500,
+    "def": 650,
+    "attribute": 4,
+    "race": 9
+  },
+  {
+    "id": 172,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 800,
+    "def": 900,
+    "attribute": 6,
+    "race": 9
+  },
+  {
+    "id": 173,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 850,
+    "def": 950,
+    "attribute": 4,
+    "race": 9
+  },
+  {
+    "id": 174,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 750,
+    "def": 1000,
+    "attribute": 4,
+    "race": 9
+  },
+  {
+    "id": 175,
+    "level": 4,
+    "rarity": 1,
+    "type": 1,
+    "atk": 1050,
+    "def": 1200,
+    "attribute": 4,
+    "race": 9
+  },
+  {
+    "id": 176,
+    "level": 4,
+    "rarity": 1,
+    "type": 1,
+    "atk": 1100,
+    "def": 1150,
+    "attribute": 4,
+    "race": 9
+  },
+  {
+    "id": 177,
+    "level": 4,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1150,
+    "def": 1300,
+    "attribute": 6,
+    "race": 9
+  },
+  {
+    "id": 178,
+    "level": 5,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1350,
+    "def": 1450,
+    "attribute": 4,
+    "race": 9
+  },
+  {
+    "id": 179,
+    "level": 5,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1300,
+    "def": 1500,
+    "attribute": 4,
+    "race": 9
+  },
+  {
+    "id": 180,
+    "level": 5,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1450,
+    "def": 1600,
+    "attribute": 4,
+    "race": 9,
+    "effect": "onSummon:bounceStrongestOpp()"
+  },
+  {
+    "id": 181,
+    "level": 5,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1500,
+    "def": 1550,
+    "attribute": 6,
+    "race": 9,
+    "effect": "onSummon:tempDefBonus(ownMonster,350)"
+  },
+  {
+    "id": 182,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1700,
+    "def": 1850,
+    "attribute": 4,
+    "race": 9,
+    "effect": "onSummon:bounceStrongestOpp()"
+  },
+  {
+    "id": 183,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1650,
+    "def": 1900,
+    "attribute": 4,
+    "race": 9,
+    "effect": "onSummon:searchDeckToHand(4)"
+  },
+  {
+    "id": 184,
+    "level": 7,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1900,
+    "def": 2100,
+    "attribute": 6,
+    "race": 9,
+    "effect": "onSummon:debuffField(300,200)"
+  },
+  {
+    "id": 185,
+    "level": 7,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1950,
+    "def": 2050,
+    "attribute": 4,
+    "race": 9,
+    "effect": "onSummon:bounceStrongestOpp()"
+  },
+  {
+    "id": 186,
+    "level": 7,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1850,
+    "def": 2150,
+    "attribute": 4,
+    "race": 9,
+    "effect": "onSummon:tempDefBonus(ownMonster,500)"
+  },
+  {
+    "id": 187,
+    "level": 7,
+    "rarity": 6,
+    "type": 1,
+    "atk": 2150,
+    "def": 2400,
+    "attribute": 4,
+    "race": 9,
+    "effect": "onSummon:bounceStrongestOpp()"
+  },
+  {
+    "id": 188,
+    "level": 8,
+    "rarity": 6,
+    "type": 1,
+    "atk": 2350,
+    "def": 2600,
+    "attribute": 4,
+    "race": 9,
+    "effect": "passive:passive_untargetable()"
+  },
+  {
+    "id": 189,
+    "level": 8,
+    "rarity": 8,
+    "type": 1,
+    "atk": 2600,
+    "def": 2800,
+    "attribute": 4,
+    "race": 9,
+    "effect": "onSummon:bounceStrongestOpp()"
+  },
+  {
+    "id": 190,
+    "level": 1,
+    "rarity": 1,
+    "type": 1,
+    "atk": 300,
+    "def": 500,
+    "attribute": 6,
+    "race": 10
+  },
+  {
+    "id": 191,
+    "level": 2,
+    "rarity": 1,
+    "type": 1,
+    "atk": 450,
+    "def": 700,
+    "attribute": 6,
+    "race": 10
+  },
+  {
+    "id": 192,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 700,
+    "def": 950,
+    "attribute": 5,
+    "race": 10
+  },
+  {
+    "id": 193,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 650,
+    "def": 1000,
+    "attribute": 6,
+    "race": 10
+  },
+  {
+    "id": 194,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 750,
+    "def": 900,
+    "attribute": 6,
+    "race": 10
+  },
+  {
+    "id": 195,
+    "level": 4,
+    "rarity": 1,
+    "type": 1,
+    "atk": 1050,
+    "def": 1100,
+    "attribute": 6,
+    "race": 10
+  },
+  {
+    "id": 196,
+    "level": 4,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1100,
+    "def": 1150,
+    "attribute": 6,
+    "race": 10
+  },
+  {
+    "id": 197,
+    "level": 5,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1350,
+    "def": 1250,
+    "attribute": 5,
+    "race": 10
+  },
+  {
+    "id": 198,
+    "level": 5,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1400,
+    "def": 1200,
+    "attribute": 6,
+    "race": 10
+  },
+  {
+    "id": 199,
+    "level": 5,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1500,
+    "def": 1300,
+    "attribute": 6,
+    "race": 10,
+    "effect": "onSummon:tempAtkBonus(ownMonster,300)"
+  },
+  {
+    "id": 200,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1750,
+    "def": 1450,
+    "attribute": 6,
+    "race": 10,
+    "effect": "onSummon:buffField(250,{r=10})"
+  },
+  {
+    "id": 201,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1700,
+    "def": 1500,
+    "attribute": 5,
+    "race": 10,
+    "effect": "onDestroyByBattle:draw(self,2)"
+  },
+  {
+    "id": 202,
+    "level": 7,
+    "rarity": 4,
+    "type": 1,
+    "atk": 2000,
+    "def": 1650,
+    "attribute": 6,
+    "race": 10,
+    "effect": "onSummon:tempAtkBonus(ownMonster,500)"
+  },
+  {
+    "id": 203,
+    "level": 7,
+    "rarity": 4,
+    "type": 1,
+    "atk": 2050,
+    "def": 1700,
+    "attribute": 6,
+    "race": 10,
+    "effect": "onSummon:buffField(350,{r=10})"
+  },
+  {
+    "id": 204,
+    "level": 7,
+    "rarity": 6,
+    "type": 1,
+    "atk": 2250,
+    "def": 1850,
+    "attribute": 6,
+    "race": 10,
+    "effect": "onSummon:buffField(400,{r=10})"
+  },
+  {
+    "id": 205,
+    "level": 8,
+    "rarity": 6,
+    "type": 1,
+    "atk": 2500,
+    "def": 2000,
+    "attribute": 5,
+    "race": 10,
+    "effect": "onSummon:tempAtkBonus(ownMonster,600)"
+  },
+  {
+    "id": 206,
+    "level": 8,
+    "rarity": 8,
+    "type": 1,
+    "atk": 2700,
+    "def": 2100,
+    "attribute": 6,
+    "race": 10,
+    "effect": "onSummon:buffField(500,{r=10})"
+  },
+  {
+    "id": 207,
+    "level": 9,
+    "rarity": 8,
+    "type": 1,
+    "atk": 2600,
+    "def": 1950,
+    "attribute": 6,
+    "race": 10,
+    "effect": "passive:passive_directAttack()"
+  },
+  {
+    "id": 208,
+    "level": 1,
+    "rarity": 1,
+    "type": 1,
+    "atk": 300,
+    "def": 400,
+    "attribute": 1,
+    "race": 11
+  },
+  {
+    "id": 209,
+    "level": 2,
+    "rarity": 1,
+    "type": 1,
+    "atk": 500,
+    "def": 600,
+    "attribute": 1,
+    "race": 11
+  },
+  {
+    "id": 210,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 750,
+    "def": 800,
+    "attribute": 5,
+    "race": 11
+  },
+  {
+    "id": 211,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 850,
+    "def": 700,
+    "attribute": 1,
+    "race": 11
+  },
+  {
+    "id": 212,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 900,
+    "def": 650,
+    "attribute": 1,
+    "race": 11
+  },
+  {
+    "id": 213,
+    "level": 4,
+    "rarity": 1,
+    "type": 1,
+    "atk": 1100,
+    "def": 900,
+    "attribute": 5,
+    "race": 11
+  },
+  {
+    "id": 214,
+    "level": 4,
+    "rarity": 1,
+    "type": 1,
+    "atk": 1200,
+    "def": 1000,
+    "attribute": 1,
+    "race": 11
+  },
+  {
+    "id": 215,
+    "level": 4,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1350,
+    "def": 1100,
+    "attribute": 1,
+    "race": 11
+  },
+  {
+    "id": 216,
+    "level": 5,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1500,
+    "def": 1300,
+    "attribute": 5,
+    "race": 11
+  },
+  {
+    "id": 217,
+    "level": 5,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1600,
+    "def": 1200,
+    "attribute": 1,
+    "race": 11
+  },
+  {
+    "id": 218,
+    "level": 5,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1700,
+    "def": 1400,
+    "attribute": 1,
+    "race": 11,
+    "effect": "onSummon:buffField(200,{r=11})"
+  },
+  {
+    "id": 219,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1900,
+    "def": 1600,
+    "attribute": 5,
+    "race": 11,
+    "effect": "onSummon:tempAtkBonus(ownMonster,300)"
+  },
+  {
+    "id": 220,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 2000,
+    "def": 1500,
+    "attribute": 1,
+    "race": 11,
+    "effect": "onSummon:buffField(300,{r=11})"
+  },
+  {
+    "id": 221,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 2100,
+    "def": 1700,
+    "attribute": 1,
+    "race": 11,
+    "effect": "onSummon:dealDamage(opponent,400)"
+  },
+  {
+    "id": 222,
+    "level": 7,
+    "rarity": 4,
+    "type": 1,
+    "atk": 2200,
+    "def": 1800,
+    "attribute": 5,
+    "race": 11,
+    "effect": "onSummon:tempAtkBonus(ownMonster,400)"
+  },
+  {
+    "id": 223,
+    "level": 7,
+    "rarity": 4,
+    "type": 1,
+    "atk": 2300,
+    "def": 1900,
+    "attribute": 1,
+    "race": 11,
+    "effect": "onSummon:buffField(400,{r=11})"
+  },
+  {
+    "id": 224,
+    "level": 7,
+    "rarity": 6,
+    "type": 1,
+    "atk": 2500,
+    "def": 2100,
+    "attribute": 1,
+    "race": 11,
+    "effect": "onSummon:buffField(500,{r=11})"
+  },
+  {
+    "id": 225,
+    "level": 8,
+    "rarity": 6,
+    "type": 1,
+    "atk": 2600,
+    "def": 2200,
+    "attribute": 5,
+    "race": 11,
+    "effect": "onSummon:tempAtkBonus(ownMonster,500)"
+  },
+  {
+    "id": 226,
+    "level": 8,
+    "rarity": 8,
+    "type": 1,
+    "atk": 2700,
+    "def": 2300,
+    "attribute": 1,
+    "race": 11,
+    "effect": "onSummon:buffField(600,{r=11})"
+  },
+  {
+    "id": 227,
+    "level": 9,
+    "rarity": 8,
+    "type": 1,
+    "atk": 2800,
+    "def": 2400,
+    "attribute": 1,
+    "race": 11,
+    "effect": "onSummon:debuffField(400,300)"
+  },
+  {
+    "id": 228,
+    "level": 1,
+    "rarity": 1,
+    "type": 1,
+    "atk": 400,
+    "def": 200,
+    "attribute": 3,
+    "race": 12
+  },
+  {
+    "id": 229,
+    "level": 2,
+    "rarity": 1,
+    "type": 1,
+    "atk": 600,
+    "def": 300,
+    "attribute": 3,
+    "race": 12
+  },
+  {
+    "id": 230,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 850,
+    "def": 450,
+    "attribute": 1,
+    "race": 12
+  },
+  {
+    "id": 231,
+    "level": 3,
+    "rarity": 1,
+    "type": 1,
+    "atk": 900,
+    "def": 500,
+    "attribute": 3,
+    "race": 12
+  },
+  {
+    "id": 232,
+    "level": 4,
+    "rarity": 1,
+    "type": 1,
+    "atk": 1100,
+    "def": 600,
+    "attribute": 3,
+    "race": 12
+  },
+  {
+    "id": 233,
+    "level": 4,
+    "rarity": 1,
+    "type": 1,
+    "atk": 1200,
+    "def": 650,
+    "attribute": 1,
+    "race": 12
+  },
+  {
+    "id": 234,
+    "level": 4,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1350,
+    "def": 700,
+    "attribute": 3,
+    "race": 12
+  },
+  {
+    "id": 235,
+    "level": 5,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1500,
+    "def": 800,
+    "attribute": 3,
+    "race": 12
+  },
+  {
+    "id": 236,
+    "level": 5,
+    "rarity": 2,
+    "type": 1,
+    "atk": 1600,
+    "def": 850,
+    "attribute": 1,
+    "race": 12
+  },
+  {
+    "id": 237,
+    "level": 5,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1750,
+    "def": 900,
+    "attribute": 3,
+    "race": 12,
+    "effect": "onSummon:dealDamage(opponent,400)"
+  },
+  {
+    "id": 238,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 1900,
+    "def": 1000,
+    "attribute": 3,
+    "race": 12,
+    "effect": "onSummon:dealDamage(opponent,500)"
+  },
+  {
+    "id": 239,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 2050,
+    "def": 1100,
+    "attribute": 1,
+    "race": 12,
+    "effect": "onSummon:dealDamage(opponent,600)"
+  },
+  {
+    "id": 240,
+    "level": 6,
+    "rarity": 4,
+    "type": 1,
+    "atk": 2150,
+    "def": 1050,
+    "attribute": 3,
+    "race": 12,
+    "effect": "onSummon:tempAtkBonus(ownMonster,400)"
+  },
+  {
+    "id": 241,
+    "level": 7,
+    "rarity": 4,
+    "type": 1,
+    "atk": 2300,
+    "def": 1200,
+    "attribute": 3,
+    "race": 12,
+    "effect": "onSummon:dealDamage(opponent,700)"
+  },
+  {
+    "id": 242,
+    "level": 7,
+    "rarity": 6,
+    "type": 1,
+    "atk": 2500,
+    "def": 1500,
+    "attribute": 3,
+    "race": 12,
+    "effect": "onSummon:dealDamage(opponent,800)"
+  },
+  {
+    "id": 243,
+    "level": 8,
+    "rarity": 6,
+    "type": 1,
+    "atk": 2650,
+    "def": 1700,
+    "attribute": 1,
+    "race": 12,
+    "effect": "onSummon:tempAtkBonus(ownMonster,500)"
+  },
+  {
+    "id": 244,
+    "level": 8,
+    "rarity": 8,
+    "type": 1,
+    "atk": 2800,
+    "def": 1900,
+    "attribute": 3,
+    "race": 12,
+    "effect": "onSummon:dealDamage(opponent,1000)"
+  },
+  {
+    "id": 245,
+    "level": 9,
+    "rarity": 8,
+    "type": 1,
+    "atk": 2900,
+    "def": 2000,
+    "attribute": 3,
+    "race": 12,
+    "effect": "onDestroyByOpponent:dealDamage(opponent,1500)"
+  },
+  {
+    "id": 246,
+    "level": 7,
+    "rarity": 6,
+    "type": 2,
+    "atk": 2400,
+    "def": 2000,
+    "attribute": 3,
+    "race": 1,
+    "effect": "onSummon:dealDamage(opponent,500)"
+  },
+  {
+    "id": 247,
+    "level": 9,
+    "rarity": 8,
+    "type": 2,
+    "atk": 3100,
+    "def": 2600,
+    "attribute": 3,
+    "race": 1,
+    "effect": "onSummon:debuffField(500,400)"
+  },
+  {
+    "id": 248,
+    "level": 6,
+    "rarity": 6,
+    "type": 2,
+    "atk": 2000,
+    "def": 1800,
+    "attribute": 2,
+    "race": 2,
+    "effect": "onSummon:draw(self,1)"
+  },
+  {
+    "id": 249,
+    "level": 8,
+    "rarity": 8,
+    "type": 2,
+    "atk": 2600,
+    "def": 2200,
+    "attribute": 2,
+    "race": 2,
+    "effect": "onSummon:bounceStrongestOpp()"
+  },
+  {
+    "id": 250,
+    "level": 7,
+    "rarity": 6,
+    "type": 2,
+    "atk": 2500,
+    "def": 2100,
+    "attribute": 5,
+    "race": 3,
+    "effect": "onSummon:buffField(300,{r=3})"
+  },
+  {
+    "id": 251,
+    "level": 8,
+    "rarity": 8,
+    "type": 2,
+    "atk": 2800,
+    "def": 2400,
+    "attribute": 5,
+    "race": 3,
+    "effect": "onSummon:permAtkBonus(ownMonster,500)"
+  },
+  {
+    "id": 252,
+    "level": 6,
+    "rarity": 6,
+    "type": 2,
+    "atk": 2200,
+    "def": 1600,
+    "attribute": 5,
+    "race": 4,
+    "effect": "onSummon:tempAtkBonus(ownMonster,400)"
+  },
+  {
+    "id": 253,
+    "level": 8,
+    "rarity": 8,
+    "type": 2,
+    "atk": 2700,
+    "def": 2000,
+    "attribute": 5,
+    "race": 4,
+    "effect": "onSummon:dealDamage(opponent,600)"
+  },
+  {
+    "id": 254,
+    "level": 6,
+    "rarity": 6,
+    "type": 2,
+    "atk": 1800,
+    "def": 2200,
+    "attribute": 5,
+    "race": 5,
+    "effect": "onSummon:gainLP(self,800)"
+  },
+  {
+    "id": 255,
+    "level": 8,
+    "rarity": 8,
+    "type": 2,
+    "atk": 2200,
+    "def": 2800,
+    "attribute": 5,
+    "race": 5,
+    "effect": "onSummon:permDefBonus(ownMonster,500)"
+  },
+  {
+    "id": 256,
+    "level": 7,
+    "rarity": 6,
+    "type": 2,
+    "atk": 2000,
+    "def": 2600,
+    "attribute": 5,
+    "race": 6,
+    "effect": "onSummon:tempDefBonus(ownMonster,500)"
+  },
+  {
+    "id": 257,
+    "level": 9,
+    "rarity": 8,
+    "type": 2,
+    "atk": 2400,
+    "def": 3200,
+    "attribute": 5,
+    "race": 6,
+    "effect": "onSummon:debuffField(300,500)"
+  },
+  {
+    "id": 258,
+    "level": 7,
+    "rarity": 6,
+    "type": 2,
+    "atk": 2300,
+    "def": 1800,
+    "attribute": 3,
+    "race": 7,
+    "effect": "onSummon:dealDamage(opponent,500)"
+  },
+  {
+    "id": 259,
+    "level": 8,
+    "rarity": 8,
+    "type": 2,
+    "atk": 2600,
+    "def": 2100,
+    "attribute": 3,
+    "race": 7,
+    "effect": "passive:passive_phoenixRevival()"
+  },
+  {
+    "id": 260,
+    "level": 6,
+    "rarity": 6,
+    "type": 2,
+    "atk": 2100,
+    "def": 1900,
+    "attribute": 2,
+    "race": 8,
+    "effect": "onSummon:tempDebuffField(400)"
+  },
+  {
+    "id": 261,
+    "level": 8,
+    "rarity": 8,
+    "type": 2,
+    "atk": 2500,
+    "def": 2300,
+    "attribute": 2,
+    "race": 8,
+    "effect": "onDestroyByBattle:draw(self,2)"
+  },
+  {
+    "id": 262,
+    "level": 7,
+    "rarity": 6,
+    "type": 2,
+    "atk": 2200,
+    "def": 2400,
+    "attribute": 4,
+    "race": 9,
+    "effect": "onSummon:gainLP(self,600)"
+  },
+  {
+    "id": 263,
+    "level": 8,
+    "rarity": 8,
+    "type": 2,
+    "atk": 2600,
+    "def": 2700,
+    "attribute": 4,
+    "race": 9,
+    "effect": "onSummon:buffField(400,{a=4})"
+  },
+  {
+    "id": 264,
+    "level": 6,
+    "rarity": 6,
+    "type": 2,
+    "atk": 2000,
+    "def": 1700,
+    "attribute": 5,
+    "race": 10,
+    "effect": "onSummon:draw(self,1)"
+  },
+  {
+    "id": 265,
+    "level": 8,
+    "rarity": 8,
+    "type": 2,
+    "atk": 2500,
+    "def": 2000,
+    "attribute": 5,
+    "race": 10,
+    "effect": "onSummon:tempAtkBonus(ownMonster,600)"
+  },
+  {
+    "id": 266,
+    "rarity": 1,
+    "type": 3,
+    "effect": "onSummon:dealDamage(opponent,300)",
+    "spellType": 1
+  },
+  {
+    "id": 267,
+    "rarity": 1,
+    "type": 3,
+    "effect": "onSummon:dealDamage(opponent,400)",
+    "spellType": 1
+  },
+  {
+    "id": 268,
+    "rarity": 1,
+    "type": 3,
+    "effect": "onSummon:dealDamage(opponent,500)",
+    "spellType": 1
+  },
+  {
+    "id": 269,
+    "rarity": 1,
+    "type": 3,
+    "effect": "onSummon:gainLP(self,300)",
+    "spellType": 1
+  },
+  {
+    "id": 270,
+    "rarity": 1,
+    "type": 3,
+    "effect": "onSummon:gainLP(self,500)",
+    "spellType": 1
+  },
+  {
+    "id": 271,
+    "rarity": 1,
+    "type": 3,
+    "effect": "onSummon:gainLP(self,800)",
+    "spellType": 1
+  },
+  {
+    "id": 272,
+    "rarity": 1,
+    "type": 3,
+    "effect": "onSummon:dealDamage(opponent,600)",
+    "spellType": 1
+  },
+  {
+    "id": 273,
+    "rarity": 1,
+    "type": 3,
+    "effect": "onSummon:dealDamage(opponent,800)",
+    "spellType": 1
+  },
+  {
+    "id": 274,
+    "rarity": 2,
+    "type": 3,
+    "effect": "onSummon:tempAtkBonus(ownMonster,300)",
+    "spellType": 2
+  },
+  {
+    "id": 275,
+    "rarity": 2,
+    "type": 3,
+    "effect": "onSummon:tempAtkBonus(ownMonster,400)",
+    "spellType": 2
+  },
+  {
+    "id": 276,
+    "rarity": 2,
+    "type": 3,
+    "effect": "onSummon:tempAtkBonus(ownMonster,500)",
+    "spellType": 2
+  },
+  {
+    "id": 277,
+    "rarity": 2,
+    "type": 3,
+    "effect": "onSummon:tempDebuffField(300)",
+    "spellType": 1
+  },
+  {
+    "id": 278,
+    "rarity": 2,
+    "type": 3,
+    "effect": "onSummon:draw(self,1)",
+    "spellType": 1
+  },
+  {
+    "id": 279,
+    "rarity": 2,
+    "type": 3,
+    "effect": "onSummon:tempDefBonus(ownMonster,400)",
+    "spellType": 2
+  },
+  {
+    "id": 280,
+    "rarity": 2,
+    "type": 3,
+    "effect": "onSummon:gainLP(self,600)",
+    "spellType": 1
+  },
+  {
+    "id": 281,
+    "rarity": 4,
+    "type": 3,
+    "effect": "onSummon:dealDamage(opponent,1000)",
+    "spellType": 1
+  },
+  {
+    "id": 282,
+    "rarity": 4,
+    "type": 3,
+    "effect": "onSummon:dealDamage(opponent,1200)",
+    "spellType": 1
+  },
+  {
+    "id": 283,
+    "rarity": 4,
+    "type": 3,
+    "effect": "onSummon:dealDamage(opponent,1500)",
+    "spellType": 1
+  },
+  {
+    "id": 284,
+    "rarity": 4,
+    "type": 3,
+    "effect": "onSummon:buffField(300,{a=3})",
+    "spellType": 1
+  },
+  {
+    "id": 285,
+    "rarity": 4,
+    "type": 3,
+    "effect": "onSummon:buffField(300,{a=4})",
+    "spellType": 1
+  },
+  {
+    "id": 286,
+    "rarity": 4,
+    "type": 3,
+    "effect": "onSummon:permAtkBonus(ownMonster,500)",
+    "spellType": 2
+  },
+  {
+    "id": 287,
+    "rarity": 6,
+    "type": 3,
+    "effect": "onSummon:bounceStrongestOpp()",
+    "spellType": 1
+  },
+  {
+    "id": 288,
+    "rarity": 6,
+    "type": 3,
+    "effect": "onSummon:bounceAllOppMonsters()",
+    "spellType": 1
+  },
+  {
+    "id": 289,
+    "rarity": 6,
+    "type": 3,
+    "effect": "onSummon:draw(self,2)",
+    "spellType": 1
+  },
+  {
+    "id": 290,
+    "rarity": 8,
+    "type": 3,
+    "effect": "onSummon:dealDamage(opponent,2000)",
+    "spellType": 1
+  },
+  {
+    "id": 291,
+    "rarity": 1,
+    "type": 4,
+    "effect": "onAttack:cancelAttack()",
+    "trapTrigger": 1
+  },
+  {
+    "id": 292,
+    "rarity": 1,
+    "type": 4,
+    "effect": "onAttack:cancelAttack()",
+    "trapTrigger": 1
+  },
+  {
+    "id": 293,
+    "rarity": 1,
+    "type": 4,
+    "effect": "onAttack:cancelAttack()",
+    "trapTrigger": 1
+  },
+  {
+    "id": 294,
+    "rarity": 1,
+    "type": 4,
+    "effect": "onAttack:cancelAttack()",
+    "trapTrigger": 1
+  },
+  {
+    "id": 295,
+    "rarity": 2,
+    "type": 4,
+    "effect": "onAttack:destroyAttacker()",
+    "trapTrigger": 1
+  },
+  {
+    "id": 296,
+    "rarity": 2,
+    "type": 4,
+    "effect": "onOwnMonsterAttacked:cancelAttack()",
+    "trapTrigger": 2
+  },
+  {
+    "id": 297,
+    "rarity": 2,
+    "type": 4,
+    "effect": "onAttack:destroyAttacker()",
+    "trapTrigger": 1
+  },
+  {
+    "id": 298,
+    "rarity": 4,
+    "type": 4,
+    "effect": "onOpponentSummon:destroySummonedIf(1500)",
+    "trapTrigger": 3
+  },
+  {
+    "id": 299,
+    "rarity": 4,
+    "type": 4,
+    "effect": "onOpponentSummon:destroySummonedIf(1500)",
+    "trapTrigger": 3
+  },
+  {
+    "id": 300,
+    "rarity": 4,
+    "type": 4,
+    "effect": "onAttack:destroyAttacker()",
+    "trapTrigger": 1
+  },
+  {
+    "id": 301,
+    "rarity": 6,
+    "type": 4,
+    "effect": "onAttack:destroyAttacker()",
+    "trapTrigger": 1
+  },
+  {
+    "id": 302,
+    "rarity": 6,
+    "type": 4,
+    "effect": "onAttack:destroyAttacker()",
+    "trapTrigger": 1
+  },
+  {
+    "id": 303,
+    "rarity": 1,
+    "type": 5,
+    "atkBonus": 500
+  },
+  {
+    "id": 304,
+    "rarity": 1,
+    "type": 5,
+    "defBonus": 600
+  },
+  {
+    "id": 305,
+    "rarity": 2,
+    "type": 5,
+    "atkBonus": 300,
+    "defBonus": 200
+  },
+  {
+    "id": 306,
+    "rarity": 2,
+    "type": 5,
+    "atkBonus": 200,
+    "defBonus": 400
+  },
+  {
+    "id": 307,
+    "rarity": 4,
+    "type": 5,
+    "atkBonus": 800
+  },
+  {
+    "id": 308,
+    "rarity": 2,
+    "type": 3,
+    "spellType": 4,
+    "effect": "passive:buffField(200,{r=5})"
+  },
+  {
+    "id": 309,
+    "rarity": 2,
+    "type": 3,
+    "spellType": 4,
+    "effect": "passive:buffField(300,{r=1})"
+  },
+  {
+    "id": 310,
+    "rarity": 2,
+    "type": 3,
+    "spellType": 4,
+    "effect": "passive:buffField(250,{r=2})"
+  }
+]

--- a/public/base.tcg-src/locales/de_cards_description.json
+++ b/public/base.tcg-src/locales/de_cards_description.json
@@ -1,1 +1,1552 @@
-[{"id":1,"name":"Feuersalamander","description":"Ein von lebenden Flammen umhüllter Salamander. Seine Schuppen brennen bei Berührung."},{"id":2,"name":"Steingolem","description":"Ein massiver, animierter Steinkoloß. Fast unverwundbar gegen physische Angriffe."},{"id":3,"name":"Meeresschlange","description":"Ein schlangenartiges Ungeheuer aus den Tiefen des Ozeans."},{"id":4,"name":"Winddracos","description":"Ein flinker Drache, der auf Windströmungen reitet."},{"id":5,"name":"Schattenwolf","description":"Ein Wolf, der sich zwischen den Schatten bewegt."},{"id":6,"name":"Kristallritter","description":"Ein in magischen Kristall gehüllter Ritter."},{"id":7,"name":"Eisenkrieger","description":"Ein erfahrener Krieger in schwerem Eisenpanzer."},{"id":8,"name":"Korallenfee","description":"Eine zarte Fee, die in bunten Korallenriffen lebt."},{"id":9,"name":"Sturmfalke","description":"Ein Falke, der Stürme aus seinen Schwingen ruft."},{"id":10,"name":"Sonnenriester","description":"Ein Priester, der der Sonnengottheit geweiht ist."},{"id":11,"name":"Knochenschütze","description":"Ein Skelettsoldaat mit tödlicher Präzision."},{"id":12,"name":"Moostroll","description":"Ein uralter Troll, bedeckt mit Moos und Flechten."},{"id":13,"name":"Gluteber","description":"Ein riesiger Eber, der aus lodernden Flammen besteht."},{"id":14,"name":"Tiefsee-Angler","description":"Ein bizarres Wesen aus den finstersten Meerestiefen."},{"id":15,"name":"Silberpaladin","description":"Ein edler Paladin in silbernem Rüstzeug."},{"id":16,"name":"Magmakrabbe","description":"Eine Krabbe aus erstarrter Lava mit glühenden Augen."},{"id":17,"name":"Frosthexe","description":"[Effekt] Bei Beschwörung: Gegner verliert 300 LP."},{"id":18,"name":"Dunkelassassin","description":"[Effekt] Wenn dieses Monster ein Monster im Kampf zerstört: Ziehe 1 Karte."},{"id":19,"name":"Naturschamane","description":"[Effekt] Bei Beschwörung: Alle deine Erde-Monster erhalten +200 ATK/DEF."},{"id":20,"name":"Flammenphönix","description":"[Effekt] Wenn durch den Gegner zerstört: Kann einmalig mit 500 weniger ATK als Spezialbeschwörung aus dem Friedhof beschworen werden."},{"id":21,"name":"Blitzmagier","description":"[Effekt] Bei Beschwörung: Füge dem Gegner 500 Schaden zu."},{"id":22,"name":"Heiliger Krieger","description":"[Passiv] Im Kampf gegen ein DUNKEL-Monster: +500 ATK."},{"id":23,"name":"Schattensensenmann","description":"[Effekt] Wenn dieses Monster ein Monster zerstört: Erhalte 500 LP."},{"id":24,"name":"Wasserdrache","description":"[Effekt] Bei Beschwörung: Füge 1 Wasserkarte aus deinem Deck in deine Hand hinzu."},{"id":25,"name":"Jungdrache","description":"Ein Drache der Stufe 9 mit einem besonderen Effekt."},{"id":26,"name":"Rekrut","description":"Ein Krieger der Stufe 1."},{"id":27,"name":"Fußsoldat","description":"Ein Krieger der Stufe 2."},{"id":28,"name":"Lanzenträger","description":"Ein Krieger der Stufe 2."},{"id":29,"name":"Speerkämpfer","description":"Ein Krieger der Stufe 3."},{"id":30,"name":"Lanzenreiter","description":"Ein Krieger der Stufe 3."},{"id":31,"name":"Schwertläufer","description":"Ein Krieger der Stufe 3."},{"id":32,"name":"Klingenwächter","description":"Ein Krieger der Stufe 3."},{"id":33,"name":"Schildmeister","description":"Ein Krieger der Stufe 4."},{"id":34,"name":"Schlachtführer","description":"Ein Krieger der Stufe 4."},{"id":35,"name":"Klingenherr","description":"Ein Krieger der Stufe 4."},{"id":36,"name":"Schlachttitan","description":"Ein Krieger der Stufe 4."},{"id":37,"name":"Schwertlord","description":"Ein Krieger der Stufe 5."},{"id":38,"name":"Schildlord","description":"Ein Krieger der Stufe 5."},{"id":39,"name":"Kriegsfürst","description":"Ein Krieger der Stufe 5. Bei Beschwörung: Ein Monster erhält +400 ATK/DEF bis zum Zugende."},{"id":40,"name":"Klingenfürst","description":"Ein Krieger der Stufe 5. Bei Beschwörung: Ein Monster erhält dauerhaft +200 ATK/DEF."},{"id":41,"name":"Schlachtgott","description":"Ein Krieger der Stufe 6. Bei Beschwörung: Alle Krieger auf deinem Feld erhalten +200 ATK/DEF."},{"id":42,"name":"Fußsoldat II","description":"Ein Krieger der Stufe 6. Bei Beschwörung: Ein Monster erhält +500 ATK/DEF bis zum Zugende."},{"id":43,"name":"Schildknappe II","description":"Ein Krieger der Stufe 6. Wenn durch Kampf zerstört: Ziehe 1 Karte."},{"id":44,"name":"Klingenläufer II","description":"Ein Krieger der Stufe 6. Bei Beschwörung: Ein Monster erhält dauerhaft +300 ATK/DEF."},{"id":45,"name":"Wyrmling","description":"Ein imposanter Drache der Stufe 1."},{"id":46,"name":"Drachenwelpe","description":"Ein imposanter Drache der Stufe 1."},{"id":47,"name":"Schuppenfuchs","description":"Ein imposanter Drache der Stufe 1."},{"id":48,"name":"Kleindrakon","description":"Ein imposanter Drache der Stufe 1."},{"id":49,"name":"Eisdrachenwelpe","description":"Ein imposanter Drache der Stufe 2."},{"id":50,"name":"Klauenechse","description":"Ein imposanter Drache der Stufe 2."},{"id":51,"name":"Nestdrache","description":"Ein imposanter Drache der Stufe 2."},{"id":52,"name":"Schuppenlizard","description":"Ein imposanter Drache der Stufe 2."},{"id":53,"name":"Bergwyrm","description":"Ein imposanter Drache der Stufe 3."},{"id":54,"name":"Schuppenwächter","description":"Ein imposanter Drache der Stufe 3."},{"id":55,"name":"Klauenwurm","description":"Ein imposanter Drache der Stufe 3."},{"id":56,"name":"Höhlendrache","description":"Ein imposanter Drache der Stufe 3."},{"id":57,"name":"Moordrache","description":"Ein imposanter Drache der Stufe 3."},{"id":58,"name":"Sumpfwyrm","description":"Ein imposanter Drache der Stufe 3."},{"id":59,"name":"Walddrache","description":"Ein imposanter Drache der Stufe 3."},{"id":60,"name":"Steinwyrm","description":"Ein imposanter Drache der Stufe 3."},{"id":61,"name":"Schattenwyrm","description":"Ein imposanter Drache der Stufe 4."},{"id":62,"name":"Eisdrache","description":"Ein imposanter Drache der Stufe 4."},{"id":63,"name":"Felsdrache","description":"Ein imposanter Drache der Stufe 4."},{"id":64,"name":"Dunkelwyrm","description":"Ein imposanter Drache der Stufe 4."},{"id":65,"name":"Sturmdrache","description":"Ein imposanter Drache der Stufe 4."},{"id":66,"name":"Blitzwyrm","description":"Ein imposanter Drache der Stufe 4."},{"id":67,"name":"Glutwyrm","description":"Ein imposanter Drache der Stufe 4."},{"id":68,"name":"Aschenwyrm","description":"Ein imposanter Drache der Stufe 4."},{"id":69,"name":"Drachenfürst","description":"Ein imposanter Drache der Stufe 5."},{"id":70,"name":"Drachenritter","description":"Ein imposanter Drache der Stufe 5."},{"id":71,"name":"Titanwyrm","description":"Ein imposanter Drache der Stufe 5."},{"id":72,"name":"Hordenwyrm","description":"Ein imposanter Drache der Stufe 5."},{"id":73,"name":"Uraltdrache","description":"Ein imposanter Drache der Stufe 5."},{"id":74,"name":"Urwyrm","description":"Ein imposanter Drache der Stufe 5."},{"id":75,"name":"Wyrmgott","description":"Ein imposanter Drache der Stufe 6."},{"id":76,"name":"Drachengott","description":"Ein imposanter Drache der Stufe 6."},{"id":77,"name":"Schuppengott","description":"Ein imposanter Drache der Stufe 6."},{"id":78,"name":"Drachenkaiser","description":"Ein imposanter Drache der Stufe 6."},{"id":79,"name":"Runenfuchs","description":"Ein magisches Wesen der Stufe 1."},{"id":80,"name":"Zauberlehrling","description":"Ein magisches Wesen der Stufe 1."},{"id":81,"name":"Kristallauge","description":"Ein magisches Wesen der Stufe 1."},{"id":82,"name":"Arkangeist","description":"Ein magisches Wesen der Stufe 1."},{"id":83,"name":"Runensprite","description":"Ein magisches Wesen der Stufe 2."},{"id":84,"name":"Arkaner Kobold","description":"Ein magisches Wesen der Stufe 2."},{"id":85,"name":"Zauberfuchs","description":"Ein magisches Wesen der Stufe 2."},{"id":86,"name":"Kristallsprite","description":"Ein magisches Wesen der Stufe 2."},{"id":87,"name":"Runenwächter","description":"Ein magisches Wesen der Stufe 3."},{"id":88,"name":"Zauberschüler","description":"Ein magisches Wesen der Stufe 3."},{"id":89,"name":"Kristallseher","description":"Ein magisches Wesen der Stufe 3."},{"id":90,"name":"Arkanist","description":"Ein magisches Wesen der Stufe 3."},{"id":91,"name":"Runenmeister","description":"Ein magisches Wesen der Stufe 3."},{"id":92,"name":"Zauberwächter","description":"Ein magisches Wesen der Stufe 3."},{"id":93,"name":"Kristallwächter","description":"Ein magisches Wesen der Stufe 3."},{"id":94,"name":"Arkanwächter","description":"Ein magisches Wesen der Stufe 3."},{"id":95,"name":"Geistbeschwörer","description":"Ein magisches Wesen der Stufe 4."},{"id":96,"name":"Zauberhändler","description":"Ein magisches Wesen der Stufe 4."},{"id":97,"name":"Kristallmagier","description":"Ein magisches Wesen der Stufe 4."},{"id":98,"name":"Runenmagier","description":"Ein magisches Wesen der Stufe 4."},{"id":99,"name":"Arkanzauberer","description":"Ein magisches Wesen der Stufe 4."},{"id":100,"name":"Beschwörer","description":"Ein magisches Wesen der Stufe 4."},{"id":101,"name":"Elementarmagier","description":"Ein magisches Wesen der Stufe 4."},{"id":102,"name":"Mystiker","description":"Ein magisches Wesen der Stufe 4."},{"id":103,"name":"Erzbeschwörer","description":"Ein magisches Wesen der Stufe 5."},{"id":104,"name":"Runenlord","description":"Ein magisches Wesen der Stufe 5."},{"id":105,"name":"Zaubertitan","description":"Ein magisches Wesen der Stufe 5."},{"id":106,"name":"Kristalltitan","description":"Ein magisches Wesen der Stufe 5."},{"id":107,"name":"Arkanmeister","description":"Ein magisches Wesen der Stufe 5."},{"id":108,"name":"Zaubermeister","description":"Ein magisches Wesen der Stufe 5."},{"id":109,"name":"Magiergott","description":"Ein magisches Wesen der Stufe 6."},{"id":110,"name":"Runenkaiser","description":"Ein magisches Wesen der Stufe 6."},{"id":111,"name":"Zauberkönig","description":"Ein magisches Wesen der Stufe 6."},{"id":112,"name":"Arkankaiser","description":"Ein magisches Wesen der Stufe 6."},{"id":113,"name":"Schildknappe","description":"Ein kampferprobter Krieger der Stufe 1."},{"id":114,"name":"Schwertlehrling","description":"Ein kampferprobter Krieger der Stufe 1."},{"id":115,"name":"Speerträger","description":"Ein kampferprobter Krieger der Stufe 1."},{"id":116,"name":"Bogenschütze","description":"Ein kampferprobter Krieger der Stufe 1."},{"id":117,"name":"Schwertknecht","description":"Ein kampferprobter Krieger der Stufe 2."},{"id":118,"name":"Schildläufer","description":"Ein kampferprobter Krieger der Stufe 2."},{"id":119,"name":"Speersöldner","description":"Ein kampferprobter Krieger der Stufe 2."},{"id":120,"name":"Bogensöldner","description":"Ein kampferprobter Krieger der Stufe 2."},{"id":121,"name":"Klingenläufer","description":"Ein kampferprobter Krieger der Stufe 3."},{"id":122,"name":"Schwertsoldat","description":"Ein kampferprobter Krieger der Stufe 3."},{"id":123,"name":"Schildgardist","description":"Ein kampferprobter Krieger der Stufe 3."},{"id":124,"name":"Lanzenwächter","description":"Ein kampferprobter Krieger der Stufe 3."},{"id":125,"name":"Axtkrieger","description":"Ein kampferprobter Krieger der Stufe 3."},{"id":126,"name":"Schwertgardist","description":"Ein kampferprobter Krieger der Stufe 3."},{"id":127,"name":"Schildritter","description":"Ein kampferprobter Krieger der Stufe 3."},{"id":128,"name":"Lanzensoldat","description":"Ein kampferprobter Krieger der Stufe 3."},{"id":129,"name":"Klinge","description":"Ein kampferprobter Krieger der Stufe 4."},{"id":130,"name":"Rüstungsbrecher","description":"Ein kampferprobter Krieger der Stufe 4."},{"id":131,"name":"Schwertritter","description":"Ein kampferprobter Krieger der Stufe 4."},{"id":132,"name":"Schildheld","description":"Ein kampferprobter Krieger der Stufe 4."},{"id":133,"name":"Lanzenkämpfer","description":"Ein kampferprobter Krieger der Stufe 4."},{"id":134,"name":"Klingenritter","description":"Ein kampferprobter Krieger der Stufe 4."},{"id":135,"name":"Schwertmeister","description":"Ein kampferprobter Krieger der Stufe 4."},{"id":136,"name":"Axtmeister","description":"Ein kampferprobter Krieger der Stufe 4."},{"id":137,"name":"Kriegerheld","description":"Ein kampferprobter Krieger der Stufe 5."},{"id":138,"name":"Klingenmeister","description":"Ein kampferprobter Krieger der Stufe 5."},{"id":139,"name":"Schwerttitan","description":"Ein kampferprobter Krieger der Stufe 5."},{"id":140,"name":"Schildtitan","description":"Ein kampferprobter Krieger der Stufe 5."},{"id":141,"name":"Lanzenfürst","description":"Ein kampferprobter Krieger der Stufe 5."},{"id":142,"name":"Schlachtherr","description":"Ein kampferprobter Krieger der Stufe 5."},{"id":143,"name":"Klingengott","description":"Ein kampferprobter Krieger der Stufe 6."},{"id":144,"name":"Schwertkaiser","description":"Ein kampferprobter Krieger der Stufe 6."},{"id":145,"name":"Schildkaiser","description":"Ein kampferprobter Krieger der Stufe 6."},{"id":146,"name":"Kriegskönig","description":"Ein kampferprobter Krieger der Stufe 6."},{"id":147,"name":"Funkenelf","description":"Ein feuriges Wesen der Stufe 1."},{"id":148,"name":"Glutwurm","description":"Ein feuriges Wesen der Stufe 1."},{"id":149,"name":"Aschemaus","description":"Ein feuriges Wesen der Stufe 1."},{"id":150,"name":"Zunderkäfer","description":"Ein feuriges Wesen der Stufe 1."},{"id":151,"name":"Kohlekatze","description":"Ein feuriges Wesen der Stufe 2."},{"id":152,"name":"Gluttaube","description":"Ein feuriges Wesen der Stufe 2."},{"id":153,"name":"Lavamolch","description":"Ein feuriges Wesen der Stufe 2."},{"id":154,"name":"Flammenwelpe","description":"Ein feuriges Wesen der Stufe 2."},{"id":155,"name":"Brandspinne","description":"Ein feuriges Wesen der Stufe 3."},{"id":156,"name":"Feuerfuchs","description":"Ein feuriges Wesen der Stufe 3."},{"id":157,"name":"Glutlöwe","description":"Ein feuriges Wesen der Stufe 3."},{"id":158,"name":"Lavakröte","description":"Ein feuriges Wesen der Stufe 3."},{"id":159,"name":"Aschegeist","description":"Ein feuriges Wesen der Stufe 3."},{"id":160,"name":"Pyrofalk","description":"Ein feuriges Wesen der Stufe 3."},{"id":161,"name":"Rußtroll","description":"Ein feuriges Wesen der Stufe 3."},{"id":162,"name":"Feuerkrabbe","description":"Ein feuriges Wesen der Stufe 3."},{"id":163,"name":"Flammenbär","description":"Ein feuriges Wesen der Stufe 4."},{"id":164,"name":"Glutstier","description":"Ein feuriges Wesen der Stufe 4."},{"id":165,"name":"Lavaechse","description":"Ein feuriges Wesen der Stufe 4."},{"id":166,"name":"Feuerbock","description":"Ein feuriges Wesen der Stufe 4."},{"id":167,"name":"Pyrowolf","description":"Ein feuriges Wesen der Stufe 4."},{"id":168,"name":"Glutkobold","description":"Ein feuriges Wesen der Stufe 4."},{"id":169,"name":"Lavariese","description":"Ein feuriges Wesen der Stufe 4."},{"id":170,"name":"Flammenoger","description":"Ein feuriges Wesen der Stufe 4."},{"id":171,"name":"Feuertitan","description":"Ein feuriges Wesen der Stufe 5."},{"id":172,"name":"Glutdrache","description":"Ein feuriges Wesen der Stufe 5."},{"id":173,"name":"Pyrohai","description":"Ein feuriges Wesen der Stufe 5."},{"id":174,"name":"Flammenfürst","description":"Ein feuriges Wesen der Stufe 5."},{"id":175,"name":"Lavagigant","description":"Ein feuriges Wesen der Stufe 5."},{"id":176,"name":"Feueroger","description":"Ein feuriges Wesen der Stufe 5."},{"id":177,"name":"Lavakönig","description":"Ein feuriges Wesen der Stufe 6."},{"id":178,"name":"Glutkoloss","description":"Ein feuriges Wesen der Stufe 6."},{"id":179,"name":"Pyrogigant","description":"Ein feuriges Wesen der Stufe 6."},{"id":180,"name":"Feuerteufel","description":"Ein feuriges Wesen der Stufe 6."},{"id":181,"name":"Moosgeist","description":"Ein pflanzliches Wesen der Stufe 1."},{"id":182,"name":"Blütenfee","description":"Ein pflanzliches Wesen der Stufe 1."},{"id":183,"name":"Pilzkobold","description":"Ein pflanzliches Wesen der Stufe 1."},{"id":184,"name":"Rankengeist","description":"Ein pflanzliches Wesen der Stufe 1."},{"id":185,"name":"Dornenrebe","description":"Ein pflanzliches Wesen der Stufe 2."},{"id":186,"name":"Waldgeist","description":"Ein pflanzliches Wesen der Stufe 2."},{"id":187,"name":"Baumelf","description":"Ein pflanzliches Wesen der Stufe 2."},{"id":188,"name":"Blütensprite","description":"Ein pflanzliches Wesen der Stufe 2."},{"id":189,"name":"Dornenranke","description":"Ein pflanzliches Wesen der Stufe 3."},{"id":190,"name":"Wurzelgeist","description":"Ein pflanzliches Wesen der Stufe 3."},{"id":191,"name":"Waldkobold","description":"Ein pflanzliches Wesen der Stufe 3."},{"id":192,"name":"Waldtroll","description":"Ein pflanzliches Wesen der Stufe 3."},{"id":193,"name":"Baumgardist","description":"Ein pflanzliches Wesen der Stufe 3."},{"id":194,"name":"Pilzriese","description":"Ein pflanzliches Wesen der Stufe 3."},{"id":195,"name":"Blütenwächter","description":"Ein pflanzliches Wesen der Stufe 3."},{"id":196,"name":"Rankenläufer","description":"Ein pflanzliches Wesen der Stufe 3."},{"id":197,"name":"Baumschildkröte","description":"Ein pflanzliches Wesen der Stufe 4."},{"id":198,"name":"Waldriese","description":"Ein pflanzliches Wesen der Stufe 4."},{"id":199,"name":"Blütendrache","description":"Ein pflanzliches Wesen der Stufe 4."},{"id":200,"name":"Mooskoloss","description":"Ein pflanzliches Wesen der Stufe 4."},{"id":201,"name":"Dornenritter","description":"Ein pflanzliches Wesen der Stufe 4."},{"id":202,"name":"Waldwächter","description":"Ein pflanzliches Wesen der Stufe 4."},{"id":203,"name":"Rankengardist","description":"Ein pflanzliches Wesen der Stufe 4."},{"id":204,"name":"Baumgigant","description":"Ein pflanzliches Wesen der Stufe 4."},{"id":205,"name":"Waldgigant","description":"Ein pflanzliches Wesen der Stufe 5."},{"id":206,"name":"Dornenfürst","description":"Ein pflanzliches Wesen der Stufe 5."},{"id":207,"name":"Blütentitan","description":"Ein pflanzliches Wesen der Stufe 5."},{"id":208,"name":"Rankentitan","description":"Ein pflanzliches Wesen der Stufe 5."},{"id":209,"name":"Waldkoloss","description":"Ein pflanzliches Wesen der Stufe 5."},{"id":210,"name":"Moostitan","description":"Ein pflanzliches Wesen der Stufe 5."},{"id":211,"name":"Waldgott","description":"Ein pflanzliches Wesen der Stufe 6."},{"id":212,"name":"Blütengott","description":"Ein pflanzliches Wesen der Stufe 6."},{"id":213,"name":"Rankenkaiser","description":"Ein pflanzliches Wesen der Stufe 6."},{"id":214,"name":"Dornenkönig","description":"Ein pflanzliches Wesen der Stufe 6."},{"id":215,"name":"Kieselwurm","description":"Ein steinernes Wesen mit hoher Verteidigung, Stufe 1."},{"id":216,"name":"Granitlaus","description":"Ein steinernes Wesen mit hoher Verteidigung, Stufe 1."},{"id":217,"name":"Felskäfer","description":"Ein steinernes Wesen mit hoher Verteidigung, Stufe 1."},{"id":218,"name":"Sandgeist","description":"Ein steinernes Wesen mit hoher Verteidigung, Stufe 1."},{"id":219,"name":"Erdmaus","description":"Ein steinernes Wesen mit hoher Verteidigung, Stufe 2."},{"id":220,"name":"Steinkobold","description":"Ein steinernes Wesen mit hoher Verteidigung, Stufe 2."},{"id":221,"name":"Felskröte","description":"Ein steinernes Wesen mit hoher Verteidigung, Stufe 2."},{"id":222,"name":"Granitechse","description":"Ein steinernes Wesen mit hoher Verteidigung, Stufe 2."},{"id":223,"name":"Felskrabbler","description":"Ein steinernes Wesen mit hoher Verteidigung, Stufe 3."},{"id":224,"name":"Erdgeist","description":"Ein steinernes Wesen mit hoher Verteidigung, Stufe 3."},{"id":225,"name":"Granitgolem","description":"Ein steinernes Wesen mit hoher Verteidigung, Stufe 3."},{"id":226,"name":"Bergkröte","description":"Ein steinernes Wesen mit hoher Verteidigung, Stufe 3."},{"id":227,"name":"Steinechse","description":"Ein steinernes Wesen mit hoher Verteidigung, Stufe 3."},{"id":228,"name":"Felskatze","description":"Ein steinernes Wesen mit hoher Verteidigung, Stufe 3."},{"id":229,"name":"Granitbär","description":"Ein steinernes Wesen mit hoher Verteidigung, Stufe 3."},{"id":230,"name":"Erdkobold","description":"Ein steinernes Wesen mit hoher Verteidigung, Stufe 3."},{"id":231,"name":"Berggolem","description":"Ein steinernes Wesen mit hoher Verteidigung, Stufe 4."},{"id":232,"name":"Steinriese","description":"Ein steinernes Wesen mit hoher Verteidigung, Stufe 4."},{"id":233,"name":"Felskoloss","description":"Ein steinernes Wesen mit hoher Verteidigung, Stufe 4."},{"id":234,"name":"Granitgigant","description":"Ein steinernes Wesen mit hoher Verteidigung, Stufe 4."},{"id":235,"name":"Erdritter","description":"Ein steinernes Wesen mit hoher Verteidigung, Stufe 4."},{"id":236,"name":"Steinwächter","description":"Ein steinernes Wesen mit hoher Verteidigung, Stufe 4."},{"id":237,"name":"Felsgardist","description":"Ein steinernes Wesen mit hoher Verteidigung, Stufe 4."},{"id":238,"name":"Bergwächter","description":"Ein steinernes Wesen mit hoher Verteidigung, Stufe 4."},{"id":239,"name":"Steinkoloss","description":"Ein steinernes Wesen mit hoher Verteidigung, Stufe 5."},{"id":240,"name":"Felstitan","description":"Ein steinernes Wesen mit hoher Verteidigung, Stufe 5."},{"id":241,"name":"Granitfürst","description":"Ein steinernes Wesen mit hoher Verteidigung, Stufe 5."},{"id":242,"name":"Erdriese","description":"Ein steinernes Wesen mit hoher Verteidigung, Stufe 5."},{"id":243,"name":"Bergfürst","description":"Ein steinernes Wesen mit hoher Verteidigung, Stufe 5."},{"id":244,"name":"Felsriese","description":"Ein steinernes Wesen mit hoher Verteidigung, Stufe 5."},{"id":245,"name":"Steinkaiser","description":"Ein steinernes Wesen mit hoher Verteidigung, Stufe 6."},{"id":246,"name":"Erdkoloss","description":"[Fusion] Winddracos + Schattenwolf."},{"id":247,"name":"Granitkönig","description":"[Fusion] Eisenkrieger + Knochenschütze."},{"id":248,"name":"Felsgott","description":"[Fusion] Moordrache + Sumpfwyrm."},{"id":249,"name":"Flatterwing","description":"[Fusion] Eisdrache + Dunkelwyrm."},{"id":250,"name":"Federgeist","description":"[Fusion] Schwertläufer + Schlachtführer."},{"id":251,"name":"Windvogel","description":"[Fusion] Schlachttitan + Schildlord."},{"id":252,"name":"Luftwelpe","description":"[Fusion] Kristallauge + Arkangeist."},{"id":253,"name":"Sturmtaube","description":"[Fusion] Zauberfuchs + Runenwächter."},{"id":254,"name":"Windgeist","description":"[Fusion] Elementarmagier + Mystiker."},{"id":255,"name":"Äthervogel","description":"[Fusion] Kristalltitan + Zaubermeister."},{"id":256,"name":"Federdrache","description":"[Fusion] Speersöldner + Bogensöldner."},{"id":257,"name":"Wolkenläufer","description":"[Fusion] Lanzenwächter + Schwertgardist."},{"id":258,"name":"Gewitterfalke","description":"[Fusion] Schwerttitan + Schildtitan."},{"id":259,"name":"Windwächter","description":"[Fusion] Schlachtherr + Klingengott."},{"id":260,"name":"Federrabe","description":"[Fusion] Flammenwelpe + Brandspinne."},{"id":261,"name":"Luftgeist","description":"[Fusion] Lavakröte + Pyrofalk."},{"id":262,"name":"Äthertaucher","description":"[Fusion] Glutdrache + Pyrohai."},{"id":263,"name":"Windkreischer","description":"[Fusion] Lavakönig + Pyrogigant."},{"id":264,"name":"Sturmschwalbe","description":"[Fusion] Waldtroll + Baumgardist."},{"id":265,"name":"Himmelsjäger","description":"[Fusion] Rankenläufer + Waldriese."},{"id":266,"name":"Feuerpfeil","description":"Füge dem Gegner 300 Schadenspunkte zu."},{"id":267,"name":"Flammenspeer","description":"Füge dem Gegner 400 Schadenspunkte zu."},{"id":268,"name":"Feuerstoß","description":"Füge dem Gegner 500 Schadenspunkte zu."},{"id":269,"name":"Heilkraut","description":"Erhalte 300 Lebenspunkte."},{"id":270,"name":"Heiltrank","description":"Erhalte 500 Lebenspunkte."},{"id":271,"name":"Heilquelle","description":"Erhalte 800 Lebenspunkte."},{"id":272,"name":"Flammenball","description":"Füge dem Gegner 600 Schadenspunkte zu."},{"id":273,"name":"Feuerball","description":"Füge dem Gegner 800 Schadenspunkte zu."},{"id":274,"name":"Schwertschärfe","description":"Wähle ein Monster auf deinem Spielfeld. Es erhält bis zum Ende des Zuges +300 ATK/DEF."},{"id":275,"name":"Kraftstoß","description":"Wähle ein Monster auf deinem Spielfeld. Es erhält bis zum Ende des Zuges +400 ATK/DEF."},{"id":276,"name":"Kraftschub","description":"Wähle ein Monster auf deinem Spielfeld. Es erhält bis zum Ende des Zuges +500 ATK/DEF."},{"id":277,"name":"Schwächungsnebel","description":"Alle Monster des Gegners verlieren bis zum Ende des Zuges 300 ATK/DEF."},{"id":278,"name":"Kartenzug","description":"Ziehe 1 Karte."},{"id":279,"name":"Schildverstärkung","description":"Wähle ein Monster auf deinem Spielfeld. Es erhält bis zum Ende des Zuges +400 DEF."},{"id":280,"name":"Heiliger Segen","description":"Erhalte 600 Lebenspunkte."},{"id":281,"name":"Feuersturm","description":"Füge dem Gegner 1000 Schadenspunkte zu."},{"id":282,"name":"Inferno","description":"Füge dem Gegner 1200 Schadenspunkte zu."},{"id":283,"name":"Flammeninferno","description":"Füge dem Gegner 1500 Schadenspunkte zu."},{"id":284,"name":"Feuerpakt","description":"Alle Feuer-Monster auf deinem Feld erhalten dauerhaft +300 ATK/DEF."},{"id":285,"name":"Wasserpakt","description":"Alle Wasser-Monster auf deinem Feld erhalten dauerhaft +300 ATK/DEF."},{"id":286,"name":"Dunkles Ritual","description":"Wähle ein Monster auf deinem Spielfeld. Es erhält dauerhaft +500 ATK/DEF."},{"id":287,"name":"Verbannung","description":"Das stärkste Monster des Gegners wird auf die Hand zurückgeschickt."},{"id":288,"name":"Massenverbannung","description":"Alle Monster des Gegners werden auf die Hand zurückgeschickt."},{"id":289,"name":"Doppelzug","description":"Ziehe 2 Karten."},{"id":290,"name":"Apokalypse","description":"Füge dem Gegner 2000 Schadenspunkte zu."},{"id":291,"name":"Spiegelkraft","description":"Aktiviere wenn ein Monster des Gegners angreift: Negiere den Angriff."},{"id":292,"name":"Schutzbarriere","description":"Aktiviere wenn ein Monster des Gegners angreift: Negiere den Angriff."},{"id":293,"name":"Bannschild","description":"Aktiviere wenn ein Monster des Gegners angreift: Negiere den Angriff."},{"id":294,"name":"Abwehrwall","description":"Aktiviere wenn ein Monster des Gegners angreift: Negiere den Angriff."},{"id":295,"name":"Fallgrube","description":"Aktiviere wenn ein Monster des Gegners angreift: Zerstöre das angreifende Monster."},{"id":296,"name":"Spiegelschild","description":"Aktiviere wenn eines deiner Monster angegriffen wird: Negiere den Angriff."},{"id":297,"name":"Todesstoß","description":"Aktiviere wenn ein Monster des Gegners angreift: Zerstöre das angreifende Monster."},{"id":298,"name":"Fallenloch","description":"Aktiviere wenn der Gegner ein Monster mit 1500+ ATK beschwört: Zerstöre es."},{"id":299,"name":"Beschwörungsfalle","description":"Aktiviere wenn der Gegner ein Monster mit 1500+ ATK beschwört: Zerstöre es."},{"id":300,"name":"Vernichtungsfalle","description":"Aktiviere wenn ein Monster des Gegners angreift: Zerstöre das angreifende Monster."},{"id":301,"name":"Hinterhalt","description":"Aktiviere wenn ein Monster des Gegners angreift: Zerstöre das angreifende Monster."},{"id":302,"name":"Todesfalle","description":"Aktiviere wenn ein Monster des Gegners angreift: Zerstöre das angreifende Monster."},{"id":303,"name":"Klinge der Geschworenen","description":"Ein Schwert, geschmiedet im Feuer der Loyalität. Erhöht die Angriffskraft des ausgerüsteten Monsters."},{"id":304,"name":"Eiserne Schildmauer","description":"Ein massiver Schild aus gehärtetem Stahl. Verstärkt die Verteidigung des ausgerüsteten Monsters."},{"id":305,"name":"Drachenzahn-Speer","description":"Ein Speer, gefertigt aus dem Zahn eines uralten Drachen. Stärkt Angriff und Verteidigung."},{"id":306,"name":"Schattenmantel","description":"Ein Umhang aus gewebter Dunkelheit. Bietet Schutz und verstärkt leicht den Angriff."},{"id":307,"name":"Hellebarde des Kriegsherrn","description":"Die legendäre Waffe eines gefallenen Generals. Verleiht immense Angriffskraft."}]
+[
+  {
+    "id": 1,
+    "name": "Feuersalamander",
+    "description": "Ein von lebenden Flammen umhüllter Salamander. Seine Schuppen brennen bei Berührung."
+  },
+  {
+    "id": 2,
+    "name": "Steingolem",
+    "description": "Ein massiver, animierter Steinkoloß. Fast unverwundbar gegen physische Angriffe."
+  },
+  {
+    "id": 3,
+    "name": "Meeresschlange",
+    "description": "Ein schlangenartiges Ungeheuer aus den Tiefen des Ozeans."
+  },
+  {
+    "id": 4,
+    "name": "Winddracos",
+    "description": "Ein flinker Drache, der auf Windströmungen reitet."
+  },
+  {
+    "id": 5,
+    "name": "Schattenwolf",
+    "description": "Ein Wolf, der sich zwischen den Schatten bewegt."
+  },
+  {
+    "id": 6,
+    "name": "Kristallritter",
+    "description": "Ein in magischen Kristall gehüllter Ritter."
+  },
+  {
+    "id": 7,
+    "name": "Eisenkrieger",
+    "description": "Ein erfahrener Krieger in schwerem Eisenpanzer."
+  },
+  {
+    "id": 8,
+    "name": "Korallenfee",
+    "description": "Eine zarte Fee, die in bunten Korallenriffen lebt."
+  },
+  {
+    "id": 9,
+    "name": "Sturmfalke",
+    "description": "Ein Falke, der Stürme aus seinen Schwingen ruft."
+  },
+  {
+    "id": 10,
+    "name": "Sonnenriester",
+    "description": "Ein Priester, der der Sonnengottheit geweiht ist."
+  },
+  {
+    "id": 11,
+    "name": "Knochenschütze",
+    "description": "Ein Skelettsoldaat mit tödlicher Präzision."
+  },
+  {
+    "id": 12,
+    "name": "Moostroll",
+    "description": "Ein uralter Troll, bedeckt mit Moos und Flechten."
+  },
+  {
+    "id": 13,
+    "name": "Gluteber",
+    "description": "Ein riesiger Eber, der aus lodernden Flammen besteht."
+  },
+  {
+    "id": 14,
+    "name": "Tiefsee-Angler",
+    "description": "Ein bizarres Wesen aus den finstersten Meerestiefen."
+  },
+  {
+    "id": 15,
+    "name": "Silberpaladin",
+    "description": "Ein edler Paladin in silbernem Rüstzeug."
+  },
+  {
+    "id": 16,
+    "name": "Magmakrabbe",
+    "description": "Eine Krabbe aus erstarrter Lava mit glühenden Augen."
+  },
+  {
+    "id": 17,
+    "name": "Frosthexe",
+    "description": "[Effekt] Bei Beschwörung: Gegner verliert 300 LP."
+  },
+  {
+    "id": 18,
+    "name": "Dunkelassassin",
+    "description": "[Effekt] Wenn dieses Monster ein Monster im Kampf zerstört: Ziehe 1 Karte."
+  },
+  {
+    "id": 19,
+    "name": "Naturschamane",
+    "description": "[Effekt] Bei Beschwörung: Alle deine Erde-Monster erhalten +200 ATK/DEF."
+  },
+  {
+    "id": 20,
+    "name": "Flammenphönix",
+    "description": "[Effekt] Wenn durch den Gegner zerstört: Kann einmalig mit 500 weniger ATK als Spezialbeschwörung aus dem Friedhof beschworen werden."
+  },
+  {
+    "id": 21,
+    "name": "Blitzmagier",
+    "description": "[Effekt] Bei Beschwörung: Füge dem Gegner 500 Schaden zu."
+  },
+  {
+    "id": 22,
+    "name": "Heiliger Krieger",
+    "description": "[Passiv] Im Kampf gegen ein DUNKEL-Monster: +500 ATK."
+  },
+  {
+    "id": 23,
+    "name": "Schattensensenmann",
+    "description": "[Effekt] Wenn dieses Monster ein Monster zerstört: Erhalte 500 LP."
+  },
+  {
+    "id": 24,
+    "name": "Wasserdrache",
+    "description": "[Effekt] Bei Beschwörung: Füge 1 Wasserkarte aus deinem Deck in deine Hand hinzu."
+  },
+  {
+    "id": 25,
+    "name": "Jungdrache",
+    "description": "Ein Drache der Stufe 9 mit einem besonderen Effekt."
+  },
+  {
+    "id": 26,
+    "name": "Rekrut",
+    "description": "Ein Krieger der Stufe 1."
+  },
+  {
+    "id": 27,
+    "name": "Fußsoldat",
+    "description": "Ein Krieger der Stufe 2."
+  },
+  {
+    "id": 28,
+    "name": "Lanzenträger",
+    "description": "Ein Krieger der Stufe 2."
+  },
+  {
+    "id": 29,
+    "name": "Speerkämpfer",
+    "description": "Ein Krieger der Stufe 3."
+  },
+  {
+    "id": 30,
+    "name": "Lanzenreiter",
+    "description": "Ein Krieger der Stufe 3."
+  },
+  {
+    "id": 31,
+    "name": "Schwertläufer",
+    "description": "Ein Krieger der Stufe 3."
+  },
+  {
+    "id": 32,
+    "name": "Klingenwächter",
+    "description": "Ein Krieger der Stufe 3."
+  },
+  {
+    "id": 33,
+    "name": "Schildmeister",
+    "description": "Ein Krieger der Stufe 4."
+  },
+  {
+    "id": 34,
+    "name": "Schlachtführer",
+    "description": "Ein Krieger der Stufe 4."
+  },
+  {
+    "id": 35,
+    "name": "Klingenherr",
+    "description": "Ein Krieger der Stufe 4."
+  },
+  {
+    "id": 36,
+    "name": "Schlachttitan",
+    "description": "Ein Krieger der Stufe 4."
+  },
+  {
+    "id": 37,
+    "name": "Schwertlord",
+    "description": "Ein Krieger der Stufe 5."
+  },
+  {
+    "id": 38,
+    "name": "Schildlord",
+    "description": "Ein Krieger der Stufe 5."
+  },
+  {
+    "id": 39,
+    "name": "Kriegsfürst",
+    "description": "Ein Krieger der Stufe 5. Bei Beschwörung: Ein Monster erhält +400 ATK/DEF bis zum Zugende."
+  },
+  {
+    "id": 40,
+    "name": "Klingenfürst",
+    "description": "Ein Krieger der Stufe 5. Bei Beschwörung: Ein Monster erhält dauerhaft +200 ATK/DEF."
+  },
+  {
+    "id": 41,
+    "name": "Schlachtgott",
+    "description": "Ein Krieger der Stufe 6. Bei Beschwörung: Alle Krieger auf deinem Feld erhalten +200 ATK/DEF."
+  },
+  {
+    "id": 42,
+    "name": "Fußsoldat II",
+    "description": "Ein Krieger der Stufe 6. Bei Beschwörung: Ein Monster erhält +500 ATK/DEF bis zum Zugende."
+  },
+  {
+    "id": 43,
+    "name": "Schildknappe II",
+    "description": "Ein Krieger der Stufe 6. Wenn durch Kampf zerstört: Ziehe 1 Karte."
+  },
+  {
+    "id": 44,
+    "name": "Klingenläufer II",
+    "description": "Ein Krieger der Stufe 6. Bei Beschwörung: Ein Monster erhält dauerhaft +300 ATK/DEF."
+  },
+  {
+    "id": 45,
+    "name": "Wyrmling",
+    "description": "Ein imposanter Drache der Stufe 1."
+  },
+  {
+    "id": 46,
+    "name": "Drachenwelpe",
+    "description": "Ein imposanter Drache der Stufe 1."
+  },
+  {
+    "id": 47,
+    "name": "Schuppenfuchs",
+    "description": "Ein imposanter Drache der Stufe 1."
+  },
+  {
+    "id": 48,
+    "name": "Kleindrakon",
+    "description": "Ein imposanter Drache der Stufe 1."
+  },
+  {
+    "id": 49,
+    "name": "Eisdrachenwelpe",
+    "description": "Ein imposanter Drache der Stufe 2."
+  },
+  {
+    "id": 50,
+    "name": "Klauenechse",
+    "description": "Ein imposanter Drache der Stufe 2."
+  },
+  {
+    "id": 51,
+    "name": "Nestdrache",
+    "description": "Ein imposanter Drache der Stufe 2."
+  },
+  {
+    "id": 52,
+    "name": "Schuppenlizard",
+    "description": "Ein imposanter Drache der Stufe 2."
+  },
+  {
+    "id": 53,
+    "name": "Bergwyrm",
+    "description": "Ein imposanter Drache der Stufe 3."
+  },
+  {
+    "id": 54,
+    "name": "Schuppenwächter",
+    "description": "Ein imposanter Drache der Stufe 3."
+  },
+  {
+    "id": 55,
+    "name": "Klauenwurm",
+    "description": "Ein imposanter Drache der Stufe 3."
+  },
+  {
+    "id": 56,
+    "name": "Höhlendrache",
+    "description": "Ein imposanter Drache der Stufe 3."
+  },
+  {
+    "id": 57,
+    "name": "Moordrache",
+    "description": "Ein imposanter Drache der Stufe 3."
+  },
+  {
+    "id": 58,
+    "name": "Sumpfwyrm",
+    "description": "Ein imposanter Drache der Stufe 3."
+  },
+  {
+    "id": 59,
+    "name": "Walddrache",
+    "description": "Ein imposanter Drache der Stufe 3."
+  },
+  {
+    "id": 60,
+    "name": "Steinwyrm",
+    "description": "Ein imposanter Drache der Stufe 3."
+  },
+  {
+    "id": 61,
+    "name": "Schattenwyrm",
+    "description": "Ein imposanter Drache der Stufe 4."
+  },
+  {
+    "id": 62,
+    "name": "Eisdrache",
+    "description": "Ein imposanter Drache der Stufe 4."
+  },
+  {
+    "id": 63,
+    "name": "Felsdrache",
+    "description": "Ein imposanter Drache der Stufe 4."
+  },
+  {
+    "id": 64,
+    "name": "Dunkelwyrm",
+    "description": "Ein imposanter Drache der Stufe 4."
+  },
+  {
+    "id": 65,
+    "name": "Sturmdrache",
+    "description": "Ein imposanter Drache der Stufe 4."
+  },
+  {
+    "id": 66,
+    "name": "Blitzwyrm",
+    "description": "Ein imposanter Drache der Stufe 4."
+  },
+  {
+    "id": 67,
+    "name": "Glutwyrm",
+    "description": "Ein imposanter Drache der Stufe 4."
+  },
+  {
+    "id": 68,
+    "name": "Aschenwyrm",
+    "description": "Ein imposanter Drache der Stufe 4."
+  },
+  {
+    "id": 69,
+    "name": "Drachenfürst",
+    "description": "Ein imposanter Drache der Stufe 5."
+  },
+  {
+    "id": 70,
+    "name": "Drachenritter",
+    "description": "Ein imposanter Drache der Stufe 5."
+  },
+  {
+    "id": 71,
+    "name": "Titanwyrm",
+    "description": "Ein imposanter Drache der Stufe 5."
+  },
+  {
+    "id": 72,
+    "name": "Hordenwyrm",
+    "description": "Ein imposanter Drache der Stufe 5."
+  },
+  {
+    "id": 73,
+    "name": "Uraltdrache",
+    "description": "Ein imposanter Drache der Stufe 5."
+  },
+  {
+    "id": 74,
+    "name": "Urwyrm",
+    "description": "Ein imposanter Drache der Stufe 5."
+  },
+  {
+    "id": 75,
+    "name": "Wyrmgott",
+    "description": "Ein imposanter Drache der Stufe 6."
+  },
+  {
+    "id": 76,
+    "name": "Drachengott",
+    "description": "Ein imposanter Drache der Stufe 6."
+  },
+  {
+    "id": 77,
+    "name": "Schuppengott",
+    "description": "Ein imposanter Drache der Stufe 6."
+  },
+  {
+    "id": 78,
+    "name": "Drachenkaiser",
+    "description": "Ein imposanter Drache der Stufe 6."
+  },
+  {
+    "id": 79,
+    "name": "Runenfuchs",
+    "description": "Ein magisches Wesen der Stufe 1."
+  },
+  {
+    "id": 80,
+    "name": "Zauberlehrling",
+    "description": "Ein magisches Wesen der Stufe 1."
+  },
+  {
+    "id": 81,
+    "name": "Kristallauge",
+    "description": "Ein magisches Wesen der Stufe 1."
+  },
+  {
+    "id": 82,
+    "name": "Arkangeist",
+    "description": "Ein magisches Wesen der Stufe 1."
+  },
+  {
+    "id": 83,
+    "name": "Runensprite",
+    "description": "Ein magisches Wesen der Stufe 2."
+  },
+  {
+    "id": 84,
+    "name": "Arkaner Kobold",
+    "description": "Ein magisches Wesen der Stufe 2."
+  },
+  {
+    "id": 85,
+    "name": "Zauberfuchs",
+    "description": "Ein magisches Wesen der Stufe 2."
+  },
+  {
+    "id": 86,
+    "name": "Kristallsprite",
+    "description": "Ein magisches Wesen der Stufe 2."
+  },
+  {
+    "id": 87,
+    "name": "Runenwächter",
+    "description": "Ein magisches Wesen der Stufe 3."
+  },
+  {
+    "id": 88,
+    "name": "Zauberschüler",
+    "description": "Ein magisches Wesen der Stufe 3."
+  },
+  {
+    "id": 89,
+    "name": "Kristallseher",
+    "description": "Ein magisches Wesen der Stufe 3."
+  },
+  {
+    "id": 90,
+    "name": "Arkanist",
+    "description": "Ein magisches Wesen der Stufe 3."
+  },
+  {
+    "id": 91,
+    "name": "Runenmeister",
+    "description": "Ein magisches Wesen der Stufe 3."
+  },
+  {
+    "id": 92,
+    "name": "Zauberwächter",
+    "description": "Ein magisches Wesen der Stufe 3."
+  },
+  {
+    "id": 93,
+    "name": "Kristallwächter",
+    "description": "Ein magisches Wesen der Stufe 3."
+  },
+  {
+    "id": 94,
+    "name": "Arkanwächter",
+    "description": "Ein magisches Wesen der Stufe 3."
+  },
+  {
+    "id": 95,
+    "name": "Geistbeschwörer",
+    "description": "Ein magisches Wesen der Stufe 4."
+  },
+  {
+    "id": 96,
+    "name": "Zauberhändler",
+    "description": "Ein magisches Wesen der Stufe 4."
+  },
+  {
+    "id": 97,
+    "name": "Kristallmagier",
+    "description": "Ein magisches Wesen der Stufe 4."
+  },
+  {
+    "id": 98,
+    "name": "Runenmagier",
+    "description": "Ein magisches Wesen der Stufe 4."
+  },
+  {
+    "id": 99,
+    "name": "Arkanzauberer",
+    "description": "Ein magisches Wesen der Stufe 4."
+  },
+  {
+    "id": 100,
+    "name": "Beschwörer",
+    "description": "Ein magisches Wesen der Stufe 4."
+  },
+  {
+    "id": 101,
+    "name": "Elementarmagier",
+    "description": "Ein magisches Wesen der Stufe 4."
+  },
+  {
+    "id": 102,
+    "name": "Mystiker",
+    "description": "Ein magisches Wesen der Stufe 4."
+  },
+  {
+    "id": 103,
+    "name": "Erzbeschwörer",
+    "description": "Ein magisches Wesen der Stufe 5."
+  },
+  {
+    "id": 104,
+    "name": "Runenlord",
+    "description": "Ein magisches Wesen der Stufe 5."
+  },
+  {
+    "id": 105,
+    "name": "Zaubertitan",
+    "description": "Ein magisches Wesen der Stufe 5."
+  },
+  {
+    "id": 106,
+    "name": "Kristalltitan",
+    "description": "Ein magisches Wesen der Stufe 5."
+  },
+  {
+    "id": 107,
+    "name": "Arkanmeister",
+    "description": "Ein magisches Wesen der Stufe 5."
+  },
+  {
+    "id": 108,
+    "name": "Zaubermeister",
+    "description": "Ein magisches Wesen der Stufe 5."
+  },
+  {
+    "id": 109,
+    "name": "Magiergott",
+    "description": "Ein magisches Wesen der Stufe 6."
+  },
+  {
+    "id": 110,
+    "name": "Runenkaiser",
+    "description": "Ein magisches Wesen der Stufe 6."
+  },
+  {
+    "id": 111,
+    "name": "Zauberkönig",
+    "description": "Ein magisches Wesen der Stufe 6."
+  },
+  {
+    "id": 112,
+    "name": "Arkankaiser",
+    "description": "Ein magisches Wesen der Stufe 6."
+  },
+  {
+    "id": 113,
+    "name": "Schildknappe",
+    "description": "Ein kampferprobter Krieger der Stufe 1."
+  },
+  {
+    "id": 114,
+    "name": "Schwertlehrling",
+    "description": "Ein kampferprobter Krieger der Stufe 1."
+  },
+  {
+    "id": 115,
+    "name": "Speerträger",
+    "description": "Ein kampferprobter Krieger der Stufe 1."
+  },
+  {
+    "id": 116,
+    "name": "Bogenschütze",
+    "description": "Ein kampferprobter Krieger der Stufe 1."
+  },
+  {
+    "id": 117,
+    "name": "Schwertknecht",
+    "description": "Ein kampferprobter Krieger der Stufe 2."
+  },
+  {
+    "id": 118,
+    "name": "Schildläufer",
+    "description": "Ein kampferprobter Krieger der Stufe 2."
+  },
+  {
+    "id": 119,
+    "name": "Speersöldner",
+    "description": "Ein kampferprobter Krieger der Stufe 2."
+  },
+  {
+    "id": 120,
+    "name": "Bogensöldner",
+    "description": "Ein kampferprobter Krieger der Stufe 2."
+  },
+  {
+    "id": 121,
+    "name": "Klingenläufer",
+    "description": "Ein kampferprobter Krieger der Stufe 3."
+  },
+  {
+    "id": 122,
+    "name": "Schwertsoldat",
+    "description": "Ein kampferprobter Krieger der Stufe 3."
+  },
+  {
+    "id": 123,
+    "name": "Schildgardist",
+    "description": "Ein kampferprobter Krieger der Stufe 3."
+  },
+  {
+    "id": 124,
+    "name": "Lanzenwächter",
+    "description": "Ein kampferprobter Krieger der Stufe 3."
+  },
+  {
+    "id": 125,
+    "name": "Axtkrieger",
+    "description": "Ein kampferprobter Krieger der Stufe 3."
+  },
+  {
+    "id": 126,
+    "name": "Schwertgardist",
+    "description": "Ein kampferprobter Krieger der Stufe 3."
+  },
+  {
+    "id": 127,
+    "name": "Schildritter",
+    "description": "Ein kampferprobter Krieger der Stufe 3."
+  },
+  {
+    "id": 128,
+    "name": "Lanzensoldat",
+    "description": "Ein kampferprobter Krieger der Stufe 3."
+  },
+  {
+    "id": 129,
+    "name": "Klinge",
+    "description": "Ein kampferprobter Krieger der Stufe 4."
+  },
+  {
+    "id": 130,
+    "name": "Rüstungsbrecher",
+    "description": "Ein kampferprobter Krieger der Stufe 4."
+  },
+  {
+    "id": 131,
+    "name": "Schwertritter",
+    "description": "Ein kampferprobter Krieger der Stufe 4."
+  },
+  {
+    "id": 132,
+    "name": "Schildheld",
+    "description": "Ein kampferprobter Krieger der Stufe 4."
+  },
+  {
+    "id": 133,
+    "name": "Lanzenkämpfer",
+    "description": "Ein kampferprobter Krieger der Stufe 4."
+  },
+  {
+    "id": 134,
+    "name": "Klingenritter",
+    "description": "Ein kampferprobter Krieger der Stufe 4."
+  },
+  {
+    "id": 135,
+    "name": "Schwertmeister",
+    "description": "Ein kampferprobter Krieger der Stufe 4."
+  },
+  {
+    "id": 136,
+    "name": "Axtmeister",
+    "description": "Ein kampferprobter Krieger der Stufe 4."
+  },
+  {
+    "id": 137,
+    "name": "Kriegerheld",
+    "description": "Ein kampferprobter Krieger der Stufe 5."
+  },
+  {
+    "id": 138,
+    "name": "Klingenmeister",
+    "description": "Ein kampferprobter Krieger der Stufe 5."
+  },
+  {
+    "id": 139,
+    "name": "Schwerttitan",
+    "description": "Ein kampferprobter Krieger der Stufe 5."
+  },
+  {
+    "id": 140,
+    "name": "Schildtitan",
+    "description": "Ein kampferprobter Krieger der Stufe 5."
+  },
+  {
+    "id": 141,
+    "name": "Lanzenfürst",
+    "description": "Ein kampferprobter Krieger der Stufe 5."
+  },
+  {
+    "id": 142,
+    "name": "Schlachtherr",
+    "description": "Ein kampferprobter Krieger der Stufe 5."
+  },
+  {
+    "id": 143,
+    "name": "Klingengott",
+    "description": "Ein kampferprobter Krieger der Stufe 6."
+  },
+  {
+    "id": 144,
+    "name": "Schwertkaiser",
+    "description": "Ein kampferprobter Krieger der Stufe 6."
+  },
+  {
+    "id": 145,
+    "name": "Schildkaiser",
+    "description": "Ein kampferprobter Krieger der Stufe 6."
+  },
+  {
+    "id": 146,
+    "name": "Kriegskönig",
+    "description": "Ein kampferprobter Krieger der Stufe 6."
+  },
+  {
+    "id": 147,
+    "name": "Funkenelf",
+    "description": "Ein feuriges Wesen der Stufe 1."
+  },
+  {
+    "id": 148,
+    "name": "Glutwurm",
+    "description": "Ein feuriges Wesen der Stufe 1."
+  },
+  {
+    "id": 149,
+    "name": "Aschemaus",
+    "description": "Ein feuriges Wesen der Stufe 1."
+  },
+  {
+    "id": 150,
+    "name": "Zunderkäfer",
+    "description": "Ein feuriges Wesen der Stufe 1."
+  },
+  {
+    "id": 151,
+    "name": "Kohlekatze",
+    "description": "Ein feuriges Wesen der Stufe 2."
+  },
+  {
+    "id": 152,
+    "name": "Gluttaube",
+    "description": "Ein feuriges Wesen der Stufe 2."
+  },
+  {
+    "id": 153,
+    "name": "Lavamolch",
+    "description": "Ein feuriges Wesen der Stufe 2."
+  },
+  {
+    "id": 154,
+    "name": "Flammenwelpe",
+    "description": "Ein feuriges Wesen der Stufe 2."
+  },
+  {
+    "id": 155,
+    "name": "Brandspinne",
+    "description": "Ein feuriges Wesen der Stufe 3."
+  },
+  {
+    "id": 156,
+    "name": "Feuerfuchs",
+    "description": "Ein feuriges Wesen der Stufe 3."
+  },
+  {
+    "id": 157,
+    "name": "Glutlöwe",
+    "description": "Ein feuriges Wesen der Stufe 3."
+  },
+  {
+    "id": 158,
+    "name": "Lavakröte",
+    "description": "Ein feuriges Wesen der Stufe 3."
+  },
+  {
+    "id": 159,
+    "name": "Aschegeist",
+    "description": "Ein feuriges Wesen der Stufe 3."
+  },
+  {
+    "id": 160,
+    "name": "Pyrofalk",
+    "description": "Ein feuriges Wesen der Stufe 3."
+  },
+  {
+    "id": 161,
+    "name": "Rußtroll",
+    "description": "Ein feuriges Wesen der Stufe 3."
+  },
+  {
+    "id": 162,
+    "name": "Feuerkrabbe",
+    "description": "Ein feuriges Wesen der Stufe 3."
+  },
+  {
+    "id": 163,
+    "name": "Flammenbär",
+    "description": "Ein feuriges Wesen der Stufe 4."
+  },
+  {
+    "id": 164,
+    "name": "Glutstier",
+    "description": "Ein feuriges Wesen der Stufe 4."
+  },
+  {
+    "id": 165,
+    "name": "Lavaechse",
+    "description": "Ein feuriges Wesen der Stufe 4."
+  },
+  {
+    "id": 166,
+    "name": "Feuerbock",
+    "description": "Ein feuriges Wesen der Stufe 4."
+  },
+  {
+    "id": 167,
+    "name": "Pyrowolf",
+    "description": "Ein feuriges Wesen der Stufe 4."
+  },
+  {
+    "id": 168,
+    "name": "Glutkobold",
+    "description": "Ein feuriges Wesen der Stufe 4."
+  },
+  {
+    "id": 169,
+    "name": "Lavariese",
+    "description": "Ein feuriges Wesen der Stufe 4."
+  },
+  {
+    "id": 170,
+    "name": "Flammenoger",
+    "description": "Ein feuriges Wesen der Stufe 4."
+  },
+  {
+    "id": 171,
+    "name": "Feuertitan",
+    "description": "Ein feuriges Wesen der Stufe 5."
+  },
+  {
+    "id": 172,
+    "name": "Glutdrache",
+    "description": "Ein feuriges Wesen der Stufe 5."
+  },
+  {
+    "id": 173,
+    "name": "Pyrohai",
+    "description": "Ein feuriges Wesen der Stufe 5."
+  },
+  {
+    "id": 174,
+    "name": "Flammenfürst",
+    "description": "Ein feuriges Wesen der Stufe 5."
+  },
+  {
+    "id": 175,
+    "name": "Lavagigant",
+    "description": "Ein feuriges Wesen der Stufe 5."
+  },
+  {
+    "id": 176,
+    "name": "Feueroger",
+    "description": "Ein feuriges Wesen der Stufe 5."
+  },
+  {
+    "id": 177,
+    "name": "Lavakönig",
+    "description": "Ein feuriges Wesen der Stufe 6."
+  },
+  {
+    "id": 178,
+    "name": "Glutkoloss",
+    "description": "Ein feuriges Wesen der Stufe 6."
+  },
+  {
+    "id": 179,
+    "name": "Pyrogigant",
+    "description": "Ein feuriges Wesen der Stufe 6."
+  },
+  {
+    "id": 180,
+    "name": "Feuerteufel",
+    "description": "Ein feuriges Wesen der Stufe 6."
+  },
+  {
+    "id": 181,
+    "name": "Moosgeist",
+    "description": "Ein pflanzliches Wesen der Stufe 1."
+  },
+  {
+    "id": 182,
+    "name": "Blütenfee",
+    "description": "Ein pflanzliches Wesen der Stufe 1."
+  },
+  {
+    "id": 183,
+    "name": "Pilzkobold",
+    "description": "Ein pflanzliches Wesen der Stufe 1."
+  },
+  {
+    "id": 184,
+    "name": "Rankengeist",
+    "description": "Ein pflanzliches Wesen der Stufe 1."
+  },
+  {
+    "id": 185,
+    "name": "Dornenrebe",
+    "description": "Ein pflanzliches Wesen der Stufe 2."
+  },
+  {
+    "id": 186,
+    "name": "Waldgeist",
+    "description": "Ein pflanzliches Wesen der Stufe 2."
+  },
+  {
+    "id": 187,
+    "name": "Baumelf",
+    "description": "Ein pflanzliches Wesen der Stufe 2."
+  },
+  {
+    "id": 188,
+    "name": "Blütensprite",
+    "description": "Ein pflanzliches Wesen der Stufe 2."
+  },
+  {
+    "id": 189,
+    "name": "Dornenranke",
+    "description": "Ein pflanzliches Wesen der Stufe 3."
+  },
+  {
+    "id": 190,
+    "name": "Wurzelgeist",
+    "description": "Ein pflanzliches Wesen der Stufe 3."
+  },
+  {
+    "id": 191,
+    "name": "Waldkobold",
+    "description": "Ein pflanzliches Wesen der Stufe 3."
+  },
+  {
+    "id": 192,
+    "name": "Waldtroll",
+    "description": "Ein pflanzliches Wesen der Stufe 3."
+  },
+  {
+    "id": 193,
+    "name": "Baumgardist",
+    "description": "Ein pflanzliches Wesen der Stufe 3."
+  },
+  {
+    "id": 194,
+    "name": "Pilzriese",
+    "description": "Ein pflanzliches Wesen der Stufe 3."
+  },
+  {
+    "id": 195,
+    "name": "Blütenwächter",
+    "description": "Ein pflanzliches Wesen der Stufe 3."
+  },
+  {
+    "id": 196,
+    "name": "Rankenläufer",
+    "description": "Ein pflanzliches Wesen der Stufe 3."
+  },
+  {
+    "id": 197,
+    "name": "Baumschildkröte",
+    "description": "Ein pflanzliches Wesen der Stufe 4."
+  },
+  {
+    "id": 198,
+    "name": "Waldriese",
+    "description": "Ein pflanzliches Wesen der Stufe 4."
+  },
+  {
+    "id": 199,
+    "name": "Blütendrache",
+    "description": "Ein pflanzliches Wesen der Stufe 4."
+  },
+  {
+    "id": 200,
+    "name": "Mooskoloss",
+    "description": "Ein pflanzliches Wesen der Stufe 4."
+  },
+  {
+    "id": 201,
+    "name": "Dornenritter",
+    "description": "Ein pflanzliches Wesen der Stufe 4."
+  },
+  {
+    "id": 202,
+    "name": "Waldwächter",
+    "description": "Ein pflanzliches Wesen der Stufe 4."
+  },
+  {
+    "id": 203,
+    "name": "Rankengardist",
+    "description": "Ein pflanzliches Wesen der Stufe 4."
+  },
+  {
+    "id": 204,
+    "name": "Baumgigant",
+    "description": "Ein pflanzliches Wesen der Stufe 4."
+  },
+  {
+    "id": 205,
+    "name": "Waldgigant",
+    "description": "Ein pflanzliches Wesen der Stufe 5."
+  },
+  {
+    "id": 206,
+    "name": "Dornenfürst",
+    "description": "Ein pflanzliches Wesen der Stufe 5."
+  },
+  {
+    "id": 207,
+    "name": "Blütentitan",
+    "description": "Ein pflanzliches Wesen der Stufe 5."
+  },
+  {
+    "id": 208,
+    "name": "Rankentitan",
+    "description": "Ein pflanzliches Wesen der Stufe 5."
+  },
+  {
+    "id": 209,
+    "name": "Waldkoloss",
+    "description": "Ein pflanzliches Wesen der Stufe 5."
+  },
+  {
+    "id": 210,
+    "name": "Moostitan",
+    "description": "Ein pflanzliches Wesen der Stufe 5."
+  },
+  {
+    "id": 211,
+    "name": "Waldgott",
+    "description": "Ein pflanzliches Wesen der Stufe 6."
+  },
+  {
+    "id": 212,
+    "name": "Blütengott",
+    "description": "Ein pflanzliches Wesen der Stufe 6."
+  },
+  {
+    "id": 213,
+    "name": "Rankenkaiser",
+    "description": "Ein pflanzliches Wesen der Stufe 6."
+  },
+  {
+    "id": 214,
+    "name": "Dornenkönig",
+    "description": "Ein pflanzliches Wesen der Stufe 6."
+  },
+  {
+    "id": 215,
+    "name": "Kieselwurm",
+    "description": "Ein steinernes Wesen mit hoher Verteidigung, Stufe 1."
+  },
+  {
+    "id": 216,
+    "name": "Granitlaus",
+    "description": "Ein steinernes Wesen mit hoher Verteidigung, Stufe 1."
+  },
+  {
+    "id": 217,
+    "name": "Felskäfer",
+    "description": "Ein steinernes Wesen mit hoher Verteidigung, Stufe 1."
+  },
+  {
+    "id": 218,
+    "name": "Sandgeist",
+    "description": "Ein steinernes Wesen mit hoher Verteidigung, Stufe 1."
+  },
+  {
+    "id": 219,
+    "name": "Erdmaus",
+    "description": "Ein steinernes Wesen mit hoher Verteidigung, Stufe 2."
+  },
+  {
+    "id": 220,
+    "name": "Steinkobold",
+    "description": "Ein steinernes Wesen mit hoher Verteidigung, Stufe 2."
+  },
+  {
+    "id": 221,
+    "name": "Felskröte",
+    "description": "Ein steinernes Wesen mit hoher Verteidigung, Stufe 2."
+  },
+  {
+    "id": 222,
+    "name": "Granitechse",
+    "description": "Ein steinernes Wesen mit hoher Verteidigung, Stufe 2."
+  },
+  {
+    "id": 223,
+    "name": "Felskrabbler",
+    "description": "Ein steinernes Wesen mit hoher Verteidigung, Stufe 3."
+  },
+  {
+    "id": 224,
+    "name": "Erdgeist",
+    "description": "Ein steinernes Wesen mit hoher Verteidigung, Stufe 3."
+  },
+  {
+    "id": 225,
+    "name": "Granitgolem",
+    "description": "Ein steinernes Wesen mit hoher Verteidigung, Stufe 3."
+  },
+  {
+    "id": 226,
+    "name": "Bergkröte",
+    "description": "Ein steinernes Wesen mit hoher Verteidigung, Stufe 3."
+  },
+  {
+    "id": 227,
+    "name": "Steinechse",
+    "description": "Ein steinernes Wesen mit hoher Verteidigung, Stufe 3."
+  },
+  {
+    "id": 228,
+    "name": "Felskatze",
+    "description": "Ein steinernes Wesen mit hoher Verteidigung, Stufe 3."
+  },
+  {
+    "id": 229,
+    "name": "Granitbär",
+    "description": "Ein steinernes Wesen mit hoher Verteidigung, Stufe 3."
+  },
+  {
+    "id": 230,
+    "name": "Erdkobold",
+    "description": "Ein steinernes Wesen mit hoher Verteidigung, Stufe 3."
+  },
+  {
+    "id": 231,
+    "name": "Berggolem",
+    "description": "Ein steinernes Wesen mit hoher Verteidigung, Stufe 4."
+  },
+  {
+    "id": 232,
+    "name": "Steinriese",
+    "description": "Ein steinernes Wesen mit hoher Verteidigung, Stufe 4."
+  },
+  {
+    "id": 233,
+    "name": "Felskoloss",
+    "description": "Ein steinernes Wesen mit hoher Verteidigung, Stufe 4."
+  },
+  {
+    "id": 234,
+    "name": "Granitgigant",
+    "description": "Ein steinernes Wesen mit hoher Verteidigung, Stufe 4."
+  },
+  {
+    "id": 235,
+    "name": "Erdritter",
+    "description": "Ein steinernes Wesen mit hoher Verteidigung, Stufe 4."
+  },
+  {
+    "id": 236,
+    "name": "Steinwächter",
+    "description": "Ein steinernes Wesen mit hoher Verteidigung, Stufe 4."
+  },
+  {
+    "id": 237,
+    "name": "Felsgardist",
+    "description": "Ein steinernes Wesen mit hoher Verteidigung, Stufe 4."
+  },
+  {
+    "id": 238,
+    "name": "Bergwächter",
+    "description": "Ein steinernes Wesen mit hoher Verteidigung, Stufe 4."
+  },
+  {
+    "id": 239,
+    "name": "Steinkoloss",
+    "description": "Ein steinernes Wesen mit hoher Verteidigung, Stufe 5."
+  },
+  {
+    "id": 240,
+    "name": "Felstitan",
+    "description": "Ein steinernes Wesen mit hoher Verteidigung, Stufe 5."
+  },
+  {
+    "id": 241,
+    "name": "Granitfürst",
+    "description": "Ein steinernes Wesen mit hoher Verteidigung, Stufe 5."
+  },
+  {
+    "id": 242,
+    "name": "Erdriese",
+    "description": "Ein steinernes Wesen mit hoher Verteidigung, Stufe 5."
+  },
+  {
+    "id": 243,
+    "name": "Bergfürst",
+    "description": "Ein steinernes Wesen mit hoher Verteidigung, Stufe 5."
+  },
+  {
+    "id": 244,
+    "name": "Felsriese",
+    "description": "Ein steinernes Wesen mit hoher Verteidigung, Stufe 5."
+  },
+  {
+    "id": 245,
+    "name": "Steinkaiser",
+    "description": "Ein steinernes Wesen mit hoher Verteidigung, Stufe 6."
+  },
+  {
+    "id": 246,
+    "name": "Erdkoloss",
+    "description": "[Fusion] Winddracos + Schattenwolf."
+  },
+  {
+    "id": 247,
+    "name": "Granitkönig",
+    "description": "[Fusion] Eisenkrieger + Knochenschütze."
+  },
+  {
+    "id": 248,
+    "name": "Felsgott",
+    "description": "[Fusion] Moordrache + Sumpfwyrm."
+  },
+  {
+    "id": 249,
+    "name": "Flatterwing",
+    "description": "[Fusion] Eisdrache + Dunkelwyrm."
+  },
+  {
+    "id": 250,
+    "name": "Federgeist",
+    "description": "[Fusion] Schwertläufer + Schlachtführer."
+  },
+  {
+    "id": 251,
+    "name": "Windvogel",
+    "description": "[Fusion] Schlachttitan + Schildlord."
+  },
+  {
+    "id": 252,
+    "name": "Luftwelpe",
+    "description": "[Fusion] Kristallauge + Arkangeist."
+  },
+  {
+    "id": 253,
+    "name": "Sturmtaube",
+    "description": "[Fusion] Zauberfuchs + Runenwächter."
+  },
+  {
+    "id": 254,
+    "name": "Windgeist",
+    "description": "[Fusion] Elementarmagier + Mystiker."
+  },
+  {
+    "id": 255,
+    "name": "Äthervogel",
+    "description": "[Fusion] Kristalltitan + Zaubermeister."
+  },
+  {
+    "id": 256,
+    "name": "Federdrache",
+    "description": "[Fusion] Speersöldner + Bogensöldner."
+  },
+  {
+    "id": 257,
+    "name": "Wolkenläufer",
+    "description": "[Fusion] Lanzenwächter + Schwertgardist."
+  },
+  {
+    "id": 258,
+    "name": "Gewitterfalke",
+    "description": "[Fusion] Schwerttitan + Schildtitan."
+  },
+  {
+    "id": 259,
+    "name": "Windwächter",
+    "description": "[Fusion] Schlachtherr + Klingengott."
+  },
+  {
+    "id": 260,
+    "name": "Federrabe",
+    "description": "[Fusion] Flammenwelpe + Brandspinne."
+  },
+  {
+    "id": 261,
+    "name": "Luftgeist",
+    "description": "[Fusion] Lavakröte + Pyrofalk."
+  },
+  {
+    "id": 262,
+    "name": "Äthertaucher",
+    "description": "[Fusion] Glutdrache + Pyrohai."
+  },
+  {
+    "id": 263,
+    "name": "Windkreischer",
+    "description": "[Fusion] Lavakönig + Pyrogigant."
+  },
+  {
+    "id": 264,
+    "name": "Sturmschwalbe",
+    "description": "[Fusion] Waldtroll + Baumgardist."
+  },
+  {
+    "id": 265,
+    "name": "Himmelsjäger",
+    "description": "[Fusion] Rankenläufer + Waldriese."
+  },
+  {
+    "id": 266,
+    "name": "Feuerpfeil",
+    "description": "Füge dem Gegner 300 Schadenspunkte zu."
+  },
+  {
+    "id": 267,
+    "name": "Flammenspeer",
+    "description": "Füge dem Gegner 400 Schadenspunkte zu."
+  },
+  {
+    "id": 268,
+    "name": "Feuerstoß",
+    "description": "Füge dem Gegner 500 Schadenspunkte zu."
+  },
+  {
+    "id": 269,
+    "name": "Heilkraut",
+    "description": "Erhalte 300 Lebenspunkte."
+  },
+  {
+    "id": 270,
+    "name": "Heiltrank",
+    "description": "Erhalte 500 Lebenspunkte."
+  },
+  {
+    "id": 271,
+    "name": "Heilquelle",
+    "description": "Erhalte 800 Lebenspunkte."
+  },
+  {
+    "id": 272,
+    "name": "Flammenball",
+    "description": "Füge dem Gegner 600 Schadenspunkte zu."
+  },
+  {
+    "id": 273,
+    "name": "Feuerball",
+    "description": "Füge dem Gegner 800 Schadenspunkte zu."
+  },
+  {
+    "id": 274,
+    "name": "Schwertschärfe",
+    "description": "Wähle ein Monster auf deinem Spielfeld. Es erhält bis zum Ende des Zuges +300 ATK/DEF."
+  },
+  {
+    "id": 275,
+    "name": "Kraftstoß",
+    "description": "Wähle ein Monster auf deinem Spielfeld. Es erhält bis zum Ende des Zuges +400 ATK/DEF."
+  },
+  {
+    "id": 276,
+    "name": "Kraftschub",
+    "description": "Wähle ein Monster auf deinem Spielfeld. Es erhält bis zum Ende des Zuges +500 ATK/DEF."
+  },
+  {
+    "id": 277,
+    "name": "Schwächungsnebel",
+    "description": "Alle Monster des Gegners verlieren bis zum Ende des Zuges 300 ATK/DEF."
+  },
+  {
+    "id": 278,
+    "name": "Kartenzug",
+    "description": "Ziehe 1 Karte."
+  },
+  {
+    "id": 279,
+    "name": "Schildverstärkung",
+    "description": "Wähle ein Monster auf deinem Spielfeld. Es erhält bis zum Ende des Zuges +400 DEF."
+  },
+  {
+    "id": 280,
+    "name": "Heiliger Segen",
+    "description": "Erhalte 600 Lebenspunkte."
+  },
+  {
+    "id": 281,
+    "name": "Feuersturm",
+    "description": "Füge dem Gegner 1000 Schadenspunkte zu."
+  },
+  {
+    "id": 282,
+    "name": "Inferno",
+    "description": "Füge dem Gegner 1200 Schadenspunkte zu."
+  },
+  {
+    "id": 283,
+    "name": "Flammeninferno",
+    "description": "Füge dem Gegner 1500 Schadenspunkte zu."
+  },
+  {
+    "id": 284,
+    "name": "Feuerpakt",
+    "description": "Alle Feuer-Monster auf deinem Feld erhalten dauerhaft +300 ATK/DEF."
+  },
+  {
+    "id": 285,
+    "name": "Wasserpakt",
+    "description": "Alle Wasser-Monster auf deinem Feld erhalten dauerhaft +300 ATK/DEF."
+  },
+  {
+    "id": 286,
+    "name": "Dunkles Ritual",
+    "description": "Wähle ein Monster auf deinem Spielfeld. Es erhält dauerhaft +500 ATK/DEF."
+  },
+  {
+    "id": 287,
+    "name": "Verbannung",
+    "description": "Das stärkste Monster des Gegners wird auf die Hand zurückgeschickt."
+  },
+  {
+    "id": 288,
+    "name": "Massenverbannung",
+    "description": "Alle Monster des Gegners werden auf die Hand zurückgeschickt."
+  },
+  {
+    "id": 289,
+    "name": "Doppelzug",
+    "description": "Ziehe 2 Karten."
+  },
+  {
+    "id": 290,
+    "name": "Apokalypse",
+    "description": "Füge dem Gegner 2000 Schadenspunkte zu."
+  },
+  {
+    "id": 291,
+    "name": "Spiegelkraft",
+    "description": "Aktiviere wenn ein Monster des Gegners angreift: Negiere den Angriff."
+  },
+  {
+    "id": 292,
+    "name": "Schutzbarriere",
+    "description": "Aktiviere wenn ein Monster des Gegners angreift: Negiere den Angriff."
+  },
+  {
+    "id": 293,
+    "name": "Bannschild",
+    "description": "Aktiviere wenn ein Monster des Gegners angreift: Negiere den Angriff."
+  },
+  {
+    "id": 294,
+    "name": "Abwehrwall",
+    "description": "Aktiviere wenn ein Monster des Gegners angreift: Negiere den Angriff."
+  },
+  {
+    "id": 295,
+    "name": "Fallgrube",
+    "description": "Aktiviere wenn ein Monster des Gegners angreift: Zerstöre das angreifende Monster."
+  },
+  {
+    "id": 296,
+    "name": "Spiegelschild",
+    "description": "Aktiviere wenn eines deiner Monster angegriffen wird: Negiere den Angriff."
+  },
+  {
+    "id": 297,
+    "name": "Todesstoß",
+    "description": "Aktiviere wenn ein Monster des Gegners angreift: Zerstöre das angreifende Monster."
+  },
+  {
+    "id": 298,
+    "name": "Fallenloch",
+    "description": "Aktiviere wenn der Gegner ein Monster mit 1500+ ATK beschwört: Zerstöre es."
+  },
+  {
+    "id": 299,
+    "name": "Beschwörungsfalle",
+    "description": "Aktiviere wenn der Gegner ein Monster mit 1500+ ATK beschwört: Zerstöre es."
+  },
+  {
+    "id": 300,
+    "name": "Vernichtungsfalle",
+    "description": "Aktiviere wenn ein Monster des Gegners angreift: Zerstöre das angreifende Monster."
+  },
+  {
+    "id": 301,
+    "name": "Hinterhalt",
+    "description": "Aktiviere wenn ein Monster des Gegners angreift: Zerstöre das angreifende Monster."
+  },
+  {
+    "id": 302,
+    "name": "Todesfalle",
+    "description": "Aktiviere wenn ein Monster des Gegners angreift: Zerstöre das angreifende Monster."
+  },
+  {
+    "id": 303,
+    "name": "Klinge der Geschworenen",
+    "description": "Ein Schwert, geschmiedet im Feuer der Loyalität. Erhöht die Angriffskraft des ausgerüsteten Monsters."
+  },
+  {
+    "id": 304,
+    "name": "Eiserne Schildmauer",
+    "description": "Ein massiver Schild aus gehärtetem Stahl. Verstärkt die Verteidigung des ausgerüsteten Monsters."
+  },
+  {
+    "id": 305,
+    "name": "Drachenzahn-Speer",
+    "description": "Ein Speer, gefertigt aus dem Zahn eines uralten Drachen. Stärkt Angriff und Verteidigung."
+  },
+  {
+    "id": 306,
+    "name": "Schattenmantel",
+    "description": "Ein Umhang aus gewebter Dunkelheit. Bietet Schutz und verstärkt leicht den Angriff."
+  },
+  {
+    "id": 307,
+    "name": "Hellebarde des Kriegsherrn",
+    "description": "Die legendäre Waffe eines gefallenen Generals. Verleiht immense Angriffskraft."
+  },
+  {
+    "id": 308,
+    "name": "Bergfestung",
+    "description": "Alle Erd-Monster erhalten +200 ATK/DEF."
+  },
+  {
+    "id": 309,
+    "name": "Drachenreich",
+    "description": "Alle Drachen-Monster erhalten +300 ATK/DEF."
+  },
+  {
+    "id": 310,
+    "name": "Magiersanktum",
+    "description": "Alle Magier-Monster erhalten +250 ATK/DEF."
+  }
+]

--- a/tests/engine.spells.test.js
+++ b/tests/engine.spells.test.js
@@ -73,6 +73,24 @@ const CARD = {
     description: 'Revives once after battle destruction',
     effect: { trigger: 'passive', actions: [{ type: 'passive_phoenixRevival' }] },
   },
+  field_spell_earth: {
+    id: 'TST_FS_EARTH', name: 'Mountain Fortress', type: CardType.Spell,
+    description: 'All Earth monsters gain +200 ATK/DEF', spellType: 'field',
+    effect: { trigger: 'passive', actions: [{ type: 'buffField', value: 200, filter: { race: 5 } }] },
+  },
+  field_spell_dragon: {
+    id: 'TST_FS_DRAGON', name: 'Dragon Domain', type: CardType.Spell,
+    description: 'All Dragon monsters gain +300 ATK/DEF', spellType: 'field',
+    effect: { trigger: 'passive', actions: [{ type: 'buffField', value: 300, filter: { race: 1 } }] },
+  },
+  earth_monster: {
+    id: 'TST_EARTH', name: 'EarthWarrior', type: CardType.Monster, atk: 1000, def: 800,
+    description: 'An earth monster', race: 5, attribute: 5,
+  },
+  dragon_monster: {
+    id: 'TST_DRAGON', name: 'DragonBeast', type: CardType.Monster, atk: 1500, def: 1000,
+    description: 'A dragon monster', race: 1, attribute: 3,
+  },
 };
 
 // ── setMonster ───────────────────────────────────────────────
@@ -336,6 +354,117 @@ describe('specialSummonFromGrave', () => {
     const fc = engine.state.player.field.monsters.find(m => m !== null && m.card.id === 'TST_MON');
     expect(fc).not.toBeNull();
     expect(engine.state.player.graveyard.find(c => c.id === 'TST_MON')).toBeUndefined();
+  });
+});
+
+// ── activateFieldSpell ──────────────────────────────────────
+
+describe('activateFieldSpell', () => {
+  it('places field spell in the fieldSpell slot', async () => {
+    const { engine } = makeEngine();
+    engine.state.player.hand.unshift({ ...CARD.field_spell_earth });
+
+    const result = await engine.activateFieldSpell('player', 0);
+
+    expect(result).toBe(true);
+    expect(engine.state.player.field.fieldSpell).not.toBeNull();
+    expect(engine.state.player.field.fieldSpell.card.id).toBe('TST_FS_EARTH');
+    expect(engine.state.player.field.fieldSpell.faceDown).toBe(false);
+  });
+
+  it('removes field spell from hand', async () => {
+    const { engine } = makeEngine();
+    engine.state.player.hand.unshift({ ...CARD.field_spell_earth });
+    const handBefore = engine.state.player.hand.length;
+
+    await engine.activateFieldSpell('player', 0);
+
+    expect(engine.state.player.hand.length).toBe(handBefore - 1);
+  });
+
+  it('buffs matching monsters on the field', async () => {
+    const { engine } = makeEngine();
+    const fc = placeMonster(engine, 'player', { ...CARD.earth_monster }, 0);
+    engine.state.player.hand.unshift({ ...CARD.field_spell_earth });
+
+    await engine.activateFieldSpell('player', 0);
+
+    expect(fc.fieldSpellATKBonus).toBe(200);
+    expect(fc.fieldSpellDEFBonus).toBe(200);
+    expect(fc.effectiveATK()).toBe(1200); // 1000 + 200
+    expect(fc.effectiveDEF()).toBe(1000); // 800 + 200
+  });
+
+  it('does not buff non-matching monsters', async () => {
+    const { engine } = makeEngine();
+    const fc = placeMonster(engine, 'player', { ...CARD.dragon_monster }, 0);
+    engine.state.player.hand.unshift({ ...CARD.field_spell_earth }); // Earth buff
+
+    await engine.activateFieldSpell('player', 0);
+
+    expect(fc.fieldSpellATKBonus).toBe(0);
+    expect(fc.fieldSpellDEFBonus).toBe(0);
+    expect(fc.effectiveATK()).toBe(1500); // unchanged
+  });
+
+  it('replaces old field spell and sends it to graveyard', async () => {
+    const { engine } = makeEngine();
+    engine.state.player.hand.unshift({ ...CARD.field_spell_dragon });
+    await engine.activateFieldSpell('player', 0);
+
+    expect(engine.state.player.field.fieldSpell.card.id).toBe('TST_FS_DRAGON');
+
+    engine.state.player.hand.unshift({ ...CARD.field_spell_earth });
+    await engine.activateFieldSpell('player', 0);
+
+    expect(engine.state.player.field.fieldSpell.card.id).toBe('TST_FS_EARTH');
+    const graveIds = engine.state.player.graveyard.map(c => c.id);
+    expect(graveIds).toContain('TST_FS_DRAGON');
+  });
+
+  it('removes old buffs and applies new ones when replacing', async () => {
+    const { engine } = makeEngine();
+    const earthMon = placeMonster(engine, 'player', { ...CARD.earth_monster }, 0);
+    const dragonMon = placeMonster(engine, 'player', { ...CARD.dragon_monster }, 1);
+
+    // Activate dragon field spell
+    engine.state.player.hand.unshift({ ...CARD.field_spell_dragon });
+    await engine.activateFieldSpell('player', 0);
+
+    expect(dragonMon.fieldSpellATKBonus).toBe(300);
+    expect(earthMon.fieldSpellATKBonus).toBe(0);
+
+    // Replace with earth field spell
+    engine.state.player.hand.unshift({ ...CARD.field_spell_earth });
+    await engine.activateFieldSpell('player', 0);
+
+    // Dragon buff removed, earth buff applied
+    expect(dragonMon.fieldSpellATKBonus).toBe(0);
+    expect(earthMon.fieldSpellATKBonus).toBe(200);
+  });
+
+  it('applies buff to monster summoned after field spell is active', async () => {
+    const { engine } = makeEngine();
+    engine.state.player.hand.unshift({ ...CARD.field_spell_earth });
+    await engine.activateFieldSpell('player', 0);
+
+    // Now summon an earth monster
+    engine.state.player.hand.unshift({ ...CARD.earth_monster });
+    engine.state.player.normalSummonUsed = false;
+    await engine.summonMonster('player', 0, 0, 'atk');
+
+    const fc = engine.state.player.field.monsters[0];
+    expect(fc.fieldSpellATKBonus).toBe(200);
+    expect(fc.effectiveATK()).toBe(1200);
+  });
+
+  it('rejects non-field-spell card', async () => {
+    const { engine } = makeEngine();
+    engine.state.player.hand.unshift({ ...CARD.spell_burn });
+
+    const result = await engine.activateFieldSpell('player', 0);
+
+    expect(result).toBe(false);
   });
 });
 


### PR DESCRIPTION
Field Spells are a new spell subtype (spellType: 'field') that stay on
the field providing continuous ATK/DEF buffs to matching monsters. Each
player has a dedicated field spell zone separate from the 5 spell/trap
zones. Playing a new field spell destroys the old one.

- Add 'field' to SpellType union (int value 4) and enum converters
- Add fieldSpell slot to PlayerState.field
- Add fieldSpellATKBonus/DEFBonus tracking on FieldCard
- Engine: activateFieldSpell(), buff apply/remove, summon hooks
- UI: field spell display in #field-effect-slot with player/opponent slots
- AI: auto-activates field spells during main phase
- Checkpoint serialization for save/resume
- 3 sample field spell cards (Earth +200, Dragon +300, Spellcaster +250)
- 8 unit tests covering activation, buffs, replacement, and summon hooks
- i18n keys for EN and DE

https://claude.ai/code/session_014z6ej34Wt5Hq7QRM2nR7N3