### PR TITLE
feat(shop): rebalance shop packs, add tiered packages, increase early coin rewards

### DIFF
--- a/public/base.tcg-src/opponents/opponent_deck_1.json
+++ b/public/base.tcg-src/opponents/opponent_deck_1.json
@@ -4,8 +4,8 @@
   "title": "Der Mentor",
   "race": 2,
   "flavor": "Ein weiser Ratgeber am kaiserlichen Hof.",
-  "coinsWin": 50,
-  "coinsLoss": 10,
+  "coinsWin": 100,
+  "coinsLoss": 0,
   "deckIds": [54, 54, 55, 55, 56, 57, 57, 58, 58, 59, 59, 266, 269, 291],
   "behavior": "default"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_10.json
+++ b/public/base.tcg-src/opponents/opponent_deck_10.json
@@ -5,7 +5,7 @@
   "race": 10,
   "flavor": "Ihre Kreaturen verwandeln sich vor deinen Augen.",
   "coinsWin": 200,
-  "coinsLoss": 40,
+  "coinsLoss": 0,
   "deckIds": [190, 190, 191, 191, 192, 192, 193, 193, 194, 195, 195, 196, 267, 274, 277, 296],
   "behavior": "default"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_11.json
+++ b/public/base.tcg-src/opponents/opponent_deck_11.json
@@ -5,7 +5,7 @@
   "race": 7,
   "flavor": "Aus Asche geboren, unzerstörbar und wunderschön.",
   "coinsWin": 250,
-  "coinsLoss": 50,
+  "coinsLoss": 0,
   "deckIds": [137, 137, 138, 138, 139, 139, 140, 140, 141, 141, 142, 142, 143, 144, 144, 272, 275, 295],
   "behavior": "smart"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_12.json
+++ b/public/base.tcg-src/opponents/opponent_deck_12.json
@@ -5,7 +5,7 @@
   "race": 11,
   "flavor": "Kalter Stahl trifft auf rohe Gewalt.",
   "coinsWin": 250,
-  "coinsLoss": 50,
+  "coinsLoss": 0,
   "deckIds": [208, 208, 209, 209, 210, 210, 211, 211, 212, 212, 213, 213, 214, 215, 215, 273, 276, 297],
   "behavior": "aggressive"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_13.json
+++ b/public/base.tcg-src/opponents/opponent_deck_13.json
@@ -5,7 +5,7 @@
   "race": 2,
   "flavor": "Die acht Zeichen enthüllen ihm die Zukunft.",
   "coinsWin": 300,
-  "coinsLoss": 60,
+  "coinsLoss": 0,
   "deckIds": [57, 58, 59, 60, 60, 61, 61, 62, 62, 63, 63, 64, 65, 66, 67, 278, 280, 296],
   "behavior": "smart"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_14.json
+++ b/public/base.tcg-src/opponents/opponent_deck_14.json
@@ -5,7 +5,7 @@
   "race": 8,
   "flavor": "Seine untoten Diener kennen weder Müdigkeit noch Mitleid.",
   "coinsWin": 300,
-  "coinsLoss": 60,
+  "coinsLoss": 0,
   "deckIds": [152, 153, 154, 155, 156, 157, 157, 158, 158, 159, 160, 161, 161, 162, 163, 278, 280, 296],
   "behavior": "smart"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_15.json
+++ b/public/base.tcg-src/opponents/opponent_deck_15.json
@@ -5,7 +5,7 @@
   "race": 3,
   "flavor": "Ein Meister der Klinge aus einer vergessenen Ära.",
   "coinsWin": 350,
-  "coinsLoss": 70,
+  "coinsLoss": 0,
   "deckIds": [29, 30, 31, 32, 33, 33, 34, 34, 35, 35, 36, 36, 37, 37, 38, 39, 40, 281, 276, 297],
   "behavior": "smart"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_16.json
+++ b/public/base.tcg-src/opponents/opponent_deck_16.json
@@ -5,7 +5,7 @@
   "race": 9,
   "flavor": "Das Wasser gehorcht ihrem Willen.",
   "coinsWin": 350,
-  "coinsLoss": 70,
+  "coinsLoss": 0,
   "deckIds": [170, 171, 172, 172, 173, 173, 174, 175, 175, 176, 176, 177, 178, 178, 179, 180, 181, 287, 280, 298],
   "behavior": "defensive"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_17.json
+++ b/public/base.tcg-src/opponents/opponent_deck_17.json
@@ -5,7 +5,7 @@
   "race": 1,
   "flavor": "Sein Drachenfeuer verschlingt alles.",
   "coinsWin": 400,
-  "coinsLoss": 80,
+  "coinsLoss": 0,
   "deckIds": [4, 5, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 12, 13, 14, 15, 16, 246, 282, 298],
   "behavior": "smart"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_18.json
+++ b/public/base.tcg-src/opponents/opponent_deck_18.json
@@ -5,7 +5,7 @@
   "race": 3,
   "flavor": "Der erste Feind nach der Rückkehr in die Vergangenheit.",
   "coinsWin": 250,
-  "coinsLoss": 50,
+  "coinsLoss": 0,
   "deckIds": [29, 30, 31, 32, 33, 34, 79, 80, 81, 82, 83, 84, 85, 86, 268, 274, 275, 295],
   "behavior": "aggressive"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_19.json
+++ b/public/base.tcg-src/opponents/opponent_deck_19.json
@@ -5,7 +5,7 @@
   "race": 3,
   "flavor": "Der General fordert dich erneut heraus.",
   "coinsWin": 300,
-  "coinsLoss": 60,
+  "coinsLoss": 0,
   "deckIds": [30, 31, 32, 33, 33, 34, 35, 36, 37, 37, 38, 39, 40, 41, 42, 43, 250, 281, 276, 297],
   "behavior": "smart"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_2.json
+++ b/public/base.tcg-src/opponents/opponent_deck_2.json
@@ -4,8 +4,8 @@
   "title": "Kriegerprinzessin",
   "race": 3,
   "flavor": "Die kämpferische Prinzessin von Wu.",
-  "coinsWin": 80,
-  "coinsLoss": 15,
+  "coinsWin": 150,
+  "coinsLoss": 0,
   "deckIds": [26, 26, 27, 27, 28, 28, 29, 29, 30, 30, 31, 266, 269, 291],
   "behavior": "default"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_20.json
+++ b/public/base.tcg-src/opponents/opponent_deck_20.json
@@ -5,7 +5,7 @@
   "race": 3,
   "flavor": "Die Prinzessin zeigt ihre wahre Stärke.",
   "coinsWin": 300,
-  "coinsLoss": 60,
+  "coinsLoss": 0,
   "deckIds": [29, 30, 31, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 250, 282, 275, 298],
   "behavior": "smart"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_21.json
+++ b/public/base.tcg-src/opponents/opponent_deck_21.json
@@ -5,7 +5,7 @@
   "race": 9,
   "flavor": "Sein feuchter Strom ist erst der Anfang.",
   "coinsWin": 300,
-  "coinsLoss": 60,
+  "coinsLoss": 0,
   "deckIds": [170, 170, 171, 171, 172, 172, 173, 173, 174, 174, 175, 175, 176, 176, 177, 271, 279, 296],
   "behavior": "defensive"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_22.json
+++ b/public/base.tcg-src/opponents/opponent_deck_22.json
@@ -5,7 +5,7 @@
   "race": 9,
   "flavor": "Das dunkle Wasser verschlingt alles.",
   "coinsWin": 400,
-  "coinsLoss": 80,
+  "coinsLoss": 0,
   "deckIds": [174, 175, 176, 177, 178, 178, 179, 179, 180, 180, 181, 181, 182, 183, 184, 185, 262, 287, 285, 299],
   "behavior": "smart"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_23.json
+++ b/public/base.tcg-src/opponents/opponent_deck_23.json
@@ -5,7 +5,7 @@
   "race": 5,
   "flavor": "Ein grüner Trieb, der zum Baum wird.",
   "coinsWin": 300,
-  "coinsLoss": 60,
+  "coinsLoss": 0,
   "deckIds": [99, 99, 100, 100, 101, 101, 102, 102, 103, 103, 104, 104, 105, 105, 106, 271, 279, 296],
   "behavior": "defensive"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_24.json
+++ b/public/base.tcg-src/opponents/opponent_deck_24.json
@@ -5,7 +5,7 @@
   "race": 5,
   "flavor": "Totes Holz, das noch immer lebt.",
   "coinsWin": 400,
-  "coinsLoss": 80,
+  "coinsLoss": 0,
   "deckIds": [103, 104, 105, 106, 107, 107, 108, 108, 109, 109, 110, 110, 111, 112, 113, 114, 254, 287, 285, 299],
   "behavior": "smart"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_25.json
+++ b/public/base.tcg-src/opponents/opponent_deck_25.json
@@ -5,7 +5,7 @@
   "race": 6,
   "flavor": "Der gelbe Sand verschluckt alles.",
   "coinsWin": 300,
-  "coinsLoss": 60,
+  "coinsLoss": 0,
   "deckIds": [117, 117, 118, 118, 119, 119, 120, 120, 121, 121, 122, 122, 123, 123, 124, 271, 279, 296],
   "behavior": "defensive"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_26.json
+++ b/public/base.tcg-src/opponents/opponent_deck_26.json
@@ -5,7 +5,7 @@
   "race": 6,
   "flavor": "Schwere Erde, unbeweglicher Stein.",
   "coinsWin": 400,
-  "coinsLoss": 80,
+  "coinsLoss": 0,
   "deckIds": [121, 122, 123, 124, 125, 125, 126, 126, 127, 127, 128, 129, 130, 131, 132, 133, 256, 287, 285, 299],
   "behavior": "smart"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_27.json
+++ b/public/base.tcg-src/opponents/opponent_deck_27.json
@@ -5,7 +5,7 @@
   "race": 11,
   "flavor": "Die geschmiedete Klinge sucht ihr Ziel.",
   "coinsWin": 300,
-  "coinsLoss": 60,
+  "coinsLoss": 0,
   "deckIds": [208, 208, 209, 209, 210, 210, 211, 211, 212, 212, 213, 213, 214, 214, 215, 273, 276, 295],
   "behavior": "aggressive"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_28.json
+++ b/public/base.tcg-src/opponents/opponent_deck_28.json
@@ -5,7 +5,7 @@
   "race": 11,
   "flavor": "Weißes Gold — unbrechbar und ewig.",
   "coinsWin": 400,
-  "coinsLoss": 80,
+  "coinsLoss": 0,
   "deckIds": [213, 214, 215, 216, 216, 217, 217, 218, 218, 219, 219, 220, 221, 222, 223, 224, 225, 283, 286, 300],
   "behavior": "smart"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_29.json
+++ b/public/base.tcg-src/opponents/opponent_deck_29.json
@@ -5,7 +5,7 @@
   "race": 12,
   "flavor": "Die kleine Flamme verbrennt alles.",
   "coinsWin": 300,
-  "coinsLoss": 60,
+  "coinsLoss": 0,
   "deckIds": [228, 228, 229, 229, 230, 230, 231, 231, 232, 232, 233, 233, 234, 234, 235, 273, 274, 295],
   "behavior": "aggressive"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_3.json
+++ b/public/base.tcg-src/opponents/opponent_deck_3.json
@@ -4,8 +4,8 @@
   "title": "Der tapfere General",
   "race": 3,
   "flavor": "Ein loyaler General mit unbeugsamer Ehre.",
-  "coinsWin": 80,
-  "coinsLoss": 15,
+  "coinsWin": 150,
+  "coinsLoss": 0,
   "deckIds": [26, 27, 27, 28, 29, 29, 30, 30, 31, 31, 32, 267, 270, 291],
   "behavior": "default"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_30.json
+++ b/public/base.tcg-src/opponents/opponent_deck_30.json
@@ -5,7 +5,7 @@
   "race": 12,
   "flavor": "Die rote Flamme kennt keine Gnade.",
   "coinsWin": 400,
-  "coinsLoss": 80,
+  "coinsLoss": 0,
   "deckIds": [232, 233, 234, 235, 235, 236, 236, 237, 237, 238, 238, 239, 240, 241, 242, 243, 244, 283, 284, 300],
   "behavior": "smart"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_31.json
+++ b/public/base.tcg-src/opponents/opponent_deck_31.json
@@ -5,7 +5,7 @@
   "race": 6,
   "flavor": "Kein Mensch, kein Geist — das Labyrinth selbst.",
   "coinsWin": 500,
-  "coinsLoss": 100,
+  "coinsLoss": 0,
   "deckIds": [48, 46, 73, 94, 113, 133, 149, 166, 186, 204, 224, 242, 167, 40, 66, 91, 110, 128, 145, 287, 288, 301],
   "behavior": "smart"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_32.json
+++ b/public/base.tcg-src/opponents/opponent_deck_32.json
@@ -5,7 +5,7 @@
   "race": 1,
   "flavor": "Der Verräter zeigt sein wahres Gesicht.",
   "coinsWin": 600,
-  "coinsLoss": 120,
+  "coinsLoss": 0,
   "deckIds": [6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 246, 283, 289, 298, 300],
   "behavior": "smart"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_33.json
+++ b/public/base.tcg-src/opponents/opponent_deck_33.json
@@ -5,7 +5,7 @@
   "race": 6,
   "flavor": "Schweigend, wartend, unbesiegbar.",
   "coinsWin": 600,
-  "coinsLoss": 120,
+  "coinsLoss": 0,
   "deckIds": [122, 123, 124, 125, 126, 127, 127, 128, 128, 129, 130, 130, 131, 131, 132, 133, 134, 135, 256, 257, 287, 301],
   "behavior": "defensive"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_34.json
+++ b/public/base.tcg-src/opponents/opponent_deck_34.json
@@ -5,7 +5,7 @@
   "race": 4,
   "flavor": "Aggressiv von der ersten Runde an.",
   "coinsWin": 600,
-  "coinsLoss": 120,
+  "coinsLoss": 0,
   "deckIds": [84, 85, 86, 87, 88, 88, 89, 89, 90, 90, 91, 91, 92, 93, 94, 95, 96, 97, 252, 253, 283, 301],
   "behavior": "aggressive"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_35.json
+++ b/public/base.tcg-src/opponents/opponent_deck_35.json
@@ -5,7 +5,7 @@
   "race": 2,
   "flavor": "Diesmal muss er fallen.",
   "coinsWin": 700,
-  "coinsLoss": 140,
+  "coinsLoss": 0,
   "deckIds": [66, 67, 68, 69, 70, 71, 71, 72, 72, 73, 73, 74, 74, 75, 75, 76, 76, 77, 78, 248, 249, 289, 290, 301],
   "behavior": "cheating"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_36.json
+++ b/public/base.tcg-src/opponents/opponent_deck_36.json
@@ -5,7 +5,7 @@
   "race": 1,
   "flavor": "Ein fragiles Bündnis gegen eine größere Bedrohung.",
   "coinsWin": 700,
-  "coinsLoss": 140,
+  "coinsLoss": 0,
   "deckIds": [9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 246, 247, 289, 290, 301],
   "behavior": "smart"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_37.json
+++ b/public/base.tcg-src/opponents/opponent_deck_37.json
@@ -5,7 +5,7 @@
   "race": 3,
   "flavor": "Von Zhang Jue entfesselt — reine Zerstörung.",
   "coinsWin": 800,
-  "coinsLoss": 160,
+  "coinsLoss": 0,
   "deckIds": [39, 40, 41, 42, 43, 44, 45, 45, 46, 46, 47, 47, 48, 48, 49, 49, 50, 50, 51, 51, 52, 250, 251, 290, 302],
   "behavior": "cheating"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_38.json
+++ b/public/base.tcg-src/opponents/opponent_deck_38.json
@@ -5,7 +5,7 @@
   "race": 3,
   "flavor": "Die wahre Form — physische Unsterblichkeit.",
   "coinsWin": 900,
-  "coinsLoss": 180,
+  "coinsLoss": 0,
   "deckIds": [42, 43, 44, 45, 46, 47, 47, 48, 48, 49, 49, 50, 50, 51, 51, 52, 52, 93, 94, 95, 96, 250, 251, 290, 302],
   "behavior": "cheating"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_39.json
+++ b/public/base.tcg-src/opponents/opponent_deck_39.json
@@ -5,7 +5,7 @@
   "race": 1,
   "flavor": "Duel Master C — der wahre Meister.",
   "coinsWin": 1000,
-  "coinsLoss": 200,
+  "coinsLoss": 0,
   "deckIds": [18, 19, 20, 21, 22, 23, 24, 25, 25, 246, 247, 50, 52, 77, 97, 151, 136, 189, 227, 245, 289, 290, 288, 301, 302],
   "behavior": "cheating"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_4.json
+++ b/public/base.tcg-src/opponents/opponent_deck_4.json
@@ -4,8 +4,8 @@
   "title": "Einfacher Bauer",
   "race": 4,
   "flavor": "Ein Dorfbewohner, der sich verteidigen muss.",
-  "coinsWin": 100,
-  "coinsLoss": 20,
+  "coinsWin": 150,
+  "coinsLoss": 0,
   "deckIds": [79, 79, 80, 80, 99, 99, 100, 170, 170, 171, 208, 266, 269, 291],
   "behavior": "default"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_5.json
+++ b/public/base.tcg-src/opponents/opponent_deck_5.json
@@ -4,8 +4,8 @@
   "title": "Wanderhändler",
   "race": 5,
   "flavor": "Ein reisender Händler mit ein paar Karten.",
-  "coinsWin": 100,
-  "coinsLoss": 20,
+  "coinsWin": 150,
+  "coinsLoss": 0,
   "deckIds": [99, 99, 100, 100, 137, 137, 138, 152, 152, 153, 228, 267, 270, 292],
   "behavior": "default"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_6.json
+++ b/public/base.tcg-src/opponents/opponent_deck_6.json
@@ -4,8 +4,8 @@
   "title": "Dorfältester",
   "race": 6,
   "flavor": "Der erfahrenste Duellant im Dorf.",
-  "coinsWin": 120,
-  "coinsLoss": 25,
+  "coinsWin": 180,
+  "coinsLoss": 0,
   "deckIds": [117, 117, 118, 118, 119, 190, 190, 191, 191, 192, 209, 229, 267, 271, 292],
   "behavior": "default"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_7.json
+++ b/public/base.tcg-src/opponents/opponent_deck_7.json
@@ -4,8 +4,8 @@
   "title": "Rivale des Helden",
   "race": 1,
   "flavor": "Der ehrgeizige Sohn des Wei-Clans.",
-  "coinsWin": 200,
-  "coinsLoss": 40,
+  "coinsWin": 300,
+  "coinsLoss": 0,
   "deckIds": [1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 8, 9, 268, 271, 293],
   "behavior": "smart"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_8.json
+++ b/public/base.tcg-src/opponents/opponent_deck_8.json
@@ -4,8 +4,8 @@
   "title": "Meister des Gelben Himmels",
   "race": 2,
   "flavor": "Der Anführer der Gelben Turbane. Sein Zauber ist überwältigend.",
-  "coinsWin": 300,
-  "coinsLoss": 60,
+  "coinsWin": 450,
+  "coinsLoss": 0,
   "deckIds": [71, 71, 72, 72, 73, 73, 74, 74, 75, 75, 76, 76, 77, 77, 78, 78, 249, 249, 289, 290],
   "behavior": "cheating"
 }

--- a/public/base.tcg-src/opponents/opponent_deck_9.json
+++ b/public/base.tcg-src/opponents/opponent_deck_9.json
@@ -5,7 +5,7 @@
   "race": 4,
   "flavor": "Sein Deck ist so wild wie ein Tiger auf der Jagd.",
   "coinsWin": 200,
-  "coinsLoss": 40,
+  "coinsLoss": 0,
   "deckIds": [79, 79, 80, 80, 81, 81, 82, 82, 83, 84, 84, 85, 86, 268, 274, 295],
   "behavior": "aggressive"
 }

--- a/public/base.tcg-src/shop.json
+++ b/public/base.tcg-src/shop.json
@@ -36,42 +36,10 @@
       }
     },
     {
-      "id": "race",
-      "name": "Race Pack",
-      "desc": "9 cards · Chosen race · Standard",
-      "price": 350,
-      "icon": "⚔",
-      "color": "#a06020",
-      "slots": [
-        {
-          "count": 5,
-          "rarity": 1
-        },
-        {
-          "count": 2,
-          "rarity": 2
-        },
-        {
-          "count": 1,
-          "rarity": 4
-        },
-        {
-          "count": 1,
-          "pool": "guaranteed_rare_plus",
-          "distribution": {
-            "4": 0.75,
-            "6": 0.2,
-            "8": 0.05
-          }
-        }
-      ],
-      "filter": "byRace"
-    },
-    {
       "id": "aether",
       "name": "Jade Pack",
       "desc": "9 cards · All races · Standard",
-      "price": 500,
+      "price": 450,
       "icon": "◈",
       "color": "#2a7848",
       "slots": [
@@ -99,6 +67,41 @@
       ]
     },
     {
+      "id": "race",
+      "name": "Race Pack",
+      "desc": "9 cards · Chosen race · Max. Rare · Max. 2500 ATK",
+      "price": 500,
+      "icon": "⚔",
+      "color": "#a06020",
+      "slots": [
+        {
+          "count": 5,
+          "rarity": 1
+        },
+        {
+          "count": 2,
+          "rarity": 2
+        },
+        {
+          "count": 1,
+          "rarity": 4
+        },
+        {
+          "count": 1,
+          "pool": "guaranteed_rare_plus",
+          "distribution": {
+            "4": 0.75,
+            "6": 0.2,
+            "8": 0.05
+          }
+        }
+      ],
+      "filter": "byRace",
+      "cardPool": {
+        "include": { "maxRarity": 4, "maxAtk": 2500 }
+      }
+    },
+    {
       "id": "rarity",
       "name": "Rarity Pack",
       "desc": "9 cards · Min. Rare · Increased SR/UR chance",
@@ -124,14 +127,14 @@
   ],
   "packages": [
     {
-      "id": "dragon_hoard",
-      "name": "Dragon's Hoard",
-      "desc": "9 cards · Dragons only · Max. Rare",
-      "price": 400,
-      "icon": "🐲",
-      "color": "#8040c0",
+      "id": "tier_1_recruit",
+      "name": "Recruit's Supply",
+      "desc": "9 cards · Beginner · Max. 1500 ATK",
+      "price": 250,
+      "icon": "📦",
+      "color": "#708090",
       "cardPool": {
-        "include": { "races": [1], "types": [1, 2], "maxRarity": 4 }
+        "include": { "maxAtk": 1500 }
       },
       "slots": [
         { "count": 5, "rarity": 1 },
@@ -141,17 +144,85 @@
       ]
     },
     {
-      "id": "warrior_path",
-      "name": "Warriors of Wei",
-      "desc": "9 cards · Warriors · No Traps · Max. Rare",
-      "price": 450,
-      "icon": "⚔",
-      "color": "#c09030",
+      "id": "tier_2_soldier",
+      "name": "Soldier's Cache",
+      "desc": "9 cards · Intermediate · Max. 1800 ATK",
+      "price": 350,
+      "icon": "🗡",
+      "color": "#5a7a3a",
       "unlockCondition": { "type": "nodeComplete", "nodeId": "duel_3" },
       "cardPool": {
-        "include": { "races": [3], "maxRarity": 4 },
-        "exclude": { "types": [4] }
+        "include": { "maxAtk": 1800 }
       },
+      "slots": [
+        { "count": 5, "rarity": 1 },
+        { "count": 2, "rarity": 2 },
+        { "count": 1, "rarity": 4 },
+        { "count": 1, "pool": "guaranteed_rare_plus", "distribution": { "4": 0.75, "6": 0.20, "8": 0.05 } }
+      ]
+    },
+    {
+      "id": "tier_3_officer",
+      "name": "Officer's Bounty",
+      "desc": "9 cards · Advanced · Max. 2100 ATK",
+      "price": 450,
+      "icon": "🏅",
+      "color": "#8a6a2a",
+      "unlockCondition": { "type": "nodeComplete", "nodeId": "duel_8" },
+      "cardPool": {
+        "include": { "maxAtk": 2100 }
+      },
+      "slots": [
+        { "count": 5, "rarity": 1 },
+        { "count": 2, "rarity": 2 },
+        { "count": 1, "rarity": 4 },
+        { "count": 1, "pool": "guaranteed_rare_plus", "distribution": { "4": 0.75, "6": 0.20, "8": 0.05 } }
+      ]
+    },
+    {
+      "id": "tier_4_commander",
+      "name": "Commander's Vault",
+      "desc": "9 cards · Expert · Max. 2500 ATK",
+      "price": 550,
+      "icon": "⚔",
+      "color": "#4a6a9a",
+      "unlockCondition": { "type": "nodeComplete", "nodeId": "gauntlet_qualifiers" },
+      "cardPool": {
+        "include": { "maxAtk": 2500 }
+      },
+      "slots": [
+        { "count": 5, "rarity": 1 },
+        { "count": 2, "rarity": 2 },
+        { "count": 1, "rarity": 4 },
+        { "count": 1, "pool": "guaranteed_rare_plus", "distribution": { "4": 0.75, "6": 0.20, "8": 0.05 } }
+      ]
+    },
+    {
+      "id": "tier_5_temple",
+      "name": "Temple Relics",
+      "desc": "9 cards · Elite · Max. 3000 ATK · No Ultra Rare",
+      "price": 650,
+      "icon": "🏛",
+      "color": "#6a4a8a",
+      "unlockCondition": { "type": "nodeComplete", "nodeId": "duel_21" },
+      "cardPool": {
+        "include": { "maxAtk": 3000, "maxRarity": 6 }
+      },
+      "slots": [
+        { "count": 5, "rarity": 1 },
+        { "count": 2, "rarity": 2 },
+        { "count": 1, "rarity": 4 },
+        { "count": 1, "pool": "guaranteed_rare_plus", "distribution": { "4": 0.75, "6": 0.20, "8": 0.05 } }
+      ]
+    },
+    {
+      "id": "tier_6_warlord",
+      "name": "Warlord's Arsenal",
+      "desc": "9 cards · Legendary · All cards available",
+      "price": 800,
+      "icon": "👑",
+      "color": "#c0a020",
+      "unlockCondition": { "type": "nodeComplete", "nodeId": "duel_31" },
       "slots": [
         { "count": 5, "rarity": 1 },
         { "count": 2, "rarity": 2 },

--- a/tests/pack-logic.test.js
+++ b/tests/pack-logic.test.js
@@ -44,10 +44,10 @@ describe('PACK_TYPES', () => {
     }
   });
 
-  it('pack prices are ordered: starter < race < aether < rarity', () => {
-    expect(PACK_TYPES.starter.price).toBeLessThan(PACK_TYPES.race.price);
-    expect(PACK_TYPES.race.price).toBeLessThan(PACK_TYPES.aether.price);
-    expect(PACK_TYPES.aether.price).toBeLessThan(PACK_TYPES.rarity.price);
+  it('pack prices are ordered: starter < aether < race < rarity', () => {
+    expect(PACK_TYPES.starter.price).toBeLessThan(PACK_TYPES.aether.price);
+    expect(PACK_TYPES.aether.price).toBeLessThan(PACK_TYPES.race.price);
+    expect(PACK_TYPES.race.price).toBeLessThan(PACK_TYPES.rarity.price);
   });
 });
 


### PR DESCRIPTION
- Increase early opponent (1-8) coin rewards by ~60-80% to counter pack nerfs
- Remove all coinsLoss rewards (set to 0 for all 39 opponents)
- Add 6 tiered progression packages unlocking through campaign:
  Recruit's Supply (250), Soldier's Cache (350), Officer's Bounty (450),
  Commander's Vault (550), Temple Relics (650), Warlord's Arsenal (800)
- Consolidate Dragon's Hoard & Warriors of Wei into Race Pack with
  maxRarity: Rare and maxAtk: 2500 at 500 coins
- Reduce Jade Pack price from 500 to 450 coins
- Update pack price ordering test

https://claude.ai/code/session_015hA93hxG5c47qwjDebvHmE