### PR TITLE
feat(ui): normalize campaign nodes to fit screen and add chapter dropdown

### DIFF
--- a/js/react/screens/CampaignScreen.module.css
+++ b/js/react/screens/CampaignScreen.module.css
@@ -28,14 +28,6 @@
   font-family: 'Press Start 2P', monospace;
 }
 
-.chapterTitle {
-  color: #6080a0;
-  font-size: 0.75rem;
-  letter-spacing: 2px;
-  margin: 0 0 8px;
-  font-family: 'Silkscreen', monospace;
-}
-
 .backBtn {
   position: absolute;
   left: 0;
@@ -46,31 +38,48 @@
 
 .chapterNav {
   display: flex;
-  gap: 8px;
+  justify-content: center;
   margin-bottom: 8px;
   flex-shrink: 0;
+  width: 100%;
+  max-width: 900px;
 }
 
-.chapterTab {
-  padding: 4px 12px;
-  font-size: 0.65rem;
+.chapterSelect {
+  width: 100%;
+  max-width: 320px;
+  padding: 6px 12px;
+  font-size: 0.6rem;
   font-family: 'Press Start 2P', monospace;
-  background: rgba(20, 30, 50, 0.8);
-  border: 1px solid #2a3a5a;
-  color: #6080a0;
+  background: rgba(20, 30, 50, 0.9);
+  border: 1px solid #c8a84b;
+  border-radius: 2px;
+  color: #c8a84b;
   cursor: pointer;
-  transition: all 0.15s;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8'%3E%3Cpath d='M1 1l5 5 5-5' stroke='%23c8a84b' fill='none' stroke-width='2'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  padding-right: 30px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
 }
 
-.chapterTab:hover {
-  border-color: #c8a84b;
-  color: #c8a84b;
+.chapterSelect:focus {
+  outline: none;
+  box-shadow: 0 0 8px rgba(200, 168, 75, 0.4);
 }
 
-.chapterTabActive {
-  background: rgba(40, 60, 90, 0.6);
-  border-color: #c8a84b;
+.chapterSelect option {
+  background: #0c1428;
   color: #c8a84b;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 0.6rem;
+  padding: 4px 8px;
+}
+
+.chapterSelect option:disabled {
+  color: #3a4a5a;
 }
 
 .mapContainer {
@@ -78,7 +87,8 @@
   width: 100%;
   max-width: 900px;
   position: relative;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
   border: 1px solid #1a2a40;
   border-radius: 2px;
   background: radial-gradient(ellipse at center, #0c1428 0%, #060a14 100%);
@@ -86,8 +96,7 @@
 
 .mapInner {
   position: relative;
-  min-width: 100%;
-  min-height: 100%;
+  width: 100%;
 }
 
 .connectionLine {

--- a/js/react/screens/CampaignScreen.tsx
+++ b/js/react/screens/CampaignScreen.tsx
@@ -28,16 +28,47 @@ export default function CampaignScreen() {
   const chapters = campaignData.chapters;
   const activeChapter: Chapter | undefined = chapters[activeChapterIdx];
 
-  // Compute map dimensions from node positions
-  const mapSize = useMemo(() => {
-    if (!activeChapter) return { width: 800, height: 500 };
-    let maxX = 0;
-    let maxY = 0;
+  // Determine which chapters are unlocked (sequential: chapter N needs ≥1 completed node in chapter N-1)
+  const chapterUnlocked = useMemo(() => {
+    return chapters.map((_, idx) => {
+      if (idx === 0) return true;
+      const prev = chapters[idx - 1];
+      return prev.nodes.some(n => progress.completedNodes.includes(n.id));
+    });
+  }, [chapters, progress.completedNodes]);
+
+  // Normalize node positions to percentages so they always fit the container width
+  const PADDING_X = 12; // % horizontal padding on each side
+  const PADDING_TOP = 40; // px top padding
+  const PADDING_BOTTOM = 50; // px bottom padding
+
+  const { nodePositions, mapHeight } = useMemo(() => {
+    if (!activeChapter) return { nodePositions: new Map<string, { leftPct: number; topPx: number }>(), mapHeight: 300 };
+
+    let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
     for (const node of activeChapter.nodes) {
+      if (node.position.x < minX) minX = node.position.x;
       if (node.position.x > maxX) maxX = node.position.x;
+      if (node.position.y < minY) minY = node.position.y;
       if (node.position.y > maxY) maxY = node.position.y;
     }
-    return { width: Math.max(maxX + 80, 400), height: Math.max(maxY + 80, 300) };
+
+    const rangeX = maxX - minX;
+    const rangeY = maxY - minY;
+
+    const positions = new Map<string, { leftPct: number; topPx: number }>();
+    for (const node of activeChapter.nodes) {
+      const leftPct = rangeX === 0
+        ? 50
+        : PADDING_X + ((node.position.x - minX) / rangeX) * (100 - 2 * PADDING_X);
+      const topPx = rangeY === 0
+        ? PADDING_TOP + 60
+        : PADDING_TOP + ((node.position.y - minY) / rangeY) * Math.max(rangeY, 200);
+      positions.set(node.id, { leftPct, topPx });
+    }
+
+    const maxTop = Math.max(...Array.from(positions.values()).map(p => p.topPx));
+    return { nodePositions: positions, mapHeight: maxTop + PADDING_BOTTOM };
   }, [activeChapter]);
 
   function getNodeState(node: CampaignNode): 'completed' | 'available' | 'locked' {
@@ -146,49 +177,58 @@ export default function CampaignScreen() {
     <div className={styles.screen}>
       <div className={styles.header}>
         <h2 className={styles.title}>{t('campaign.title')}</h2>
-        <p className={styles.chapterTitle}>
-          {t('campaign.chapter')} — {t(`campaign.chapter_${activeChapter.id}`, activeChapter.id)}
-        </p>
         <button className={`btn-secondary ${styles.backBtn}`} onClick={() => navigateTo('title')}>{t('common.back')}</button>
       </div>
 
       {chapters.length > 1 && (
         <div className={styles.chapterNav}>
-          {chapters.map((ch, idx) => (
-            <button
-              key={ch.id}
-              className={`${styles.chapterTab}${idx === activeChapterIdx ? ` ${styles.chapterTabActive}` : ''}`}
-              onClick={() => setActiveChapterIdx(idx)}
-            >
-              {t(`campaign.chapter_${ch.id}`, ch.id)}
-            </button>
-          ))}
+          <select
+            className={styles.chapterSelect}
+            value={activeChapterIdx}
+            onChange={e => {
+              const idx = Number(e.target.value);
+              if (chapterUnlocked[idx]) setActiveChapterIdx(idx);
+            }}
+          >
+            {chapters.map((ch, idx) => (
+              <option key={ch.id} value={idx} disabled={!chapterUnlocked[idx]}>
+                {t(`campaign.chapter_${ch.id}`, ch.id)}{!chapterUnlocked[idx] ? ` 🔒` : ''}
+              </option>
+            ))}
+          </select>
         </div>
       )}
 
       <div className={styles.mapContainer}>
-        <div className={styles.mapInner} style={{ width: mapSize.width, height: mapSize.height }}>
+        <div className={styles.mapInner} style={{ height: mapHeight }}>
           {/* Connection lines (SVG overlay) */}
           <svg
             style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', pointerEvents: 'none' }}
-            viewBox={`0 0 ${mapSize.width} ${mapSize.height}`}
             preserveAspectRatio="none"
           >
-            {connections.map((conn, i) => (
-              <line
-                key={i}
-                x1={conn.from.position.x}
-                y1={conn.from.position.y}
-                x2={conn.to.position.x}
-                y2={conn.to.position.y}
-                className={`${styles.connectionLine}${conn.completed ? ` ${styles.connectionLineCompleted}` : ''}`}
-              />
-            ))}
+            {connections.map((conn, i) => {
+              const fromPos = nodePositions.get(conn.from.id);
+              const toPos = nodePositions.get(conn.to.id);
+              if (!fromPos || !toPos) return null;
+              return (
+                <line
+                  key={i}
+                  x1={`${fromPos.leftPct}%`}
+                  y1={fromPos.topPx}
+                  x2={`${toPos.leftPct}%`}
+                  y2={toPos.topPx}
+                  className={`${styles.connectionLine}${conn.completed ? ` ${styles.connectionLineCompleted}` : ''}`}
+                />
+              );
+            })}
           </svg>
 
           {/* Nodes */}
           {activeChapter.nodes.map(node => {
             const state = getNodeState(node);
+            const pos = nodePositions.get(node.id);
+            if (!pos) return null;
+
             const nodeClass = [
               styles.node,
               state === 'completed' ? styles.nodeCompleted : '',
@@ -206,7 +246,7 @@ export default function CampaignScreen() {
               <div
                 key={node.id}
                 className={nodeClass}
-                style={{ left: node.position.x, top: node.position.y }}
+                style={{ left: `${pos.leftPct}%`, top: pos.topPx }}
                 onClick={() => handleNodeClick(node)}
                 title={state === 'locked' ? t('campaign.locked') : node.id}
               >


### PR DESCRIPTION
Story nodes now use percentage-based horizontal positioning instead of
absolute pixel values, ensuring all nodes fit within the viewport on
mobile without horizontal scrolling. Chapter navigation replaced with
a styled dropdown where only unlocked chapters (requiring ≥1 completed
node in the previous chapter) are selectable.

https://claude.ai/code/session_01SWdm883DZscZdgrqYJKmtx