### PR TITLE
fix(test): fix flaky title screen E2E tests

### DIFF
--- a/tests-e2e/game.spec.ts
+++ b/tests-e2e/game.spec.ts
@@ -45,6 +45,6 @@ test.describe('Title Screen', () => {
 
   test('options button is present', async ({ page }) => {
     await passPressStart(page);
-    await expect(page.locator('#title-screen button.btn-secondary')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Options' })).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary\n- Wait for \"PRESS ANY KEY\" to be visible before pressing Enter/clicking, fixing a race condition where the keydown listener wasn't attached yet\n- Use `getByRole('button', { name: 'Options' })` instead of `button.btn-secondary` which matched both Options and Quit Game buttons\n\n## Test plan\n- [ ] All 6 E2E tests in `game.spec.ts` pass\n- [ ] No regressions in unit tests (`npm test`)\n\nhttps://claude.ai/code/session_013kc3RVKUwrWUSqFXirgkGR