### PR TITLE
fix(ui): restore card click in duel screen by using native onClick

### DIFF
--- a/js/react/hooks/useLongPress.ts
+++ b/js/react/hooks/useLongPress.ts
@@ -46,20 +46,24 @@ export function useLongPress({
 
   const onPointerUp = useCallback(() => {
     clear();
-    if (!firedRef.current && onClick) {
-      onClick();
-    }
     startPos.current = null;
-  }, [clear, onClick]);
+  }, [clear]);
 
   const onPointerCancel = useCallback(() => {
     clear();
     startPos.current = null;
   }, [clear]);
 
+  // Native click handler — more reliable than synthesizing clicks from onPointerUp
+  const handleClick = useCallback(() => {
+    if (!firedRef.current && onClick) {
+      onClick();
+    }
+  }, [onClick]);
+
   const onContextMenu = useCallback((e: React.MouseEvent) => {
     if (firedRef.current) e.preventDefault();
   }, []);
 
-  return { onPointerDown, onPointerMove, onPointerUp, onPointerCancel, onContextMenu };
+  return { onPointerDown, onPointerMove, onPointerUp, onPointerCancel, onClick: handleClick, onContextMenu };
 }

--- a/js/react/screens/game/PlayerField.tsx
+++ b/js/react/screens/game/PlayerField.tsx
@@ -47,6 +47,12 @@ export function PlayerField({ showDirect, setShowDirect }: Props) {
     return isMyTurn && phase === 'main' && fst.faceDown && fst.card.type === CardType.Spell;
   }
 
+  function isPlayerMonsterViewable(zone: number) {
+    const fc = player.field.monsters[zone];
+    if (!fc) return false;
+    return selMode === null && !isPlayerMonsterInteractive(zone) && !playerMonsterCanAttack(zone);
+  }
+
   function isPlayerMonsterSpellTarget(zone: number) {
     return (selMode === 'spell-target' || selMode === 'field-spell-target') && !!player.field.monsters[zone];
   }
@@ -108,6 +114,7 @@ export function PlayerField({ showDirect, setShowDirect }: Props) {
           const canAtk    = playerMonsterCanAttack(i);
           const interact  = isPlayerMonsterInteractive(i);
           const targetable = isPlayerMonsterSpellTarget(i) || isPlayerMonsterEquipTarget(i);
+          const viewable   = isPlayerMonsterViewable(i);
           return (
             <div key={i} className="zone-slot" data-zone={i}>
               {!fc && <div className="zone-label">M</div>}
@@ -116,9 +123,11 @@ export function PlayerField({ showDirect, setShowDirect }: Props) {
                   fc={fc} owner="player" zone={i}
                   selected={selected} targetable={targetable}
                   interactive={interact} canAttack={canAtk}
+                  viewable={viewable}
                   onOwnClick={() => onOwnFieldCardClick(fc, i)}
                   onAttackerSelect={() => onAttackerSelect(i)}
                   onDefenderClick={() => onSpellTargetSelect(i)}
+                  onViewClick={() => openModal({ type: 'card-detail', card: fc.card, fc })}
                   onDetail={() => openModal({ type: 'card-detail', card: fc.card, fc })}
                 />
               )}


### PR DESCRIPTION
The useLongPress hook was synthesizing clicks from onPointerUp, which
can be silently swallowed by browsers (pointercancel fires instead).
Switch to native onClick for reliable click handling, keeping pointer
events only for long-press timer management.

Also add viewable/onViewClick props to player's own field cards so
they can be clicked to view details outside of main phase.

https://claude.ai/code/session_01F6m6sLHXJFhDoVqW7Q1vMm