### PR TITLE
fix(ui): add victory screen for campaign duel wins

### DIFF
--- a/js/react/App.tsx
+++ b/js/react/App.tsx
@@ -21,6 +21,7 @@ import GameScreen       from './screens/GameScreen.js';
 import DeckbuilderScreen  from './screens/DeckbuilderScreen.js';
 import SavePointScreen   from './screens/SavePointScreen.js';
 import DefeatedScreen    from './screens/DefeatedScreen.js';
+import VictoryScreen     from './screens/VictoryScreen.js';
 
 import { HoverPreview }        from './components/HoverPreview.js';
 import { CardActivationOverlay } from './components/CardActivationOverlay.js';
@@ -49,6 +50,7 @@ function Router() {
       {screen === 'deckbuilder'  && <DeckbuilderScreen />}
       {screen === 'save-point'   && <SavePointScreen />}
       {screen === 'defeated'     && <DefeatedScreen />}
+      {screen === 'victory'      && <VictoryScreen />}
       <HoverPreview />
       <CardActivationOverlay />
       <AnimSkipOverlay />

--- a/js/react/contexts/GameContext.tsx
+++ b/js/react/contexts/GameContext.tsx
@@ -195,12 +195,15 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
               refreshRef.current();
               refreshCampaignRef.current();
               if (pending.postDialogue && pending.postDialogue.length > 0) {
-                navigateToRef.current('dialogue', {
-                  scene: pending.postDialogue as unknown as Record<string, unknown>,
-                  nextScreen: 'campaign',
+                navigateToRef.current('victory', {
+                  nextScreen: 'dialogue',
+                  dialogueData: {
+                    scene: pending.postDialogue as unknown as Record<string, unknown>,
+                    nextScreen: 'campaign',
+                  },
                 });
               } else {
-                navigateToRef.current('campaign');
+                navigateToRef.current('victory', { nextScreen: 'campaign' });
               }
             } else {
               // Defeat in gauntlet — entire gauntlet fails
@@ -237,7 +240,18 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
           }
           refreshRef.current();
           refreshCampaignRef.current();
-          if (isComplete && pending.postDialogue && pending.postDialogue.length > 0) {
+          if (result === 'victory' && pending.postDialogue && pending.postDialogue.length > 0) {
+            navigateToRef.current('victory', {
+              nextScreen: 'dialogue',
+              dialogueData: {
+                scene: pending.postDialogue as unknown as Record<string, unknown>,
+                nextScreen: 'campaign',
+              },
+            });
+          } else if (result === 'victory') {
+            navigateToRef.current('victory', { nextScreen: 'campaign' });
+          } else if (isComplete && pending.postDialogue && pending.postDialogue.length > 0) {
+            // completeOnLoss with post-dialogue — show dialogue, skip victory screen
             navigateToRef.current('dialogue', {
               scene: pending.postDialogue as unknown as Record<string, unknown>,
               nextScreen: 'campaign',

--- a/js/react/contexts/ScreenContext.tsx
+++ b/js/react/contexts/ScreenContext.tsx
@@ -15,7 +15,8 @@ export type Screen =
   | 'save-point'
   | 'campaign'
   | 'dialogue'
-  | 'defeated';
+  | 'defeated'
+  | 'victory';
 
 interface ScreenCtx {
   screen: Screen;
@@ -39,6 +40,7 @@ const SCREEN_MUSIC: Partial<Record<Screen, string>> = {
   deckbuilder:    'music_shop',
   'save-point':   'music_shop',
   defeated:       'music_defeat',
+  victory:        'music_victory',
 };
 
 export function ScreenProvider({ children }: { children: React.ReactNode }) {

--- a/js/react/screens/VictoryScreen.module.css
+++ b/js/react/screens/VictoryScreen.module.css
@@ -1,0 +1,54 @@
+.screen {
+  position: fixed; inset: 0;
+  display: flex; align-items: center; justify-content: center;
+  background: #0a0406;
+  z-index: 100;
+  cursor: pointer;
+}
+
+.content {
+  position: relative;
+  z-index: 1;
+  text-align: center;
+  display: flex; flex-direction: column; align-items: center;
+  gap: 16px;
+}
+
+.title {
+  font-size: 1.5rem;
+  letter-spacing: 4px;
+  color: #d4a017;
+  text-shadow: 0 0 20px rgba(212, 160, 23, 0.6), 2px 2px 8px #000;
+  font-family: 'Press Start 2P', monospace;
+  margin: 0;
+  animation: pulseGold 2s ease-in-out infinite;
+}
+
+.message {
+  font-size: 0.65rem;
+  letter-spacing: 1px;
+  color: #b0a090;
+  text-shadow: 1px 1px 4px #000;
+  max-width: 400px;
+  line-height: 1.8;
+  margin: 0;
+}
+
+.pressStart {
+  font-size: 0.65rem;
+  letter-spacing: 3px;
+  color: #d4a017;
+  text-shadow: 0 0 8px rgba(212, 160, 23, 0.4);
+  margin-top: 40px;
+  animation: blink 1.2s step-start infinite;
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0; }
+}
+
+@keyframes pulseGold {
+  0%, 100% { text-shadow: 0 0 20px rgba(212, 160, 23, 0.6), 2px 2px 8px #000; }
+  50%      { text-shadow: 0 0 40px rgba(212, 160, 23, 0.9), 2px 2px 8px #000; }
+}

--- a/js/react/screens/VictoryScreen.tsx
+++ b/js/react/screens/VictoryScreen.tsx
@@ -1,0 +1,37 @@
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useScreen } from '../contexts/ScreenContext.js';
+import styles from './VictoryScreen.module.css';
+
+export default function VictoryScreen() {
+  const { screenData, navigateTo } = useScreen();
+  const { t } = useTranslation();
+
+  function proceed() {
+    const next = screenData?.nextScreen as string | undefined;
+    if (next === 'dialogue') {
+      navigateTo('dialogue', screenData?.dialogueData as Record<string, unknown>);
+    } else {
+      navigateTo('campaign');
+    }
+  }
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.repeat) return;
+      proceed();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  return (
+    <div className={styles.screen} onClick={proceed}>
+      <div className={styles.content}>
+        <h1 className={styles.title}>{t('victory.title')}</h1>
+        <p className={styles.message}>{t('victory.message')}</p>
+        <p className={styles.pressStart}>{t('victory.continue')}</p>
+      </div>
+    </div>
+  );
+}

--- a/locales/de.json
+++ b/locales/de.json
@@ -350,5 +350,10 @@
     "title": "NIEDERLAGE",
     "message": "Deine Truppen sind gefallen. Doch jeder Krieger kann wieder aufstehen...",
     "continue": "BELIEBIGE TASTE DRÜCKEN"
+  },
+  "victory": {
+    "title": "SIEG",
+    "message": "Deine Truppen haben triumphiert! Ruhm hallt durch das ganze Land...",
+    "continue": "BELIEBIGE TASTE DRÜCKEN"
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -350,5 +350,10 @@
     "title": "DEFEAT",
     "message": "Your forces have fallen. But every warrior can rise again...",
     "continue": "PRESS ANY KEY"
+  },
+  "victory": {
+    "title": "VICTORY",
+    "message": "Your forces have triumphed! Glory echoes across the land...",
+    "continue": "PRESS ANY KEY"
   }
 }


### PR DESCRIPTION
Campaign duels were navigating directly to dialogue/campaign map after
a win without showing any victory screen. Add a dedicated VictoryScreen
(mirroring DefeatedScreen) with gold theme that displays before
proceeding to the next screen.

https://claude.ai/code/session_01A3PhJ14NqKi9YHFf3gnTkK