### PR TITLE
fix(engine): remove automatic log download on win/lose

### DIFF
--- a/js/engine.ts
+++ b/js/engine.ts
@@ -290,8 +290,6 @@ export class GameEngine {
   }
 
   _endDuel(result: 'victory' | 'defeat'){
-    const logSuffix = result === 'victory' ? 'victory' : 'defeat';
-    EchoesOfSanguo.downloadLog(logSuffix);
     // onDuelEnd allows progression evaluation in the UI layer
     if(typeof this.ui.onDuelEnd === 'function'){
       this.ui.onDuelEnd(result, this._currentOpponentId);


### PR DESCRIPTION
The debug log file was automatically downloaded every time a duel ended,
which is no longer needed. The AI crash log and manual download button
in the battle log modal are preserved.

https://claude.ai/code/session_01PHRuSHgqmkkz4L7bSstP6H