### PR TITLE
feat(ui): add click-to-speed-up for card effect animations

### DIFF
--- a/js/react/App.tsx
+++ b/js/react/App.tsx
@@ -24,6 +24,7 @@ import DefeatedScreen    from './screens/DefeatedScreen.js';
 
 import { HoverPreview }        from './components/HoverPreview.js';
 import { CardActivationOverlay } from './components/CardActivationOverlay.js';
+import { AnimSkipOverlay }      from './components/AnimSkipOverlay.js';
 import { VFXOverlay }           from './components/VFXOverlay.js';
 import { ModalOverlay }         from './modals/ModalOverlay.js';
 
@@ -50,6 +51,7 @@ function Router() {
       {screen === 'defeated'     && <DefeatedScreen />}
       <HoverPreview />
       <CardActivationOverlay />
+      <AnimSkipOverlay />
       <VFXOverlay />
       <ModalOverlay />
       <div id="screen-transition-overlay" style={{ position: 'fixed', inset: 0, background: '#000', opacity: 0, pointerEvents: 'none', zIndex: 9999 }} />

--- a/js/react/components/AnimSkipOverlay.tsx
+++ b/js/react/components/AnimSkipOverlay.tsx
@@ -1,0 +1,25 @@
+// ============================================================
+// AnimSkipOverlay — transparent full-screen click-capture overlay
+// Visible only while a skippable animation is active.
+// ============================================================
+import { useSyncExternalStore } from 'react';
+import { fireSkip, isAnimActive, subscribeActive } from './animSkipSignal.js';
+
+export function AnimSkipOverlay() {
+  const active = useSyncExternalStore(subscribeActive, isAnimActive);
+
+  if (!active) return null;
+
+  return (
+    <div
+      id="anim-skip-overlay"
+      onClick={fireSkip}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 490,
+        cursor: 'pointer',
+      }}
+    />
+  );
+}

--- a/js/react/components/CardActivationOverlay.tsx
+++ b/js/react/components/CardActivationOverlay.tsx
@@ -8,6 +8,7 @@ import { Card } from './Card.js';
 import { CardType } from '../../types.js';
 import { setActivationDispatch } from './cardActivationApi.js';
 import type { ActivationState } from './cardActivationApi.js';
+import { onSkip, pushAnim, popAnim, fireSkip } from './animSkipSignal.js';
 
 const LABELS: Record<number, string> = {
   [CardType.Spell]: 'ZAUBER AKTIVIERT', [CardType.Trap]: 'FALLE AKTIVIERT',
@@ -32,8 +33,11 @@ export function CardActivationOverlay() {
     gsap.set(bg,  { backgroundColor: 'rgba(0,0,0,0)' });
     gsap.set(con, { y: 50, scale: 0.75, opacity: 0 });
 
+    pushAnim();
+    const unsub = onSkip(() => { tl.timeScale(8); });
+
     const tl = gsap.timeline({
-      onComplete() { setAct(null); act.resolve(); },
+      onComplete() { popAnim(); unsub(); setAct(null); act.resolve(); },
     });
     tl.to(bg,  { duration: 0.3,  ease: 'none', backgroundColor: 'rgba(0,0,10,0.72)' }, 0);
     tl.to(con, { duration: 0.38, ease: 'back.out(1.7)', y: 0, scale: 1, opacity: 1 }, 0);
@@ -41,13 +45,13 @@ export function CardActivationOverlay() {
     tl.to(con, { duration: 0.55, ease: 'power2.in', y: -30, scale: 1.18, opacity: 0 });
     tl.to(bg,  { duration: 0.5,  ease: 'power2.in', backgroundColor: 'rgba(0,0,0,0)' }, '<');
 
-    return () => { tl.kill(); };
+    return () => { tl.kill(); popAnim(); unsub(); };
   }, [act]);
 
   if (!act) return null;
 
   return (
-    <div id="card-activate-overlay">
+    <div id="card-activate-overlay" onClick={fireSkip} style={{ cursor: 'pointer' }}>
       <div id="card-activate-bg" ref={bgRef} />
       <div id="card-activate-content" ref={contentRef}>
         <div id="card-activate-render">

--- a/js/react/components/VFXOverlay.tsx
+++ b/js/react/components/VFXOverlay.tsx
@@ -5,6 +5,7 @@
 import { useEffect, useRef, useCallback } from 'react';
 import { setVFXDispatch } from './vfxApi.js';
 import type { VFXRequest, VFXType } from './vfxApi.js';
+import { onSkip, pushAnim, popAnim } from './animSkipSignal.js';
 
 /** Duration per effect type (ms) */
 const DURATIONS: Record<VFXType, number> = {
@@ -34,10 +35,26 @@ export function VFXOverlay() {
     const count = COUNTS[req.type];
     const duration = DURATIONS[req.type];
     let finished = 0;
+    let resolved = false;
+    const particles: HTMLDivElement[] = [];
+
+    pushAnim();
+
+    const done = () => {
+      if (resolved) return;
+      resolved = true;
+      unsub();
+      popAnim();
+      particles.forEach(p => { if (p.parentNode) p.remove(); });
+      req.resolve();
+    };
+
+    const unsub = onSkip(done);
 
     for (let i = 0; i < count; i++) {
       const particle = document.createElement('div');
       particle.className = `vfx-particle vfx-${req.type}`;
+      particles.push(particle);
 
       // Randomize position & timing per particle
       const angle = (i / count) * 360;
@@ -55,16 +72,17 @@ export function VFXOverlay() {
       const onEnd = () => {
         particle.remove();
         finished++;
-        if (finished >= count) req.resolve();
+        if (finished >= count) done();
       };
       particle.addEventListener('animationend', onEnd, { once: true });
 
       // Safety timeout in case animationend doesn't fire
       setTimeout(() => {
+        if (resolved) return;
         if (particle.parentNode) {
           particle.remove();
           finished++;
-          if (finished >= count) req.resolve();
+          if (finished >= count) done();
         }
       }, duration + delay + 200);
     }

--- a/js/react/components/animSkipSignal.ts
+++ b/js/react/components/animSkipSignal.ts
@@ -1,0 +1,41 @@
+// ============================================================
+// animSkipSignal — global animation skip signal (no React)
+// Same module-level pattern as cardActivationApi.ts / vfxApi.ts
+// ============================================================
+
+type Listener = () => void;
+const _skipListeners = new Set<Listener>();
+const _activeListeners = new Set<Listener>();
+let _activeCount = 0;
+
+/** Subscribe to skip events. Returns unsubscribe function. */
+export function onSkip(fn: Listener): () => void {
+  _skipListeners.add(fn);
+  return () => { _skipListeners.delete(fn); };
+}
+
+/** Fire the skip signal (called by click handlers). */
+export function fireSkip(): void {
+  for (const fn of _skipListeners) fn();
+}
+
+/** Increment/decrement active animation count. */
+export function pushAnim(): void {
+  _activeCount++;
+  if (_activeCount === 1) _notifyActive();
+}
+export function popAnim(): void {
+  _activeCount = Math.max(0, _activeCount - 1);
+  if (_activeCount === 0) _notifyActive();
+}
+export function isAnimActive(): boolean { return _activeCount > 0; }
+
+/** Subscribe to active-state changes (for AnimSkipOverlay). */
+export function subscribeActive(fn: Listener): () => void {
+  _activeListeners.add(fn);
+  return () => { _activeListeners.delete(fn); };
+}
+
+function _notifyActive() {
+  for (const fn of _activeListeners) fn();
+}

--- a/js/react/hooks/useFusionAnimation.ts
+++ b/js/react/hooks/useFusionAnimation.ts
@@ -1,4 +1,5 @@
 import { gsap } from 'gsap';
+import { onSkip, pushAnim, popAnim } from '../components/animSkipSignal.js';
 
 // ── Shared helpers ──
 
@@ -100,13 +101,20 @@ export function playFusionChainAnim(
     // Clone all materials
     const clones = materials.map(el => cloneCardEl(el, mergeX, mergeY));
 
+    pushAnim();
+    let unsub: (() => void) | null = null;
+
     const tl = gsap.timeline({
       onComplete() {
+        popAnim();
+        unsub?.();
         clones.forEach(c => c.remove());
         materials.forEach(el => { el.style.opacity = ''; });
         resolve();
       },
     });
+
+    unsub = onSkip(() => { tl.timeScale(8); });
 
     // Animate all cards flying to center together
     clones.forEach((clone, i) => {


### PR DESCRIPTION
Card activation overlay (2.8s), VFX particles, and fusion animations
can now be fast-forwarded by clicking during playback. Uses a global
skip signal that GSAP timelines respond to with timeScale(8) and CSS
particle animations resolve immediately.

https://claude.ai/code/session_0187ainTx5HFUJqNg4v3BU7N