### PR TITLE
fix(shop): cap Starter Pack card strength with maxAtk filter

### DIFF
--- a/js/react/utils/pack-logic.ts
+++ b/js/react/utils/pack-logic.ts
@@ -178,6 +178,30 @@ export function openPack(packType: string, race: Race | null = null): CardData[]
     : null;
 
   const rarities = _expandSlots(packDef);
+
+  if (packDef.cardPool) {
+    let pool = buildCardPool(packDef.cardPool);
+    if (targetRace != null) {
+      const raceFiltered = pool.filter(c => c.race === targetRace);
+      if (raceFiltered.length) pool = raceFiltered;
+    }
+    return rarities.map(rarity => {
+      let candidates = pool.filter(c => (c.rarity ?? Rarity.Common) === rarity);
+      const fallbacks: Partial<Record<Rarity, Rarity>> = {
+        [Rarity.UltraRare]: Rarity.SuperRare,
+        [Rarity.SuperRare]: Rarity.Rare,
+        [Rarity.Rare]:      Rarity.Uncommon,
+        [Rarity.Uncommon]:  Rarity.Common,
+      };
+      while (!candidates.length && fallbacks[rarity]) {
+        rarity = fallbacks[rarity]!;
+        candidates = pool.filter(c => (c.rarity ?? Rarity.Common) === rarity);
+      }
+      if (!candidates.length) candidates = pool.length ? pool : Object.values(CARD_DB) as CardData[];
+      return candidates[Math.floor(Math.random() * candidates.length)];
+    });
+  }
+
   return rarities.map(r => _pickCard(r, targetRace));
 }
 

--- a/js/shop-data.ts
+++ b/js/shop-data.ts
@@ -63,6 +63,7 @@ export interface PackDef {
   color: string;
   slots: PackSlotDef[];
   filter?: string;                      // 'byRace' or undefined
+  cardPool?: CardPoolDef;               // optional card pool filter (same as packages)
 }
 
 export interface ShopData {
@@ -99,6 +100,7 @@ export const SHOP_DATA: ShopData = {
       color: '#4080a0',
       slots: STANDARD_SLOTS,
       filter: 'byRace',
+      cardPool: { include: { maxAtk: 1500 } },
     },
     {
       id: 'race',

--- a/public/base.tcg-src/shop.json
+++ b/public/base.tcg-src/shop.json
@@ -30,7 +30,10 @@
           }
         }
       ],
-      "filter": "byRace"
+      "filter": "byRace",
+      "cardPool": {
+        "include": { "maxAtk": 1500 }
+      }
     },
     {
       "id": "race",


### PR DESCRIPTION
The Starter Pack could yield monsters up to 3200 ATK, trivializing
early campaign opponents (max 850-1000 ATK). Add cardPool support to
regular packs (reusing the existing package filtering system) and apply
a maxAtk: 1500 constraint to the Starter Pack.

https://claude.ai/code/session_011D77mdmrCfMFiCBFF8eRyv