### PR TITLE
fix(test): wait for PressStartScreen before interacting in E2E tests

### DIFF
--- a/tests-e2e/game.spec.ts
+++ b/tests-e2e/game.spec.ts
@@ -3,6 +3,7 @@ import { test, expect, Page } from '@playwright/test';
 // Dismiss the press-start screen by pressing a key, then wait for title screen.
 async function passPressStart(page: Page) {
   await page.goto('/');
+  await expect(page.getByText('PRESS ANY KEY')).toBeVisible({ timeout: 5_000 });
   await page.keyboard.press('Enter');
   await expect(page.locator('#title-screen')).toBeVisible({ timeout: 5_000 });
 }
@@ -22,6 +23,7 @@ test.describe('Press Start Screen', () => {
 
   test('navigates to title screen on click', async ({ page }) => {
     await page.goto('/');
+    await expect(page.getByText('PRESS ANY KEY')).toBeVisible({ timeout: 5_000 });
     await page.locator('body').click();
     await expect(page.locator('#title-screen')).toBeVisible({ timeout: 5_000 });
   });


### PR DESCRIPTION
The E2E tests were pressing Enter/clicking before React had mounted the
PressStartScreen component, causing the keydown listener to miss the
event. Now we wait for "PRESS ANY KEY" to be visible before interacting.

https://claude.ai/code/session_013kc3RVKUwrWUSqFXirgkGR