### PR TITLE
fix(campaign): back button navigates to save-point and shrink dropdown

### DIFF
--- a/js/react/screens/CampaignScreen.module.css
+++ b/js/react/screens/CampaignScreen.module.css
@@ -47,7 +47,7 @@
 
 .chapterSelect {
   width: 100%;
-  max-width: 320px;
+  max-width: 220px;
   padding: 6px 12px;
   font-size: 0.6rem;
   font-family: 'Press Start 2P', monospace;

--- a/js/react/screens/CampaignScreen.tsx
+++ b/js/react/screens/CampaignScreen.tsx
@@ -166,7 +166,7 @@ export default function CampaignScreen() {
       <div className={styles.screen}>
         <div className={styles.header}>
           <h2 className={styles.title}>{t('campaign.title')}</h2>
-          <button className={`btn-secondary ${styles.backBtn}`} onClick={() => navigateTo('title')}>{t('common.back')}</button>
+          <button className={`btn-secondary ${styles.backBtn}`} onClick={() => navigateTo('save-point')}>{t('common.back')}</button>
         </div>
         <p style={{ color: '#6080a0', marginTop: 40 }}>{t('campaign.no_data')}</p>
       </div>
@@ -177,7 +177,7 @@ export default function CampaignScreen() {
     <div className={styles.screen}>
       <div className={styles.header}>
         <h2 className={styles.title}>{t('campaign.title')}</h2>
-        <button className={`btn-secondary ${styles.backBtn}`} onClick={() => navigateTo('title')}>{t('common.back')}</button>
+        <button className={`btn-secondary ${styles.backBtn}`} onClick={() => navigateTo('save-point')}>{t('common.back')}</button>
       </div>
 
       {chapters.length > 1 && (


### PR DESCRIPTION
Back button was navigating to title screen instead of save-point screen.
Also reduced chapter dropdown max-width from 320px to 220px.

https://claude.ai/code/session_01TR6eFc3DGnU9TMMZZucWAu