### PR TITLE
feat(ui): highlight keywords in card descriptions

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -784,6 +784,17 @@ button { cursor: pointer; border: none; font-family: inherit; transition: none; 
 .detail-desc  { font-size: 0.75rem; color: var(--text); line-height: 1.5; margin-bottom: 8px; }
 .detail-stats { font-size: 0.875rem; font-weight: bold; color: var(--gold); }
 
+/* ── Card description keyword highlights ──────────────────── */
+.kw-effect  { font-weight: bold; color: #ff9955; }
+.kw-passive { font-weight: bold; color: #55aaff; }
+.kw-fusion  { font-weight: bold; color: #cc88ff; }
+.kw-atk     { font-weight: bold; color: #ff9955; }
+.kw-def     { font-weight: bold; color: #55aaff; }
+.kw-number  { font-weight: bold; color: var(--gold-light); }
+.kw-term    { color: var(--gold); }
+.kw-race    { font-weight: bold; }
+.kw-attr    { font-weight: bold; }
+
 /* Trap Prompt */
 #trap-prompt-modal { max-width: 380px; text-align: center; }
 #trap-prompt-card { display: flex; justify-content: center; margin: 10px 0; }

--- a/js/react/components/Card.tsx
+++ b/js/react/components/Card.tsx
@@ -6,6 +6,7 @@ import type { CardData, FieldCard } from '../../types.js';
 import {
   getRaceById, getAttrById, getRarityById, getCardTypeById,
 } from '../../type-metadata.js';
+import { highlightCardText, highlightCardTextHTML } from '../utils/highlightCardText.js';
 import styles from './Card.module.css';
 
 function getTypeLabel(card: CardData): string {
@@ -149,7 +150,7 @@ export function Card({ card, fc = null, dimmed = false, rotated = false, big = f
       </div>
       <div className={styles.cardBody}>
         <div className={styles.typeSubtype}>{typeSubtypeStr}</div>
-        <div className={styles.descText}>{card.description || ''}</div>
+        <div className={styles.descText}>{big && card.description ? highlightCardText(card.description) : (card.description || '')}</div>
       </div>
       {statsBar}
       {eqReqLabel && <div className={styles.equipReq}>{eqReqLabel} only</div>}
@@ -235,7 +236,7 @@ export function cardInnerHTML(card: any, _dimmed = false, _rotated = false, fc: 
     </div>
     <div class="card-body">
       <div class="card-type-subtype">${typeSubtypeStr}</div>
-      <div class="card-desc-text">${card.description || ''}</div>
+      <div class="card-desc-text">${card.description ? highlightCardTextHTML(card.description) : ''}</div>
     </div>
     ${statsHTML}
   `;

--- a/js/react/components/HoverPreview.tsx
+++ b/js/react/components/HoverPreview.tsx
@@ -7,6 +7,7 @@ import { gsap } from 'gsap';
 import { getAttrById } from '../../type-metadata.js';
 import { CardType } from '../../types.js';
 import { Card } from './Card.js';
+import { highlightCardText } from '../utils/highlightCardText.js';
 import { setHoverDispatch } from './hoverApi.js';
 import type { HoverState } from './hoverApi.js';
 
@@ -75,7 +76,7 @@ export function HoverPreview() {
           <div className="hover-info">
             <div id="hover-card-name">{card.name}</div>
             <div id="hover-card-meta">{[attrNameStr, typeName].filter(Boolean).join(' · ')}{levelStr}</div>
-            <div id="hover-card-desc">{card.description || ''}</div>
+            <div id="hover-card-desc">{card.description ? highlightCardText(card.description) : ''}</div>
             <div id="hover-card-stats">
               {card.atk !== undefined
                 ? <>

--- a/js/react/modals/CardDetailModal.tsx
+++ b/js/react/modals/CardDetailModal.tsx
@@ -3,6 +3,7 @@ import { useModal }  from '../contexts/ModalContext.js';
 import { useGame }   from '../contexts/GameContext.js';
 import { useSelection } from '../contexts/SelectionContext.js';
 import { Card }       from '../components/Card.js';
+import { highlightCardText } from '../utils/highlightCardText.js';
 import { CardType, Attribute, isMonsterType, meetsEquipRequirement } from '../../types.js';
 import { getAttrById } from '../../type-metadata.js';
 import type { ModalState } from '../contexts/ModalContext.js';
@@ -163,7 +164,7 @@ export function CardDetailModal({ modal }: Props) {
         <div className="detail-info">
           <h2 id="detail-card-name">{card.name}</h2>
           <p className="detail-type">{[attrName, typeLabel].filter(Boolean).join(' · ')}{levelStr}</p>
-          <p className="detail-desc">{card.description || ''}</p>
+          <p className="detail-desc">{card.description ? highlightCardText(card.description) : ''}</p>
           <p className="detail-stats">{statsText}</p>
         </div>
       </div>

--- a/js/react/utils/highlightCardText.tsx
+++ b/js/react/utils/highlightCardText.tsx
@@ -1,0 +1,134 @@
+// ============================================================
+// highlightCardText — keyword highlighting for card descriptions
+// ============================================================
+import React from 'react';
+import { TYPE_META, getRaceByKey, getAttrByKey } from '../../type-metadata.js';
+
+// ── Static keyword rules (checked before dynamic race/attr) ──
+
+type StaticRule = { pattern: RegExp; className: string };
+
+const STATIC_RULES: StaticRule[] = [
+  // Tags
+  { pattern: /\[Effect\]/g,           className: 'kw-effect' },
+  { pattern: /\[Passive\]/g,          className: 'kw-passive' },
+  { pattern: /\[Fusion\]/g,           className: 'kw-fusion' },
+  // Stats
+  { pattern: /\bATK\b/g,              className: 'kw-atk' },
+  { pattern: /\bDEF\b/g,              className: 'kw-def' },
+  // Signed numbers (+200, -500)
+  { pattern: /[+-]\d+/g,              className: 'kw-number' },
+  // Game terms (longer patterns first to avoid partial matches)
+  { pattern: /\bSpecial Summon(?:ed)?\b/g, className: 'kw-term' },
+  { pattern: /\bSummon\b/g,           className: 'kw-term' },
+  { pattern: /\bGraveyard\b/g,        className: 'kw-term' },
+  { pattern: /\bDraw\b/g,             className: 'kw-term' },
+  { pattern: /\bDeck\b/g,             className: 'kw-term' },
+  { pattern: /\bLP\b/g,               className: 'kw-term' },
+];
+
+// ── Build combined regex from all rules ──
+
+type MatchRule = { className: string; color?: string };
+
+function buildCombinedRegex(): { regex: RegExp; ruleMap: MatchRule[] } {
+  const groups: string[] = [];
+  const ruleMap: MatchRule[] = [];
+
+  // Static rules first
+  for (const r of STATIC_RULES) {
+    groups.push(`(${r.pattern.source})`);
+    ruleMap.push({ className: r.className });
+  }
+
+  // Dynamic race names (sorted longest-first)
+  const races = [...TYPE_META.races].sort((a, b) => b.key.length - a.key.length);
+  for (const race of races) {
+    groups.push(`(\\b${race.key}\\b)`);
+    ruleMap.push({ className: 'kw-race', color: race.color });
+  }
+
+  // Dynamic attribute names (sorted longest-first)
+  const attrs = [...TYPE_META.attributes].sort((a, b) => b.key.length - a.key.length);
+  for (const attr of attrs) {
+    groups.push(`(\\b${attr.key}\\b)`);
+    ruleMap.push({ className: 'kw-attr', color: attr.color });
+  }
+
+  return { regex: new RegExp(groups.join('|'), 'g'), ruleMap };
+}
+
+// Cache: rebuilt lazily when TYPE_META changes size
+let _cache: { regex: RegExp; ruleMap: MatchRule[] } | null = null;
+let _cacheKey = 0;
+
+function getCompiledRules() {
+  const key = TYPE_META.races.length + TYPE_META.attributes.length;
+  if (!_cache || _cacheKey !== key) {
+    _cache = buildCombinedRegex();
+    _cacheKey = key;
+  }
+  return _cache;
+}
+
+// ── Tokeniser ──
+
+type Token = { text: string; rule?: MatchRule };
+
+function tokenize(desc: string): Token[] {
+  const { regex, ruleMap } = getCompiledRules();
+  const tokens: Token[] = [];
+  let lastIndex = 0;
+
+  regex.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(desc)) !== null) {
+    // Plain text before match
+    if (match.index > lastIndex) {
+      tokens.push({ text: desc.slice(lastIndex, match.index) });
+    }
+    // Find which capture group matched
+    for (let i = 1; i < match.length; i++) {
+      if (match[i] !== undefined) {
+        tokens.push({ text: match[0], rule: ruleMap[i - 1] });
+        break;
+      }
+    }
+    lastIndex = match.index + match[0].length;
+  }
+  // Trailing text
+  if (lastIndex < desc.length) {
+    tokens.push({ text: desc.slice(lastIndex) });
+  }
+  return tokens;
+}
+
+// ── React output ──
+
+export function highlightCardText(desc: string): React.ReactNode {
+  const tokens = tokenize(desc);
+  if (tokens.length === 1 && !tokens[0].rule) return desc;
+
+  return (
+    <>
+      {tokens.map((tok, i) =>
+        tok.rule
+          ? <span key={i} className={tok.rule.className} style={tok.rule.color ? { color: tok.rule.color } : undefined}>{tok.text}</span>
+          : tok.text
+      )}
+    </>
+  );
+}
+
+// ── HTML string output (for cardInnerHTML) ──
+
+export function highlightCardTextHTML(desc: string): string {
+  const tokens = tokenize(desc);
+  if (tokens.length === 1 && !tokens[0].rule) return desc;
+
+  return tokens.map(tok => {
+    if (!tok.rule) return tok.text;
+    const style = tok.rule.color ? ` style="color:${tok.rule.color}"` : '';
+    return `<span class="${tok.rule.className}"${style}>${tok.text}</span>`;
+  }).join('');
+}


### PR DESCRIPTION
Add keyword highlighting for card descriptions in CardDetailModal,
Card (big layout), HoverPreview, and cardInnerHTML. Keywords like
[Effect], [Passive], [Fusion], ATK/DEF, signed numbers, game terms,
race names, and attribute names are rendered with bold text and
color coding matching the game's visual theme.

https://claude.ai/code/session_01322otPzrep9mE4kjsYfV6j