### PR TITLE
fix(data): rename all 312 cards to match their actual race, attribute, and type

### DIFF
--- a/public/base.tcg-src/locales/cards_description.json
+++ b/public/base.tcg-src/locales/cards_description.json
@@ -1,193 +1,193 @@
 [
   {
     "id": 1,
-    "name": "Fire Salamander",
+    "name": "Shadow Hatchling",
     "description": "A fearsome dragon that commands dark energy."
   },
   {
     "id": 2,
-    "name": "Stone Golem",
-    "description": "An ancient dragon radiating dark force."
+    "name": "Darkscale Drake",
+    "description": "A fearsome dragon that commands dark energy."
   },
   {
     "id": 3,
-    "name": "Sea Serpent",
-    "description": "A mighty Fire dragon of great power."
+    "name": "Flame Whelp",
+    "description": "A mighty dragon wreathed in scorching flames."
   },
   {
     "id": 4,
-    "name": "Wind Drake",
+    "name": "Nightfang Dragon",
     "description": "A fearsome dragon that commands dark energy."
   },
   {
     "id": 5,
-    "name": "Shadow Wolf",
-    "description": "An ancient dragon radiating dark force."
+    "name": "Duskwing Serpent",
+    "description": "A fearsome dragon that commands dark energy."
   },
   {
     "id": 6,
-    "name": "Crystal Knight",
-    "description": "A mighty Fire dragon of great power."
+    "name": "Ember Wyrm",
+    "description": "A mighty dragon wreathed in scorching flames."
   },
   {
     "id": 7,
-    "name": "Iron Warrior",
+    "name": "Obsidian Dragon",
     "description": "A fearsome dragon that commands dark energy."
   },
   {
     "id": 8,
-    "name": "Coral Fairy",
-    "description": "An ancient dragon radiating dark force."
+    "name": "Twilight Drake",
+    "description": "A fearsome dragon that commands dark energy."
   },
   {
     "id": 9,
-    "name": "Storm Hawk",
-    "description": "A mighty Fire dragon of great power."
+    "name": "Crimson Fang Dragon",
+    "description": "A mighty dragon wreathed in scorching flames."
   },
   {
     "id": 10,
-    "name": "Sun Priest",
+    "name": "Moonscale Dragon",
     "description": "A fearsome dragon that commands dark energy."
   },
   {
     "id": 11,
-    "name": "Bone Archer",
-    "description": "An ancient dragon radiating dark force."
+    "name": "Dark Tempest Dragon",
+    "description": "A fearsome dragon that commands dark energy."
   },
   {
     "id": 12,
-    "name": "Moss Troll",
-    "description": "A mighty Fire dragon of great power."
+    "name": "Inferno Serpent",
+    "description": "A mighty dragon wreathed in scorching flames."
   },
   {
     "id": 13,
-    "name": "Ember Boar",
+    "name": "Shadowflame Dragon",
     "description": "A fearsome dragon that commands dark energy."
   },
   {
     "id": 14,
-    "name": "Deep-Sea Angler",
+    "name": "Voidfire Dragon",
     "description": "[Effect] On Summon: Deal 300 damage to opponent."
   },
   {
     "id": 15,
-    "name": "Silver Paladin",
+    "name": "Dread Dragon Lord",
     "description": "[Effect] On Summon: All your Dragon monsters gain +200 ATK/DEF."
   },
   {
     "id": 16,
-    "name": "Magma Crab",
+    "name": "Blazescale Wyvern",
     "description": "[Effect] On Summon: Deal 400 damage to opponent."
   },
   {
     "id": 17,
-    "name": "Frost Witch",
+    "name": "Eclipse Dragon",
     "description": "[Effect] When destroyed in battle: Draw 1 card."
   },
   {
     "id": 18,
-    "name": "Dark Assassin",
+    "name": "Flamecrest Dragon",
     "description": "[Effect] On Summon: All your Dragon monsters gain +300 ATK/DEF."
   },
   {
     "id": 19,
-    "name": "Nature Shaman",
+    "name": "Abyssal Dragon",
     "description": "[Effect] On Summon: Deal 500 damage to opponent."
   },
   {
     "id": 20,
-    "name": "Flame Phoenix",
+    "name": "Darkstorm Wyrm",
     "description": "[Passive] Piercing: Deals battle damage even when attacking a DEF position monster."
   },
   {
     "id": 21,
-    "name": "Lightning Mage",
+    "name": "Shadow Dragon King",
     "description": "[Effect] On Summon: All your Dragon monsters gain +400 ATK/DEF."
   },
   {
     "id": 22,
-    "name": "Holy Warrior",
+    "name": "Hellfire Dragon",
     "description": "[Effect] On Summon: Deal 600 damage to opponent."
   },
   {
     "id": 23,
-    "name": "Shadow Reaper",
+    "name": "Nightfall Wyrm",
     "description": "[Passive] Piercing: Deals battle damage even when attacking a DEF position monster."
   },
   {
     "id": 24,
-    "name": "Water Dragon",
+    "name": "Chaos Dragon Emperor",
     "description": "[Effect] On Summon: Deal 800 damage to opponent."
   },
   {
     "id": 25,
-    "name": "Young Dragon",
+    "name": "Supreme Dragon Lord",
     "description": "[Effect] On Summon: All your Dragon monsters gain +500 ATK/DEF."
   },
   {
     "id": 26,
     "name": "Recruit",
-    "description": "A disciplined warrior wielding earth strength."
+    "description": "A disciplined warrior wielding the strength of earth."
   },
   {
     "id": 27,
     "name": "Foot Soldier",
-    "description": "A battle-hardened warrior of earth allegiance."
+    "description": "A disciplined warrior wielding the strength of earth."
   },
   {
     "id": 28,
     "name": "Lancer",
-    "description": "A courageous fighter blessed with light power."
+    "description": "A courageous fighter blessed with radiant light."
   },
   {
     "id": 29,
     "name": "Spear Fighter",
-    "description": "A disciplined warrior wielding earth strength."
+    "description": "A disciplined warrior wielding the strength of earth."
   },
   {
     "id": 30,
     "name": "Lance Rider",
-    "description": "A battle-hardened warrior of earth allegiance."
+    "description": "A disciplined warrior wielding the strength of earth."
   },
   {
     "id": 31,
     "name": "Sword Runner",
-    "description": "A courageous fighter blessed with earth power."
+    "description": "A disciplined warrior wielding the strength of earth."
   },
   {
     "id": 32,
     "name": "Blade Warden",
-    "description": "A disciplined warrior wielding light strength."
+    "description": "A courageous fighter blessed with radiant light."
   },
   {
     "id": 33,
     "name": "Shield Master",
-    "description": "A battle-hardened warrior of earth allegiance."
+    "description": "A disciplined warrior wielding the strength of earth."
   },
   {
     "id": 34,
     "name": "Battle Commander",
-    "description": "A courageous fighter blessed with earth power."
+    "description": "A disciplined warrior wielding the strength of earth."
   },
   {
     "id": 35,
     "name": "Blade Lord",
-    "description": "A disciplined warrior wielding light strength."
+    "description": "A courageous fighter blessed with radiant light."
   },
   {
     "id": 36,
     "name": "Battle Titan",
-    "description": "A battle-hardened warrior of earth allegiance."
+    "description": "A disciplined warrior wielding the strength of earth."
   },
   {
     "id": 37,
     "name": "Sword Lord",
-    "description": "A courageous fighter blessed with earth power."
+    "description": "A disciplined warrior wielding the strength of earth."
   },
   {
     "id": 38,
     "name": "Shield Lord",
-    "description": "A disciplined warrior wielding light strength."
+    "description": "A courageous fighter blessed with radiant light."
   },
   {
     "id": 39,
@@ -241,227 +241,227 @@
   },
   {
     "id": 49,
-    "name": "Apprentice",
+    "name": "Golden Vanguard",
     "description": "[Passive] This monster cannot be targeted by effects."
   },
   {
     "id": 50,
-    "name": "Acolyte",
+    "name": "Grand Champion",
     "description": "[Effect] On Summon: One of your monsters permanently gains +500 ATK."
   },
   {
     "id": 51,
-    "name": "Mystic",
+    "name": "Imperial Warlord",
     "description": "[Effect] On Summon: All your Warrior monsters gain +500 ATK/DEF."
   },
   {
     "id": 52,
-    "name": "Enchanter",
+    "name": "Heaven's Blade",
     "description": "[Passive] Piercing: Deals battle damage even when attacking a DEF position monster."
   },
   {
     "id": 53,
-    "name": "Conjurer",
+    "name": "Tempest Duelist",
     "description": "[Effect] On Summon: One of your monsters gains +700 ATK until end of turn."
   },
   {
     "id": 54,
     "name": "Arcane Scholar",
-    "description": "A skilled mage who wields light magic."
+    "description": "A skilled mage who channels the power of light."
   },
   {
     "id": 55,
     "name": "Hex Weaver",
-    "description": "A mysterious sorcerer attuned to light power."
+    "description": "A skilled mage who channels the power of light."
   },
   {
     "id": 56,
     "name": "Spell Sage",
-    "description": "An arcane spellcaster channeling dark energy."
+    "description": "A mysterious sorcerer attuned to dark forces."
   },
   {
     "id": 57,
     "name": "Rune Master",
-    "description": "A skilled mage who wields light magic."
+    "description": "A skilled mage who channels the power of light."
   },
   {
     "id": 58,
     "name": "Archmage",
-    "description": "A mysterious sorcerer attuned to light power."
+    "description": "A skilled mage who channels the power of light."
   },
   {
     "id": 59,
     "name": "Grand Sorcerer",
-    "description": "An arcane spellcaster channeling dark energy."
+    "description": "A mysterious sorcerer attuned to dark forces."
   },
   {
     "id": 60,
     "name": "Void Mage",
-    "description": "A skilled mage who wields light magic."
+    "description": "A skilled mage who channels the power of light."
   },
   {
     "id": 61,
-    "name": "Shadow Wyrm",
-    "description": "A mysterious sorcerer attuned to light power."
+    "name": "Starlight Diviner",
+    "description": "A skilled mage who channels the power of light."
   },
   {
     "id": 62,
-    "name": "Frost Dragon",
-    "description": "An arcane spellcaster channeling dark energy."
+    "name": "Shadow Enchanter",
+    "description": "A mysterious sorcerer attuned to dark forces."
   },
   {
     "id": 63,
-    "name": "Stone Dragon",
-    "description": "A skilled mage who wields light magic."
+    "name": "Jade Mystic",
+    "description": "A skilled mage who channels the power of light."
   },
   {
     "id": 64,
-    "name": "Dark Wyrm",
-    "description": "A mysterious sorcerer attuned to light power."
+    "name": "Lunar Invoker",
+    "description": "A skilled mage who channels the power of light."
   },
   {
     "id": 65,
-    "name": "Storm Dragon",
-    "description": "An arcane spellcaster channeling dark energy."
+    "name": "Dusk Conjurer",
+    "description": "A mysterious sorcerer attuned to dark forces."
   },
   {
     "id": 66,
-    "name": "Ancient Dragon",
+    "name": "Oracle of Light",
     "description": "[Effect] On Summon: Add 1 card from your Deck to your hand."
   },
   {
     "id": 67,
-    "name": "Jade Dragon",
+    "name": "Celestial Sage",
     "description": "[Effect] On Summon: All opponent monsters lose 200 ATK and 200 DEF."
   },
   {
     "id": 68,
-    "name": "Crimson Dragon",
+    "name": "Twilight Warlock",
     "description": "[Effect] When destroyed in battle: Draw 2 cards."
   },
   {
     "id": 69,
-    "name": "Thunder Dragon",
+    "name": "Healing Sage",
     "description": "[Effect] On Summon: Gain 500 LP."
   },
   {
     "id": 70,
-    "name": "Celestial Dragon",
+    "name": "Grand Diviner",
     "description": "[Effect] On Summon: Add 1 card from your Deck to your hand."
   },
   {
     "id": 71,
-    "name": "Emperor Dragon",
+    "name": "Dark Illusionist",
     "description": "[Effect] On Summon: All opponent monsters lose 300 ATK and 300 DEF."
   },
   {
     "id": 72,
-    "name": "Chaos Dragon",
+    "name": "Radiant Spellweaver",
     "description": "[Effect] On Summon: Return opponent's strongest monster to their hand."
   },
   {
     "id": 73,
-    "name": "Forest Wolf",
+    "name": "Mind Shatter Mage",
     "description": "[Effect] On Summon: All opponent monsters lose 400 ATK and 300 DEF."
   },
   {
     "id": 74,
-    "name": "Wild Boar",
+    "name": "Shadow Oracle",
     "description": "[Effect] On Summon: Add 1 card from your Deck to your hand."
   },
   {
     "id": 75,
-    "name": "Iron Bear",
+    "name": "Spirit Banisher",
     "description": "[Effect] On Summon: Return opponent's strongest monster to their hand."
   },
   {
     "id": 76,
-    "name": "Shadow Panther",
+    "name": "Supreme Enchantress",
     "description": "[Effect] On Summon: All opponent monsters lose 500 ATK and 400 DEF."
   },
   {
     "id": 77,
-    "name": "Storm Tiger",
+    "name": "Immortal Sage",
     "description": "[Passive] This monster cannot be targeted by effects."
   },
   {
     "id": 78,
-    "name": "Great Stag",
+    "name": "Chaos Sorcerer",
     "description": "[Effect] On Summon: Return opponent's strongest monster to their hand."
   },
   {
     "id": 79,
     "name": "War Elephant",
-    "description": "A wild creature born from fire forces."
+    "description": "A ferocious beast born from the flames of battle."
   },
   {
     "id": 80,
     "name": "Mountain Lion",
-    "description": "A powerful beast of the fire realm."
+    "description": "A ferocious beast born from the flames of battle."
   },
   {
     "id": 81,
     "name": "Dire Wolf",
-    "description": "A fierce beast infused with earth energy."
+    "description": "A mighty creature infused with the power of earth."
   },
   {
     "id": 82,
-    "name": "Savage Beast",
-    "description": "A wild creature born from fire forces."
+    "name": "Savage Boar",
+    "description": "A ferocious beast born from the flames of battle."
   },
   {
     "id": 83,
     "name": "Alpha Predator",
-    "description": "A powerful beast of the fire realm."
+    "description": "A ferocious beast born from the flames of battle."
   },
   {
     "id": 84,
     "name": "King of Beasts",
-    "description": "A fierce beast infused with fire energy."
+    "description": "A ferocious beast born from the flames of battle."
   },
   {
     "id": 85,
-    "name": "Seedling",
-    "description": "A wild creature born from earth forces."
+    "name": "Iron Stag",
+    "description": "A mighty creature infused with the power of earth."
   },
   {
     "id": 86,
-    "name": "Thorn Sprout",
-    "description": "A powerful beast of the fire realm."
+    "name": "Blazeclaw Tiger",
+    "description": "A ferocious beast born from the flames of battle."
   },
   {
     "id": 87,
-    "name": "Vine Creeper",
-    "description": "A fierce beast infused with fire energy."
+    "name": "Firemane Lion",
+    "description": "A ferocious beast born from the flames of battle."
   },
   {
     "id": 88,
-    "name": "Moss Guardian",
+    "name": "Embertusk Boar",
     "description": "[Effect] On Summon: Deal 300 damage to opponent."
   },
   {
     "id": 89,
-    "name": "Petal Dancer",
+    "name": "Stampede Bull",
     "description": "[Passive] Piercing: Deals battle damage even when attacking a DEF position monster."
   },
   {
     "id": 90,
-    "name": "Root Walker",
+    "name": "Scorchfang Panther",
     "description": "[Effect] On Summon: Deal 400 damage to opponent."
   },
   {
     "id": 91,
-    "name": "Flower Sentinel",
+    "name": "Inferno Tiger",
     "description": "[Passive] Piercing: Deals battle damage even when attacking a DEF position monster."
   },
   {
     "id": 92,
-    "name": "Ancient Treant",
+    "name": "Ancient Tortoise",
     "description": "[Effect] When destroyed in battle: Gain 500 LP."
   },
   {
     "id": 93,
-    "name": "Poison Bloom",
+    "name": "Thundermaw Bear",
     "description": "[Effect] On Summon: Deal 500 damage to opponent."
   },
   {
@@ -471,547 +471,547 @@
   },
   {
     "id": 95,
-    "name": "Sacred Tree",
+    "name": "Sacred Qilin",
     "description": "[Effect] On Summon: Deal 600 damage to opponent."
   },
   {
     "id": 96,
-    "name": "World Tree",
+    "name": "Divine Beast King",
     "description": "[Passive] When destroyed: Special Summon this monster from the Graveyard once."
   },
   {
     "id": 97,
-    "name": "Pebble",
+    "name": "Raging Behemoth",
     "description": "[Passive] Piercing: Deals battle damage even when attacking a DEF position monster."
   },
   {
     "id": 98,
-    "name": "Stone Shard",
+    "name": "Swift Raptor",
     "description": "[Passive] This monster can attack directly."
   },
   {
     "id": 99,
-    "name": "Boulder",
+    "name": "Seedling",
     "description": "A sentient plant thriving with earth energy."
   },
   {
     "id": 100,
-    "name": "Rock Sentinel",
-    "description": "A living plant creature nourished by earth power."
+    "name": "Thorn Sprout",
+    "description": "A sentient plant thriving with earth energy."
   },
   {
     "id": 101,
-    "name": "Iron Ore Golem",
-    "description": "A mystical flora channeling wind force."
+    "name": "Willow Wisp",
+    "description": "A mystical flora channeling the force of wind."
   },
   {
     "id": 102,
-    "name": "Granite Guard",
+    "name": "Vine Creeper",
     "description": "A sentient plant thriving with earth energy."
   },
   {
     "id": 103,
-    "name": "Obsidian Knight",
-    "description": "A living plant creature nourished by earth power."
+    "name": "Bamboo Sentinel",
+    "description": "A sentient plant thriving with earth energy."
   },
   {
     "id": 104,
-    "name": "Crystal Colossus",
-    "description": "A mystical flora channeling earth force."
+    "name": "Moss Guardian",
+    "description": "A sentient plant thriving with earth energy."
   },
   {
     "id": 105,
-    "name": "Diamond Titan",
-    "description": "A sentient plant thriving with wind energy."
+    "name": "Windbloom Fern",
+    "description": "A mystical flora channeling the force of wind."
   },
   {
     "id": 106,
-    "name": "Mountain Lord",
-    "description": "A living plant creature nourished by earth power."
+    "name": "Lotus Spirit",
+    "description": "A sentient plant thriving with earth energy."
   },
   {
     "id": 107,
-    "name": "Earthquake Giant",
-    "description": "A mystical flora channeling earth force."
+    "name": "Root Walker",
+    "description": "A sentient plant thriving with earth energy."
   },
   {
     "id": 108,
-    "name": "Primordial Rock",
-    "description": "A sentient plant thriving with wind energy."
+    "name": "Gale Blossom",
+    "description": "A mystical flora channeling the force of wind."
   },
   {
     "id": 109,
-    "name": "Spark",
+    "name": "Ancient Treant",
     "description": "[Effect] When destroyed in battle: Gain 500 LP."
   },
   {
     "id": 110,
-    "name": "Cinder Bird",
+    "name": "Jade Lotus",
     "description": "[Effect] On Summon: Gain 400 LP."
   },
   {
     "id": 111,
-    "name": "Fire Swallow",
+    "name": "Stormleaf Guardian",
     "description": "[Effect] When destroyed in battle: Draw 1 card."
   },
   {
     "id": 112,
-    "name": "Ember Crane",
+    "name": "Ironbark Titan",
     "description": "[Effect] On Summon: One of your monsters gains +300 DEF until end of turn."
   },
   {
     "id": 113,
-    "name": "Blaze Falcon",
+    "name": "Sacred Peach Tree",
     "description": "[Effect] When destroyed in battle: Gain 800 LP."
   },
   {
     "id": 114,
-    "name": "Solar Hawk",
+    "name": "World Tree",
     "description": "[Effect] On Summon: Gain 800 LP."
   },
   {
     "id": 115,
-    "name": "Inferno Raptor",
+    "name": "Celestial Orchid",
     "description": "[Effect] On Summon: All your Plant monsters gain +300 ATK/DEF."
   },
   {
     "id": 116,
-    "name": "Golden Phoenix",
+    "name": "Eternal Banyan",
     "description": "[Effect] When destroyed in battle: Gain 1200 LP."
   },
   {
     "id": 117,
-    "name": "Celestial Phoenix",
-    "description": "A massive stone creature infused with earth energy."
+    "name": "Pebble",
+    "description": "A massive stone creature animated by earth power."
   },
   {
     "id": 118,
-    "name": "Eternal Flame",
-    "description": "An ancient rock formation animated by earth power."
+    "name": "Stone Shard",
+    "description": "A massive stone creature animated by earth power."
   },
   {
     "id": 119,
-    "name": "Phoenix Emperor",
-    "description": "A sturdy rock being of the dark element."
+    "name": "Obsidian Sentry",
+    "description": "An ancient rock formation infused with dark energy."
   },
   {
     "id": 120,
-    "name": "Rebirth Phoenix",
-    "description": "A massive stone creature infused with earth energy."
+    "name": "Boulder",
+    "description": "A massive stone creature animated by earth power."
   },
   {
     "id": 121,
-    "name": "Skeleton",
-    "description": "An ancient rock formation animated by earth power."
+    "name": "Rock Sentinel",
+    "description": "A massive stone creature animated by earth power."
   },
   {
     "id": 122,
-    "name": "Ghoul",
-    "description": "A sturdy rock being of the earth element."
+    "name": "Granite Guard",
+    "description": "A massive stone creature animated by earth power."
   },
   {
     "id": 123,
-    "name": "Zombie Soldier",
-    "description": "A massive stone creature infused with dark energy."
+    "name": "Dark Ore Golem",
+    "description": "An ancient rock formation infused with dark energy."
   },
   {
     "id": 124,
-    "name": "Bone Knight",
-    "description": "An ancient rock formation animated by earth power."
+    "name": "Iron Ore Colossus",
+    "description": "A massive stone creature animated by earth power."
   },
   {
     "id": 125,
-    "name": "Phantom",
-    "description": "A sturdy rock being of the earth element."
+    "name": "Jade Stone",
+    "description": "A massive stone creature animated by earth power."
   },
   {
     "id": 126,
-    "name": "Wraith",
-    "description": "A massive stone creature infused with dark energy."
+    "name": "Onyx Golem",
+    "description": "An ancient rock formation infused with dark energy."
   },
   {
     "id": 127,
-    "name": "Death Knight",
+    "name": "Basalt Warden",
     "description": "[Passive] This monster cannot be targeted by effects."
   },
   {
     "id": 128,
-    "name": "Lich",
+    "name": "Crystal Colossus",
     "description": "[Effect] On Summon: All opponent monsters lose 200 ATK and 100 DEF."
   },
   {
     "id": 129,
-    "name": "Vampire Lord",
+    "name": "Shadow Monolith",
     "description": "[Effect] On Summon: One of your monsters gains +400 DEF until end of turn."
   },
   {
     "id": 130,
-    "name": "Soul Devourer",
+    "name": "Earthquake Giant",
     "description": "[Effect] When destroyed in battle: Draw 1 card."
   },
   {
     "id": 131,
-    "name": "Undead King",
+    "name": "Mountain Titan",
     "description": "[Passive] This monster cannot be targeted by effects."
   },
   {
     "id": 132,
-    "name": "Lord of the Dead",
+    "name": "Dark Mountain Lord",
     "description": "[Effect] On Summon: All opponent monsters lose 300 ATK and 200 DEF."
   },
   {
     "id": 133,
-    "name": "Tadpole",
+    "name": "Diamond Fortress",
     "description": "[Effect] On Summon: All opponent monsters lose 400 ATK and 300 DEF."
   },
   {
     "id": 134,
-    "name": "Jellyfish",
+    "name": "Primordial Colossus",
     "description": "[Passive] This monster cannot be targeted by effects."
   },
   {
     "id": 135,
-    "name": "Reef Fish",
+    "name": "Obsidian Emperor",
     "description": "[Effect] On Summon: All opponent monsters lose 500 ATK and 400 DEF."
   },
   {
     "id": 136,
-    "name": "River Sprite",
+    "name": "Earth Colossus",
     "description": "[Passive] This monster cannot be targeted by effects."
   },
   {
     "id": 137,
-    "name": "Tide Walker",
-    "description": "A legendary phoenix of fire origin."
+    "name": "Spark",
+    "description": "A radiant firebird blazing with fierce flames."
   },
   {
     "id": 138,
-    "name": "Deep Diver",
-    "description": "A radiant phoenix blazing with fire fire."
+    "name": "Cinder Bird",
+    "description": "A radiant firebird blazing with fierce flames."
   },
   {
     "id": 139,
-    "name": "Coral Guardian",
-    "description": "An immortal bird reborn through wind flames."
+    "name": "Wind Swallow",
+    "description": "An immortal bird soaring on winds of rebirth."
   },
   {
     "id": 140,
-    "name": "Sea Witch",
-    "description": "A legendary phoenix of fire origin."
+    "name": "Fire Swallow",
+    "description": "A radiant firebird blazing with fierce flames."
   },
   {
     "id": 141,
-    "name": "Leviathan",
-    "description": "A radiant phoenix blazing with fire fire."
+    "name": "Ember Crane",
+    "description": "A radiant firebird blazing with fierce flames."
   },
   {
     "id": 142,
-    "name": "Ocean Lord",
-    "description": "An immortal bird reborn through fire flames."
+    "name": "Blaze Falcon",
+    "description": "A radiant firebird blazing with fierce flames."
   },
   {
     "id": 143,
-    "name": "Tidal Wave",
-    "description": "A legendary phoenix of wind origin."
+    "name": "Gale Phoenix",
+    "description": "An immortal bird soaring on winds of rebirth."
   },
   {
     "id": 144,
-    "name": "Abyssal Sovereign",
+    "name": "Solar Hawk",
     "description": "[Effect] On Summon: Deal 400 damage to opponent."
   },
   {
     "id": 145,
-    "name": "Larva",
+    "name": "Inferno Raptor",
     "description": "[Passive] When destroyed: Special Summon this monster from the Graveyard once."
   },
   {
     "id": 146,
-    "name": "Firefly",
+    "name": "Stormfire Heron",
     "description": "[Effect] On Summon: Deal 500 damage to opponent."
   },
   {
     "id": 147,
-    "name": "Mantis",
+    "name": "Crimson Firebird",
     "description": "[Effect] On Summon: One of your monsters gains +400 ATK until end of turn."
   },
   {
     "id": 148,
-    "name": "Beetle Guard",
+    "name": "Golden Phoenix",
     "description": "[Passive] When destroyed: Special Summon this monster from the Graveyard once."
   },
   {
     "id": 149,
-    "name": "Wasp Warrior",
+    "name": "Blazewing Sovereign",
     "description": "[Effect] On Summon: Deal 700 damage to opponent."
   },
   {
     "id": 150,
-    "name": "Spider Queen",
+    "name": "Celestial Phoenix",
     "description": "[Passive] When destroyed: Special Summon this monster from the Graveyard once."
   },
   {
     "id": 151,
-    "name": "Scorpion King",
+    "name": "Phoenix Emperor",
     "description": "[Effect] On Summon: Deal 1000 damage to opponent."
   },
   {
     "id": 152,
-    "name": "Centipede",
-    "description": "A haunting presence fueled by dark power."
+    "name": "Skeleton",
+    "description": "A restless spirit bound by dark sorcery."
   },
   {
     "id": 153,
-    "name": "Moth Dancer",
-    "description": "A restless spirit bound by dark energy."
+    "name": "Ghoul",
+    "description": "A restless spirit bound by dark sorcery."
   },
   {
     "id": 154,
-    "name": "Scarab Lord",
-    "description": "An undead creature risen through earth sorcery."
+    "name": "Bone Warrior",
+    "description": "An undead creature risen through earth magic."
   },
   {
     "id": 155,
-    "name": "Hive Queen",
-    "description": "A haunting presence fueled by dark power."
+    "name": "Restless Spirit",
+    "description": "A restless spirit bound by dark sorcery."
   },
   {
     "id": 156,
-    "name": "Insect Emperor",
-    "description": "A restless spirit bound by dark energy."
+    "name": "Zombie Soldier",
+    "description": "A restless spirit bound by dark sorcery."
   },
   {
     "id": 157,
-    "name": "Cog",
-    "description": "An undead creature risen through dark sorcery."
+    "name": "Phantom",
+    "description": "A restless spirit bound by dark sorcery."
   },
   {
     "id": 158,
-    "name": "Gear Soldier",
-    "description": "A haunting presence fueled by dark power."
+    "name": "Bone Knight",
+    "description": "A restless spirit bound by dark sorcery."
   },
   {
     "id": 159,
-    "name": "Steam Golem",
-    "description": "A restless spirit bound by earth energy."
+    "name": "Grave Golem",
+    "description": "An undead creature risen through earth magic."
   },
   {
     "id": 160,
-    "name": "Iron Sentinel",
-    "description": "An undead creature risen through dark sorcery."
+    "name": "Wraith",
+    "description": "A restless spirit bound by dark sorcery."
   },
   {
     "id": 161,
-    "name": "Clockwork Knight",
+    "name": "Death Knight",
     "description": "[Passive] When destroyed: Special Summon this monster from the Graveyard once."
   },
   {
     "id": 162,
-    "name": "Cannon Golem",
+    "name": "Soul Harvester",
     "description": "[Effect] When destroyed in battle: Gain 600 LP."
   },
   {
     "id": 163,
-    "name": "Siege Engine",
+    "name": "Lich",
     "description": "[Effect] When destroyed in battle: Draw 2 cards."
   },
   {
     "id": 164,
-    "name": "Steel Colossus",
+    "name": "Vampire Lord",
     "description": "[Passive] When destroyed: Special Summon this monster from the Graveyard once."
   },
   {
     "id": 165,
-    "name": "War Machine",
+    "name": "Soul Devourer",
     "description": "[Effect] On Summon: Gain 600 LP."
   },
   {
     "id": 166,
-    "name": "Mecha Dragon",
+    "name": "Undead General",
     "description": "[Passive] When destroyed: Special Summon this monster from the Graveyard once."
   },
   {
     "id": 167,
-    "name": "Iron Fortress",
+    "name": "Lord of the Dead",
     "description": "[Effect] When destroyed in battle: Gain 1000 LP."
   },
   {
     "id": 168,
-    "name": "Omega Machine",
+    "name": "Netherworld King",
     "description": "[Passive] When destroyed: Special Summon this monster from the Graveyard once."
   },
   {
     "id": 169,
-    "name": "Ember Sprite",
+    "name": "Abyssal Revenant",
     "description": "[Effect] On Summon: All opponent monsters lose 400 ATK and 300 DEF."
   },
   {
     "id": 170,
-    "name": "Fire Imp",
-    "description": "A mysterious sea creature infused with water energy."
+    "name": "Tadpole",
+    "description": "A graceful water creature of the deep currents."
   },
   {
     "id": 171,
-    "name": "Lava Slug",
-    "description": "A graceful aquatic creature of water origin."
+    "name": "Jellyfish",
+    "description": "A graceful water creature of the deep currents."
   },
   {
     "id": 172,
-    "name": "Flame Djinn",
-    "description": "A water dweller channeling wind currents."
+    "name": "Wind Koi",
+    "description": "A swift aquatic spirit riding wind-touched waves."
   },
   {
     "id": 173,
-    "name": "Molten Golem",
-    "description": "A mysterious sea creature infused with water energy."
+    "name": "Reef Fish",
+    "description": "A graceful water creature of the deep currents."
   },
   {
     "id": 174,
-    "name": "Inferno Hound",
-    "description": "A graceful aquatic creature of water origin."
+    "name": "River Sprite",
+    "description": "A graceful water creature of the deep currents."
   },
   {
     "id": 175,
-    "name": "Blaze Elemental",
-    "description": "A water dweller channeling water currents."
+    "name": "Tide Walker",
+    "description": "A graceful water creature of the deep currents."
   },
   {
     "id": 176,
-    "name": "Volcanic Giant",
-    "description": "A mysterious sea creature infused with water energy."
+    "name": "Deep Diver",
+    "description": "A graceful water creature of the deep currents."
   },
   {
     "id": 177,
-    "name": "Fire Lord",
-    "description": "A graceful aquatic creature of wind origin."
+    "name": "Coral Guardian",
+    "description": "A swift aquatic spirit riding wind-touched waves."
   },
   {
     "id": 178,
-    "name": "Magma Dragon",
-    "description": "A water dweller channeling water currents."
+    "name": "Sea Witch",
+    "description": "A graceful water creature of the deep currents."
   },
   {
     "id": 179,
-    "name": "Solar Titan",
-    "description": "A mysterious sea creature infused with water energy."
+    "name": "Abyssal Angler",
+    "description": "A graceful water creature of the deep currents."
   },
   {
     "id": 180,
-    "name": "Hellfire King",
+    "name": "Leviathan",
     "description": "[Effect] On Summon: Return opponent's strongest monster to their hand."
   },
   {
     "id": 181,
-    "name": "Lunar Mage",
+    "name": "Gale Mermaid",
     "description": "[Effect] On Summon: One of your monsters gains +350 DEF until end of turn."
   },
   {
     "id": 182,
-    "name": "Starlight Sage",
+    "name": "Ocean Sage",
     "description": "[Effect] On Summon: Return opponent's strongest monster to their hand."
   },
   {
     "id": 183,
-    "name": "Phantom Thief",
+    "name": "Depth Oracle",
     "description": "[Effect] On Summon: Add 1 card from your Deck to your hand."
   },
   {
     "id": 184,
-    "name": "Shadow Dancer",
+    "name": "Storm Serpent",
     "description": "[Effect] On Summon: All opponent monsters lose 300 ATK and 200 DEF."
   },
   {
     "id": 185,
-    "name": "Thunder Lord",
+    "name": "Tidal Lord",
     "description": "[Effect] On Summon: Return opponent's strongest monster to their hand."
   },
   {
     "id": 186,
-    "name": "Frost Giant",
+    "name": "Frost Kraken",
     "description": "[Effect] On Summon: One of your monsters gains +500 DEF until end of turn."
   },
   {
     "id": 187,
-    "name": "Iron Maiden",
+    "name": "Abyssal Sovereign",
     "description": "[Effect] On Summon: Return opponent's strongest monster to their hand."
   },
   {
     "id": 188,
-    "name": "Golden General",
+    "name": "Ocean Emperor",
     "description": "[Passive] This monster cannot be targeted by effects."
   },
   {
     "id": 189,
-    "name": "Jade Empress",
+    "name": "Jade Sea Dragon",
     "description": "[Effect] On Summon: Return opponent's strongest monster to their hand."
   },
   {
     "id": 190,
-    "name": "Dragon Knight",
-    "description": "A resilient bug creature of the wind domain."
+    "name": "Larva",
+    "description": "A swift insect empowered by the wind."
   },
   {
     "id": 191,
-    "name": "Storm Sage",
-    "description": "A cunning insect thriving in wind conditions."
+    "name": "Firefly",
+    "description": "A swift insect empowered by the wind."
   },
   {
     "id": 192,
-    "name": "Fire Sorcerer",
-    "description": "A swift insect empowered by earth energy."
+    "name": "Scarab",
+    "description": "A resilient bug creature of the earth."
   },
   {
     "id": 193,
-    "name": "Water Mystic",
-    "description": "A resilient bug creature of the wind domain."
+    "name": "Windhopper",
+    "description": "A swift insect empowered by the wind."
   },
   {
     "id": 194,
-    "name": "Earth Shaman",
-    "description": "A cunning insect thriving in wind conditions."
+    "name": "Mantis",
+    "description": "A swift insect empowered by the wind."
   },
   {
     "id": 195,
-    "name": "Wind Dancer",
-    "description": "A swift insect empowered by wind energy."
+    "name": "Beetle Guard",
+    "description": "A swift insect empowered by the wind."
   },
   {
     "id": 196,
-    "name": "Light Paladin",
-    "description": "A resilient bug creature of the wind domain."
+    "name": "Gale Moth",
+    "description": "A swift insect empowered by the wind."
   },
   {
     "id": 197,
-    "name": "Dark Overlord",
-    "description": "A cunning insect thriving in earth conditions."
+    "name": "Burrowing Centipede",
+    "description": "A resilient bug creature of the earth."
   },
   {
     "id": 198,
-    "name": "Chaos Mage",
-    "description": "A swift insect empowered by wind energy."
+    "name": "Wasp Warrior",
+    "description": "A swift insect empowered by the wind."
   },
   {
     "id": 199,
-    "name": "Crystal Sage",
+    "name": "Silk Spinner",
     "description": "[Effect] On Summon: One of your monsters gains +300 ATK until end of turn."
   },
   {
     "id": 200,
-    "name": "Moss Colossus",
+    "name": "Hive Commander",
     "description": "[Effect] On Summon: All your Insect monsters gain +250 ATK/DEF."
   },
   {
     "id": 201,
-    "name": "Thunder Bird",
+    "name": "Thunder Beetle",
     "description": "[Effect] When destroyed in battle: Draw 2 cards."
   },
   {
     "id": 202,
-    "name": "Iron Scorpion",
+    "name": "Scorpion King",
     "description": "[Effect] On Summon: One of your monsters gains +500 ATK until end of turn."
   },
   {
     "id": 203,
-    "name": "Poison Viper",
+    "name": "Swarm Queen",
     "description": "[Effect] On Summon: All your Insect monsters gain +350 ATK/DEF."
   },
   {
@@ -1021,92 +1021,92 @@
   },
   {
     "id": 205,
-    "name": "Blood Wolf",
+    "name": "Earth Borer",
     "description": "[Effect] On Summon: One of your monsters gains +600 ATK until end of turn."
   },
   {
     "id": 206,
-    "name": "Ghost Knight",
+    "name": "Insect Emperor",
     "description": "[Effect] On Summon: All your Insect monsters gain +500 ATK/DEF."
   },
   {
     "id": 207,
-    "name": "Flame Titan",
+    "name": "Windstorm Locust",
     "description": "[Passive] This monster can attack directly."
   },
   {
     "id": 208,
-    "name": "Ice Phoenix",
-    "description": "A mechanical construct driven by light force."
+    "name": "Cog",
+    "description": "A mechanical construct driven by radiant energy."
   },
   {
     "id": 209,
-    "name": "Storm Wyrm",
-    "description": "A sophisticated automaton fueled by light power."
+    "name": "Gear Soldier",
+    "description": "A mechanical construct driven by radiant energy."
   },
   {
     "id": 210,
-    "name": "Root Ancient",
-    "description": "An advanced machine powered by earth energy."
+    "name": "Iron Digger",
+    "description": "An advanced automaton powered by earth force."
   },
   {
     "id": 211,
-    "name": "Star Dragon",
-    "description": "A mechanical construct driven by light force."
+    "name": "Spark Automaton",
+    "description": "A mechanical construct driven by radiant energy."
   },
   {
     "id": 212,
-    "name": "Void Walker",
-    "description": "A sophisticated automaton fueled by light power."
+    "name": "Bronze Sentry",
+    "description": "A mechanical construct driven by radiant energy."
   },
   {
     "id": 213,
-    "name": "Sun General",
-    "description": "An advanced machine powered by earth energy."
+    "name": "Earth Crawler",
+    "description": "An advanced automaton powered by earth force."
   },
   {
     "id": 214,
-    "name": "Moon Priestess",
-    "description": "A mechanical construct driven by light force."
+    "name": "Clockwork Knight",
+    "description": "A mechanical construct driven by radiant energy."
   },
   {
     "id": 215,
-    "name": "Dawn Warrior",
-    "description": "A sophisticated automaton fueled by light power."
+    "name": "Luminous Mech",
+    "description": "A mechanical construct driven by radiant energy."
   },
   {
     "id": 216,
-    "name": "Dusk Assassin",
-    "description": "An advanced machine powered by earth energy."
+    "name": "Siege Golem",
+    "description": "An advanced automaton powered by earth force."
   },
   {
     "id": 217,
-    "name": "Inferno Dragon",
-    "description": "A mechanical construct driven by light force."
+    "name": "Radiant Automaton",
+    "description": "A mechanical construct driven by radiant energy."
   },
   {
     "id": 218,
-    "name": "Blizzard Dragon",
+    "name": "Steel Colossus",
     "description": "[Effect] On Summon: All your Machine monsters gain +200 ATK/DEF."
   },
   {
     "id": 219,
-    "name": "Thunder Dragon Lord",
+    "name": "Iron Juggernaut",
     "description": "[Effect] On Summon: One of your monsters gains +300 ATK until end of turn."
   },
   {
     "id": 220,
-    "name": "Gaia Knight",
+    "name": "War Machine",
     "description": "[Effect] On Summon: All your Machine monsters gain +300 ATK/DEF."
   },
   {
     "id": 221,
-    "name": "Sacred Beast",
+    "name": "Cannon Golem",
     "description": "[Effect] On Summon: Deal 400 damage to opponent."
   },
   {
     "id": 222,
-    "name": "Ancient Guardian",
+    "name": "Mecha Titan",
     "description": "[Effect] On Summon: One of your monsters gains +400 ATK until end of turn."
   },
   {
@@ -1116,312 +1116,312 @@
   },
   {
     "id": 224,
-    "name": "Deep Terror",
+    "name": "Iron Fortress",
     "description": "[Effect] On Summon: All your Machine monsters gain +500 ATK/DEF."
   },
   {
     "id": 225,
-    "name": "World Serpent",
+    "name": "Omega Machine",
     "description": "[Effect] On Summon: One of your monsters gains +500 ATK until end of turn."
   },
   {
     "id": 226,
-    "name": "Heaven General",
+    "name": "Heaven's Automaton",
     "description": "[Effect] On Summon: All your Machine monsters gain +600 ATK/DEF."
   },
   {
     "id": 227,
-    "name": "Demon Slayer",
+    "name": "Mecha Dragon",
     "description": "[Effect] On Summon: All opponent monsters lose 400 ATK and 300 DEF."
   },
   {
     "id": 228,
-    "name": "Holy Dragon",
-    "description": "A blazing pyro creature of fire origin."
+    "name": "Ember Sprite",
+    "description": "A blazing pyro creature born from pure fire."
   },
   {
     "id": 229,
-    "name": "Shadow Dragon",
-    "description": "A fiery being born from fire flames."
+    "name": "Fire Imp",
+    "description": "A blazing pyro creature born from pure fire."
   },
   {
     "id": 230,
-    "name": "Divine Phoenix",
-    "description": "A volatile pyro entity radiating light heat."
+    "name": "Flash Flare",
+    "description": "A volatile fire entity radiating brilliant light."
   },
   {
     "id": 231,
-    "name": "Spirit King",
-    "description": "A blazing pyro creature of fire origin."
+    "name": "Lava Slug",
+    "description": "A blazing pyro creature born from pure fire."
   },
   {
     "id": 232,
-    "name": "Cursed Knight",
-    "description": "A fiery being born from fire flames."
+    "name": "Flame Djinn",
+    "description": "A blazing pyro creature born from pure fire."
   },
   {
     "id": 233,
-    "name": "Brave Hero",
-    "description": "A volatile pyro entity radiating light heat."
+    "name": "Solar Wisp",
+    "description": "A volatile fire entity radiating brilliant light."
   },
   {
     "id": 234,
-    "name": "Fallen Angel",
-    "description": "A blazing pyro creature of fire origin."
+    "name": "Molten Golem",
+    "description": "A blazing pyro creature born from pure fire."
   },
   {
     "id": 235,
-    "name": "Rising Dragon",
-    "description": "A fiery being born from fire flames."
+    "name": "Inferno Hound",
+    "description": "A blazing pyro creature born from pure fire."
   },
   {
     "id": 236,
-    "name": "Azure Dragon",
-    "description": "A volatile pyro entity radiating light heat."
+    "name": "Blaze Elemental",
+    "description": "A volatile fire entity radiating brilliant light."
   },
   {
     "id": 237,
-    "name": "Vermilion Bird",
+    "name": "Volcanic Giant",
     "description": "[Effect] On Summon: Deal 400 damage to opponent."
   },
   {
     "id": 238,
-    "name": "White Tiger",
+    "name": "Fire Lord",
     "description": "[Effect] On Summon: Deal 500 damage to opponent."
   },
   {
     "id": 239,
-    "name": "Black Tortoise",
+    "name": "Solar Titan",
     "description": "[Effect] On Summon: Deal 600 damage to opponent."
   },
   {
     "id": 240,
-    "name": "Celestial Emperor",
+    "name": "Magma Dragon",
     "description": "[Effect] On Summon: One of your monsters gains +400 ATK until end of turn."
   },
   {
     "id": 241,
-    "name": "Flame Dragon Knight",
+    "name": "Hellfire Knight",
     "description": "[Effect] On Summon: Deal 700 damage to opponent."
   },
   {
     "id": 242,
-    "name": "Storm Blade Master",
+    "name": "Inferno Colossus",
     "description": "[Effect] On Summon: Deal 800 damage to opponent."
   },
   {
     "id": 243,
-    "name": "Shadow Phoenix",
+    "name": "Radiant Pyre",
     "description": "[Effect] On Summon: One of your monsters gains +500 ATK until end of turn."
   },
   {
     "id": 244,
-    "name": "Crystal Dragon",
+    "name": "Eruption King",
     "description": "[Effect] On Summon: Deal 1000 damage to opponent."
   },
   {
     "id": 245,
-    "name": "Iron Dragon",
+    "name": "Hellfire Sovereign",
     "description": "[Effect] When destroyed by opponent: Deal 1500 damage to opponent."
   },
   {
     "id": 246,
-    "name": "Moss Dragon",
+    "name": "Dragonflame Fury",
     "description": "[Effect] On Summon: Deal 500 damage to opponent."
   },
   {
     "id": 247,
-    "name": "Thunder Phoenix",
+    "name": "Supreme Dragonlord",
     "description": "[Effect] On Summon: All opponent monsters lose 500 ATK and 400 DEF."
   },
   {
     "id": 248,
-    "name": "Frost Warrior",
+    "name": "Twilight Enchanter",
     "description": "[Effect] On Summon: Draw 1 card."
   },
   {
     "id": 249,
-    "name": "Magma Warrior",
+    "name": "Grand Shadowcaster",
     "description": "[Effect] On Summon: Return opponent's strongest monster to their hand."
   },
   {
     "id": 250,
-    "name": "Aqua Dragon",
+    "name": "Earth's Vanguard",
     "description": "[Effect] On Summon: All your Warrior monsters gain +300 ATK/DEF."
   },
   {
     "id": 251,
-    "name": "Wind Phoenix",
+    "name": "Imperial War God",
     "description": "[Effect] On Summon: One of your monsters permanently gains +500 ATK."
   },
   {
     "id": 252,
-    "name": "Earth Dragon",
+    "name": "Stampede Chimera",
     "description": "[Effect] On Summon: One of your monsters gains +400 ATK until end of turn."
   },
   {
     "id": 253,
-    "name": "Solar Dragon Knight",
+    "name": "Sacred Beast Emperor",
     "description": "[Effect] On Summon: Deal 600 damage to opponent."
   },
   {
     "id": 254,
-    "name": "Lunar Dragon Knight",
+    "name": "Lotus Treeguard",
     "description": "[Effect] On Summon: Gain 800 LP."
   },
   {
     "id": 255,
-    "name": "Chaos Dragon Knight",
+    "name": "Eternal Grove Spirit",
     "description": "[Effect] On Summon: One of your monsters permanently gains +500 DEF."
   },
   {
     "id": 256,
-    "name": "Supreme War General",
+    "name": "Granite Overlord",
     "description": "[Effect] On Summon: One of your monsters gains +500 DEF until end of turn."
   },
   {
     "id": 257,
-    "name": "Divine Dragon Emperor",
+    "name": "Primordial Earth Titan",
     "description": "[Effect] On Summon: All opponent monsters lose 300 ATK and 500 DEF."
   },
   {
     "id": 258,
-    "name": "Phantom Dragon",
+    "name": "Blazewing Wyvern",
     "description": "[Effect] On Summon: Deal 500 damage to opponent."
   },
   {
     "id": 259,
-    "name": "Jade Dragon Knight",
+    "name": "Immortal Phoenix Lord",
     "description": "[Passive] When destroyed: Special Summon this monster from the Graveyard once."
   },
   {
     "id": 260,
-    "name": "Crimson Phoenix",
+    "name": "Spectral Warlord",
     "description": "[Effect] On Summon: All opponent monsters lose 400 ATK until end of turn."
   },
   {
     "id": 261,
-    "name": "Dark Phoenix",
+    "name": "Netherworld Overlord",
     "description": "[Effect] When destroyed in battle: Draw 2 cards."
   },
   {
     "id": 262,
-    "name": "Holy Phoenix",
+    "name": "Tidal Dragon",
     "description": "[Effect] On Summon: Gain 600 LP."
   },
   {
     "id": 263,
-    "name": "Storm Dragon Knight",
+    "name": "Abyssal Sea God",
     "description": "[Effect] On Summon: All your Water monsters gain +400 ATK/DEF."
   },
   {
     "id": 264,
-    "name": "Frost Dragon Knight",
+    "name": "Ironshell Mantis",
     "description": "[Effect] On Summon: Draw 1 card."
   },
   {
     "id": 265,
-    "name": "Inferno Phoenix",
+    "name": "Swarm Overlord",
     "description": "[Effect] On Summon: One of your monsters gains +600 ATK until end of turn."
   },
   {
     "id": 266,
-    "name": "Sacred Dragon",
+    "name": "Flame Arrow",
     "description": "Deal 300 damage to opponent."
   },
   {
     "id": 267,
-    "name": "Ancient Dragon God",
+    "name": "Fireball",
     "description": "Deal 400 damage to opponent."
   },
   {
     "id": 268,
-    "name": "Dragon Phoenix",
+    "name": "Inferno Blast",
     "description": "Deal 500 damage to opponent."
   },
   {
     "id": 269,
-    "name": "Supreme Phoenix",
+    "name": "Herbal Remedy",
     "description": "Gain 300 LP."
   },
   {
     "id": 270,
-    "name": "Celestial Dragon Knight",
+    "name": "Jade Elixir",
     "description": "Gain 500 LP."
   },
   {
     "id": 271,
-    "name": "Dragon Emperor",
+    "name": "Heavenly Blessing",
     "description": "Gain 800 LP."
   },
   {
     "id": 272,
-    "name": "Phoenix Emperor",
+    "name": "Dragon's Breath",
     "description": "Deal 600 damage to opponent."
   },
   {
     "id": 273,
-    "name": "Storm Emperor",
+    "name": "Thunder Strike",
     "description": "Deal 800 damage to opponent."
   },
   {
     "id": 274,
-    "name": "Frost Emperor",
+    "name": "Warrior's Rally",
     "description": "One of your monsters gains +300 ATK until end of turn."
   },
   {
     "id": 275,
-    "name": "Supreme Emperor",
+    "name": "General's Command",
     "description": "One of your monsters gains +400 ATK until end of turn."
   },
   {
     "id": 276,
-    "name": "Dragon Phoenix Emperor",
+    "name": "Warlord's Fury",
     "description": "One of your monsters gains +500 ATK until end of turn."
   },
   {
     "id": 277,
-    "name": "Heavenly Dragon",
+    "name": "Weakening Hex",
     "description": "All opponent monsters lose 300 ATK until end of turn."
   },
   {
     "id": 278,
-    "name": "Supreme Beast",
+    "name": "Draw of Fate",
     "description": "Draw 1 card."
   },
   {
     "id": 279,
-    "name": "Ultimate Dragon",
+    "name": "Iron Wall Tactic",
     "description": "One of your monsters gains +400 DEF until end of turn."
   },
   {
     "id": 280,
-    "name": "Supreme Fusion",
+    "name": "Mystic Restoration",
     "description": "Gain 600 LP."
   },
   {
     "id": 281,
-    "name": "Fireball",
+    "name": "Cataclysm",
     "description": "Deal 1000 damage to opponent."
   },
   {
     "id": 282,
-    "name": "Healing Light",
+    "name": "Annihilation Wave",
     "description": "Deal 1200 damage to opponent."
   },
   {
     "id": 283,
-    "name": "Dark Hole",
+    "name": "Void Collapse",
     "description": "Deal 1500 damage to opponent."
   },
   {
     "id": 284,
-    "name": "Thunder Strike",
+    "name": "Blaze Formation",
     "description": "All your Fire monsters gain +300 ATK/DEF."
   },
   {
     "id": 285,
-    "name": "Mystical Wind",
+    "name": "Tidal Formation",
     "description": "All your Water monsters gain +300 ATK/DEF."
   },
   {
@@ -1431,22 +1431,22 @@
   },
   {
     "id": 287,
-    "name": "Trap Destruction",
+    "name": "Forced Retreat",
     "description": "Return opponent's strongest monster to their hand."
   },
   {
     "id": 288,
-    "name": "Monster Reincarnation",
+    "name": "Grand Expulsion",
     "description": "Return all opponent monsters to their hand."
   },
   {
     "id": 289,
-    "name": "Draw of Fate",
+    "name": "Scroll of Wisdom",
     "description": "Draw 2 cards."
   },
   {
     "id": 290,
-    "name": "Shield of Light",
+    "name": "Devastation Bolt",
     "description": "Deal 2000 damage to opponent."
   },
   {
@@ -1491,7 +1491,7 @@
   },
   {
     "id": 299,
-    "name": "Double Attack",
+    "name": "Ambush Strike",
     "description": "Activate when opponent summons a monster: Destroy the summoned monster if it has 1500+ ATK."
   },
   {


### PR DESCRIPTION
Card names were completely mismatched with their data - dragon-race cards
had names like "Fire Salamander" and "Stone Golem", spellcaster cards were
named "Frost Dragon" and "Ancient Dragon", beast cards had plant names, etc.
Descriptions also referenced wrong races. This renames every card to fit its
actual race/attribute/level and fixes flavor text descriptions accordingly.

https://claude.ai/code/session_01FtgRmTUdMup8TnZUmFiTER