### PR TITLE
Improve fusion card selection UX with toggle and better positioning

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -621,11 +621,17 @@ button { cursor: pointer; border: none; font-family: inherit; transition: none; 
   background: rgba(0, 0, 0, 0.85);
   border: 2px solid #ffd700;
   border-radius: 8px;
-  margin-bottom: 6px;
   font-family: 'Silkscreen', 'Press Start 2P', monospace;
   font-size: 10px;
   color: #eee;
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-bottom: 4px;
   z-index: 100;
+  white-space: nowrap;
+  pointer-events: auto;
 }
 .fusion-preview-text {
   color: #ffd700;

--- a/js/react/components/HandCard.tsx
+++ b/js/react/components/HandCard.tsx
@@ -25,10 +25,9 @@ export function HandCard({ card, index, playable, fusionable, targetable, chainS
   const isSelected = chainSelected || fusionSelected;
   const badgeNumber = chainIndex ?? fusionIndex;
 
-  const canClick = playable || targetable || fusionSelected;
   const longPressHandlers = useLongPress({
     onLongPress: onLongPress ?? (() => {}),
-    onClick: canClick ? onClick : undefined,
+    onClick,
   });
 
   const cls = [

--- a/js/react/screens/game/HandArea.tsx
+++ b/js/react/screens/game/HandArea.tsx
@@ -72,7 +72,14 @@ export function HandArea() {
     if (player.normalSummonUsed) return;
     const freeZone = player.field.monsters.findIndex((z: any) => z === null);
     if (freeZone === -1) return;
-    if (fusionGroup.includes(index)) return;
+    // Toggle: remove if already in group
+    if (fusionGroup.includes(index)) {
+      const newGroup = fusionGroup.filter(i => i !== index);
+      const cardIds = newGroup.map(i => player.hand[i].id);
+      const preview = cardIds.length >= 2 ? resolveFusionChain(cardIds) : null;
+      setSel({ fusionGroup: newGroup, fusionGroupPreview: preview });
+      return;
+    }
 
     const newGroup = [...fusionGroup, index];
     const cardIds = newGroup.map(i => player.hand[i].id);


### PR DESCRIPTION
## Summary
Enhanced the fusion card selection mechanic to allow toggling cards in/out of the fusion group, and improved the visual presentation of fusion preview tooltips with better positioning and accessibility.

## Key Changes
- **Fusion group toggle functionality**: Cards can now be deselected from the fusion group by clicking them again, with the preview updating accordingly
- **Fusion preview tooltip positioning**: Changed from margin-based to absolute positioning (bottom: 100%, centered) for more reliable placement above cards
- **Improved tooltip styling**: Added `white-space: nowrap` and `pointer-events: auto` for better text handling and interaction
- **Simplified hand card click logic**: Removed conditional click handler logic to allow clicks on all hand cards, letting parent components handle the routing

## Implementation Details
- When a card already in the fusion group is clicked, it's now removed and the preview is recalculated (only showing if 2+ cards remain)
- The fusion preview tooltip now uses CSS transforms for centering, making it more robust across different container sizes
- The HandCard component now always passes the onClick handler to the long press handler, simplifying the component logic

https://claude.ai/code/session_01JPTEDLuLV9x2G9ex78ei32