### PR TITLE
Fix duel checkpoint cleanup and add battle music on game start

### DIFF
--- a/js/progression.ts
+++ b/js/progression.ts
@@ -335,6 +335,7 @@ export const Progression = (() => {
   /** Resets all progression data (debug only) */
   function resetAll() {
     Object.values(KEYS).forEach(k => localStorage.removeItem(k));
+    localStorage.removeItem(DUEL_CHECKPOINT_KEY);
     console.warn('[Progression] All data reset.');
   }
 

--- a/js/react/contexts/GameContext.tsx
+++ b/js/react/contexts/GameContext.tsx
@@ -142,6 +142,11 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
       });
     },
     onDuelEnd: (result, opponentId) => {
+      // Clear engine refs synchronously so beforeunload won't re-save a stale checkpoint
+      gameRef.current = null;
+      gameStateRef.current = null;
+      setGameState(null);
+
       // Clear duel checkpoint — the duel is over
       import('../../progression.js').then(({ Progression }) => Progression.clearDuelCheckpoint());
 
@@ -328,6 +333,7 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
 
         g.restoreGame(saved.checkpoint);
         setScreenRef.current('game');
+        Audio.playMusic('music_battle');
       });
     });
   }, [uiCallbacks]);
@@ -357,6 +363,7 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
         gameRef.current = g;
         g.initGame(deck, cfg).then(() => {
           setScreenRef.current('game');
+          Audio.playMusic('music_battle');
         });
       });
     });

--- a/js/react/screens/TitleScreen.tsx
+++ b/js/react/screens/TitleScreen.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { useScreen }      from '../contexts/ScreenContext.js';
 import { useProgression } from '../contexts/ProgressionContext.js';
 import { useModal }       from '../contexts/ModalContext.js';
+import { useCampaign }    from '../contexts/CampaignContext.js';
 import { Progression }    from '../../progression.js';
 import styles from './TitleScreen.module.css';
 
@@ -9,6 +10,7 @@ export default function TitleScreen() {
   const { navigateTo } = useScreen();
   const { refresh }   = useProgression();
   const { openModal } = useModal();
+  const { refreshCampaignProgress } = useCampaign();
   const { t } = useTranslation();
   const hasSave = !Progression.isFirstLaunch();
 
@@ -17,6 +19,7 @@ export default function TitleScreen() {
     Progression.resetAll();
     Progression.init();
     refresh();
+    refreshCampaignProgress();
     navigateTo('starter');
   }
 


### PR DESCRIPTION
## Summary
This PR fixes several issues related to duel checkpoint management and adds missing battle music playback when starting or resuming games.

## Key Changes
- **Duel checkpoint cleanup**: Clear engine refs synchronously in `onDuelEnd` before the async checkpoint clearing to prevent `beforeunload` from re-saving a stale checkpoint
- **Battle music**: Add `Audio.playMusic('music_battle')` when resuming a saved game and when starting a new game
- **Campaign progress refresh**: Call `refreshCampaignProgress()` when resetting all progression data from the title screen
- **Complete progression reset**: Include duel checkpoint key in the `resetAll()` function to ensure all progression data is properly cleared

## Implementation Details
- The synchronous clearing of `gameRef.current`, `gameStateRef.current`, and `setGameState(null)` ensures the game state is cleaned up before the async progression checkpoint clearing occurs
- Battle music is now consistently played in both game initialization paths (new game and resume game)
- Campaign context is now properly refreshed alongside progression data when resetting the game

https://claude.ai/code/session_019Krw76DBURnsKDtemajVtz