### PR TITLE
refactor: improve code quality across engine and UI layers

### DIFF
--- a/js/ai-behaviors.ts
+++ b/js/ai-behaviors.ts
@@ -211,7 +211,7 @@ export function pickSmartSummonCandidate(hand: CardData[], ctx: BoardContext): n
 
     // Can this monster beat any player monster? Big bonus
     for (const pfc of playerMonsters) {
-      const pVal = pfc.position === 'atk' ? pfc.effectiveATK() : pfc.effectiveDEF();
+      const pVal = pfc.combatValue();
       if (atk > pVal) score += 300; // can destroy a target
     }
 
@@ -269,7 +269,7 @@ export function findLethal(
     if (!fc) continue;
     defenders.push({
       zone: z,
-      val: fc.position === 'atk' ? fc.effectiveATK() : fc.effectiveDEF(),
+      val: fc.combatValue(),
       inAtk: fc.position === 'atk',
       cantBeAttacked: fc.cantBeAttacked,
     });
@@ -422,7 +422,7 @@ export function planAttacks(
   for (const a of attackers) {
     if (usedAttackers.has(a.zone)) continue;
     for (const d of defenders) {
-      const dVal = d.fc.position === 'atk' ? d.fc.effectiveATK() : d.fc.effectiveDEF();
+      const dVal = d.fc.combatValue();
       const aAtk = a.fc.effectiveATK();
       let score = 0;
 
@@ -485,7 +485,7 @@ export function planAttacks(
       let weakest: { zone: number; val: number } | null = null;
       for (const d of defenders) {
         if (usedDefenders.has(d.zone)) continue;
-        const dVal = d.fc.position === 'atk' ? d.fc.effectiveATK() : d.fc.effectiveDEF();
+        const dVal = d.fc.combatValue();
         if (!weakest || dVal < weakest.val) weakest = { zone: d.zone, val: dVal };
       }
       if (weakest) {
@@ -514,7 +514,7 @@ export function pickEquipTarget(
 ): number {
   const oppMaxVal = oppMonsters
     .filter((fc): fc is FieldCard => fc !== null)
-    .reduce((max, fc) => Math.max(max, fc.position === 'atk' ? fc.effectiveATK() : fc.effectiveDEF()), 0);
+    .reduce((max, fc) => Math.max(max, fc.combatValue()), 0);
 
   let bestZone = -1;
   let bestScore = -Infinity;

--- a/js/ai-orchestrator.ts
+++ b/js/ai-orchestrator.ts
@@ -8,6 +8,7 @@
 //
 
 import { EchoesOfSanguo } from './debug-logger.js';
+import { GAME_RULES } from './rules.js';
 import { CardType, Attribute, isMonsterType } from './types.js';
 import type { AIBehavior, CardData } from './types.js';
 import type { FieldCard } from './field.js';
@@ -207,14 +208,16 @@ async function _activateSpells(engine: GameEngine): Promise<void> {
 
       if(card.spellType === 'normal'){
         const actions = card.effect?.actions ?? [];
-        const dealsDamage = actions.some((a: any) => a.type === 'dealDamage');
-        const heals = actions.some((a: any) => a.type === 'gainLP');
-        const buffs = actions.some((a: any) =>
-          a.type === 'buffAtkAll' || a.type === 'buffAtkRace' ||
-          a.type === 'buffAtk' || a.type === 'buffField');
-        const destroys = actions.some((a: any) =>
-          a.type === 'destroyMonster' || a.type === 'destroyAll' ||
-          a.type === 'destroySpellTrap');
+        const dealsDamage = actions.some(a => a.type === 'dealDamage');
+        const heals = actions.some(a => a.type === 'gainLP');
+        const buffs = actions.some(a => {
+          const t = a.type as string;
+          return t === 'buffAtkAll' || t === 'buffAtkRace' || t === 'buffAtk' || t === 'buffField';
+        });
+        const destroys = actions.some(a => {
+          const t = a.type as string;
+          return t === 'destroyMonster' || t === 'destroyAll' || t === 'destroySpellTrap';
+        });
 
         let should = false;
         if (dealsDamage) {
@@ -310,9 +313,7 @@ async function aiEquipCards(engine: GameEngine): Promise<void> {
 
       if (isPositive) {
         // Smart: equip to the monster that benefits most (respects equipRequirement)
-        const targetZone = (bh.battleStrategy === 'smart' || bh.positionStrategy === 'smart')
-          ? pickEquipTarget(ai.field.monsters, plr.field.monsters, atkB, defB, card)
-          : pickEquipTarget(ai.field.monsters, plr.field.monsters, atkB, defB, card);
+        const targetZone = pickEquipTarget(ai.field.monsters, plr.field.monsters, atkB, defB, card);
 
         if (targetZone !== -1) {
           const fc = ai.field.monsters[targetZone]!;
@@ -323,9 +324,7 @@ async function aiEquipCards(engine: GameEngine): Promise<void> {
         }
       } else if (isNegative) {
         // Smart: debuff the biggest threat (respects equipRequirement)
-        const targetZone = (bh.battleStrategy === 'smart' || bh.positionStrategy === 'smart')
-          ? pickDebuffTarget(plr.field.monsters, atkB, card)
-          : pickDebuffTarget(plr.field.monsters, atkB, card);
+        const targetZone = pickDebuffTarget(plr.field.monsters, atkB, card);
 
         if (targetZone !== -1) {
           const fc = plr.field.monsters[targetZone]!;
@@ -388,7 +387,7 @@ async function aiBattlePhase(engine: GameEngine): Promise<boolean> {
       // Targeted attack
       const def = plr.field.monsters[plan.targetZone];
       if (def) {
-        const defVal = def.position === 'atk' ? def.effectiveATK() : def.effectiveDEF();
+        const defVal = def.combatValue();
         EchoesOfSanguo.log('BATTLE', `${atk.card.name}(${atk.effectiveATK()}) → ${def.card.name}(${def.position==='atk'?'ATK':'DEF'}:${defVal})`);
         await engine.attack('opponent', plan.attackerZone, plan.targetZone);
         if (engine.checkWin()) return true;
@@ -429,10 +428,10 @@ export function aiBattlePickTarget(atk: FieldCard, plrMonsters: Array<FieldCard 
   if (strategy === 'aggressive') {
     // Attack anything — prefer highest-value target we can destroy, then any target at all
     let bestTarget = -1, bestScore = -Infinity;
-    for (let dz = 0; dz < 5; dz++) {
+    for (let dz = 0; dz < GAME_RULES.fieldZones; dz++) {
       const def = plrMonsters[dz];
       if (!def || def.cantBeAttacked) continue;
-      const defVal = def.position === 'atk' ? def.effectiveATK() : def.effectiveDEF();
+      const defVal = def.combatValue();
       if (atk.effectiveATK() > defVal) {
         // Prefer destroying effect monsters and high-ATK threats
         let score = defVal;
@@ -443,10 +442,10 @@ export function aiBattlePickTarget(atk: FieldCard, plrMonsters: Array<FieldCard 
     if (bestTarget !== -1) return bestTarget;
     // Aggressive: attack even unfavorably — pick weakest target to minimize damage
     let weakest = -1, weakVal = Infinity;
-    for (let dz = 0; dz < 5; dz++) {
+    for (let dz = 0; dz < GAME_RULES.fieldZones; dz++) {
       const def = plrMonsters[dz];
       if (!def || def.cantBeAttacked) continue;
-      const defVal = def.position === 'atk' ? def.effectiveATK() : def.effectiveDEF();
+      const defVal = def.combatValue();
       if (defVal < weakVal) { weakVal = defVal; weakest = dz; }
     }
     return weakest;
@@ -454,10 +453,10 @@ export function aiBattlePickTarget(atk: FieldCard, plrMonsters: Array<FieldCard 
 
   // 'smart' and 'conservative': destroy strongest possible, considering threat level
   let bestTarget = -1, bestScore = -Infinity;
-  for (let dz = 0; dz < 5; dz++) {
+  for (let dz = 0; dz < GAME_RULES.fieldZones; dz++) {
     const def = plrMonsters[dz];
     if (!def || def.cantBeAttacked) continue;
-    const defVal = def.position === 'atk' ? def.effectiveATK() : def.effectiveDEF();
+    const defVal = def.combatValue();
     if (atk.effectiveATK() > defVal) {
       let score = defVal;
       // Prioritize effect monsters — they're dangerous
@@ -475,7 +474,7 @@ export function aiBattlePickTarget(atk: FieldCard, plrMonsters: Array<FieldCard 
 
   // 'smart': also attack DEF-position targets safely, prefer face-down (reveal them)
   let safeTarget = -1, safeScore = -Infinity;
-  for (let dz = 0; dz < 5; dz++) {
+  for (let dz = 0; dz < GAME_RULES.fieldZones; dz++) {
     const def = plrMonsters[dz];
     if (!def || def.cantBeAttacked || def.position !== 'def') continue;
     const defVal = def.effectiveDEF();

--- a/js/effect-registry.ts
+++ b/js/effect-registry.ts
@@ -97,6 +97,26 @@ function _triggerBuffVFX(fc: FieldCard, ctx: EffectContext): void {
   }
 }
 
+// ── Helpers ─────────────────────────────────────────────────
+
+/** Find the monster zone index with the highest or lowest effective ATK. */
+function findMonsterByATK(
+  monsters: Array<FieldCard | null>,
+  mode: 'strongest' | 'weakest',
+  opts?: { excludeUntargetable?: boolean },
+): number | null {
+  const cmp = mode === 'strongest'
+    ? (a: number, b: number) => a > b
+    : (a: number, b: number) => a < b;
+  let idx: number | null = null;
+  monsters.forEach((fm, i) => {
+    if (!fm) return;
+    if (opts?.excludeUntargetable && fm.cannotBeTargeted) return;
+    if (idx === null || cmp(fm.effectiveATK(), monsters[idx]!.effectiveATK())) idx = i;
+  });
+  return idx;
+}
+
 // ── Effect Implementations ──────────────────────────────────
 
 // Public API type — call sites receive EffectDescriptor (no `any`)
@@ -187,13 +207,9 @@ const IMPL: Record<string, InternalImpl> = {
     const opp = oppOf(ctx.owner);
     const st = ctx.engine.getState();
     const monsters = st[opp].field.monsters;
-    let strongest: number | null = null;
-    monsters.forEach((fm, i) => {
-      if (!fm || fm.cannotBeTargeted) return;
-      if (strongest === null || fm.effectiveATK() > monsters[strongest]!.effectiveATK()) strongest = i;
-    });
+    const strongest = findMonsterByATK(monsters, 'strongest', { excludeUntargetable: true });
     if (strongest !== null && monsters[strongest]) {
-      const fc = monsters[strongest]!;
+      const fc = monsters[strongest];
       st[opp].hand.push(fc.card);
       monsters[strongest] = null;
       ctx.engine._removeEquipmentForMonster(opp, strongest);
@@ -343,13 +359,9 @@ const IMPL: Record<string, InternalImpl> = {
     const opp = oppOf(ctx.owner);
     const st = ctx.engine.getState();
     const monsters = st[opp].field.monsters;
-    let weakestIdx: number | null = null;
-    monsters.forEach((fm, i) => {
-      if (!fm) return;
-      if (weakestIdx === null || fm.effectiveATK() < monsters[weakestIdx]!.effectiveATK()) weakestIdx = i;
-    });
+    const weakestIdx = findMonsterByATK(monsters, 'weakest');
     if (weakestIdx !== null && monsters[weakestIdx]) {
-      const fc = monsters[weakestIdx]!;
+      const fc = monsters[weakestIdx];
       st[opp].graveyard.push(fc.card);
       monsters[weakestIdx] = null;
       ctx.engine._removeEquipmentForMonster(opp, weakestIdx);
@@ -362,13 +374,9 @@ const IMPL: Record<string, InternalImpl> = {
     const opp = oppOf(ctx.owner);
     const st = ctx.engine.getState();
     const monsters = st[opp].field.monsters;
-    let strongestIdx: number | null = null;
-    monsters.forEach((fm, i) => {
-      if (!fm) return;
-      if (strongestIdx === null || fm.effectiveATK() > monsters[strongestIdx]!.effectiveATK()) strongestIdx = i;
-    });
+    const strongestIdx = findMonsterByATK(monsters, 'strongest');
     if (strongestIdx !== null && monsters[strongestIdx]) {
-      const fc = monsters[strongestIdx]!;
+      const fc = monsters[strongestIdx];
       st[opp].graveyard.push(fc.card);
       monsters[strongestIdx] = null;
       ctx.engine._removeEquipmentForMonster(opp, strongestIdx);

--- a/js/engine.ts
+++ b/js/engine.ts
@@ -844,7 +844,7 @@ export class GameEngine {
       await this._triggerFlipEffect(defFC, defOwner, defZone);
     }
 
-    const defVal = defFC.position === 'atk' ? defFC.effectiveATK() : defFC.effectiveDEF();
+    const defVal = defFC.combatValue();
     const modeStr= defFC.position === 'atk' ? 'ATK' : 'DEF';
 
     // passive: vsAttrBonus (e.g. Heiliger Krieger +500 ATK vs DARK)

--- a/js/field.ts
+++ b/js/field.ts
@@ -76,6 +76,10 @@ export class FieldCard {
   effectiveDEF(): number {
     return Math.max(0, (this.card.def ?? 0) + this.tempDEFBonus + this.permDEFBonus + this.fieldSpellDEFBonus);
   }
+  /** Returns the effective combat value based on current position. */
+  combatValue(): number {
+    return this.position === 'atk' ? this.effectiveATK() : this.effectiveDEF();
+  }
 }
 
 // ── FieldSpellTrap ─────────────────────────────────────────

--- a/js/react/contexts/ModalContext.tsx
+++ b/js/react/contexts/ModalContext.tsx
@@ -1,9 +1,9 @@
 import { createContext, useContext, useState } from 'react';
-import type { CardData, GameState, PromptOptions } from '../../types.js';
+import type { CardData, GameState, PromptOptions, FieldCard } from '../../types.js';
 
 export type ModalState =
   | null
-  | { type: 'card-detail'; card: CardData; fc?: any | null; index?: number; state?: GameState; source?: 'hand' | 'field' | 'field-spell' | 'deckbuilder-collection' | 'deckbuilder-deck'; onDeckAction?: (action: 'add' | 'remove') => void }
+  | { type: 'card-detail'; card: CardData; fc?: FieldCard | null; index?: number; state?: GameState; source?: 'hand' | 'field' | 'field-spell' | 'deckbuilder-collection' | 'deckbuilder-deck'; onDeckAction?: (action: 'add' | 'remove') => void }
   | { type: 'trap-prompt'; opts: PromptOptions; resolve: (v: boolean) => void }
   | { type: 'grave-select'; cards: CardData[]; resolve: (card: CardData) => void }
   | { type: 'card-list' }

--- a/js/react/modals/CardDetailModal.tsx
+++ b/js/react/modals/CardDetailModal.tsx
@@ -5,8 +5,12 @@ import { useSelection } from '../contexts/SelectionContext.js';
 import { Card }       from '../components/Card.js';
 import { highlightCardText } from '../utils/highlightCardText.js';
 import { CardType, Attribute, isMonsterType, meetsEquipRequirement } from '../../types.js';
+import type { CardData, GameState } from '../../types.js';
+import type { FieldCard } from '../../field.js';
+import type { GameEngine } from '../../engine.js';
 import { getAttrById } from '../../type-metadata.js';
 import type { ModalState } from '../contexts/ModalContext.js';
+import type { Selection } from '../contexts/SelectionContext.js';
 
 interface Props { modal: Extract<ModalState, { type: 'card-detail' }>; }
 
@@ -50,7 +54,7 @@ export function CardDetailModal({ modal }: Props) {
     const isMon = isMonsterType(card.type);
     const isSp  = card.type === CardType.Spell;
     const isTr  = card.type === CardType.Trap;
-    const freeZone = state.player.field.monsters.findIndex((z: any) => z === null);
+    const freeZone = state.player.field.monsters.findIndex((z): z is null => z === null);
 
     if (isMon && phase === 'main' && source === 'field') {
       const fieldCard = state.player.field.monsters[index];
@@ -99,7 +103,7 @@ export function CardDetailModal({ modal }: Props) {
         closeModal();
       }));
       actions.push(actionBtn(t('card_action.set_spell'), () => {
-        const zone = state.player.field.spellTraps.findIndex((z: any) => z === null);
+        const zone = state.player.field.spellTraps.findIndex((z): z is null => z === null);
         if (zone !== -1) game.setSpellTrap('player', index, zone);
         closeModal();
       }));
@@ -108,9 +112,9 @@ export function CardDetailModal({ modal }: Props) {
     const isEq = card.type === CardType.Equipment;
     if (isEq && phase === 'main' && source !== 'field-spell') {
       // Check if any face-up monster exists that meets equipment requirements
-      const hasTarget = state.player.field.monsters.some((m: any) => m && !m.faceDown && meetsEquipRequirement(card, m.card))
-                     || state.opponent.field.monsters.some((m: any) => m && !m.faceDown && meetsEquipRequirement(card, m.card));
-      const freeSTZone = state.player.field.spellTraps.findIndex((z: any) => z === null);
+      const hasTarget = state.player.field.monsters.some(m => m && !m.faceDown && meetsEquipRequirement(card, m.card))
+                     || state.opponent.field.monsters.some(m => m && !m.faceDown && meetsEquipRequirement(card, m.card));
+      const freeSTZone = state.player.field.spellTraps.findIndex((z): z is null => z === null);
       if (hasTarget && freeSTZone !== -1) {
         actions.push(actionBtn(t('card_action.equip', 'Equip'), () => {
           setSel({ mode: 'equip-target', equipHandIndex: index, equipCard: card, hint: t('card_action.hint_equip', 'Select a monster to equip') });
@@ -128,7 +132,7 @@ export function CardDetailModal({ modal }: Props) {
     if (isTr && (phase === 'main' || phase === 'battle')) {
       if (phase === 'main') {
         actions.push(actionBtn(t('card_action.set_trap'), () => {
-          const zone = state.player.field.spellTraps.findIndex((z: any) => z === null);
+          const zone = state.player.field.spellTraps.findIndex((z): z is null => z === null);
           if (zone !== -1) game.setSpellTrap('player', index, zone);
           closeModal();
         }));
@@ -189,44 +193,48 @@ function actionBtn(label: string, handler: (() => void) | null, disabled = false
 
 // ── Targeting helpers ──────────────────────────────────────
 
-function startSpellTargeting(card: any, handIndex: number, state: any, game: any, setSel: any, openModal: any, close: any, t: any) {
+type SetSel = (s: Partial<Selection>) => void;
+type OpenModal = (m: ModalState) => void;
+type TFunc = (key: string, defaultValue?: string) => string;
+
+function startSpellTargeting(card: CardData, handIndex: number, state: GameState, game: GameEngine, setSel: SetSel, openModal: OpenModal, close: () => void, t: TFunc) {
   if (card.spellType === 'targeted' && card.target === 'ownMonster') {
     const targets = state.player.field.monsters
-      .map((fc: any, i: number) => ({ fc, zone: i }))
-      .filter(({ fc }: any) => fc);
+      .map((fc, i) => ({ fc, zone: i }))
+      .filter((e): e is { fc: FieldCard; zone: number } => e.fc !== null);
     if (!targets.length) return;
-    if (targets.length === 1) { game.activateSpell('player', handIndex, targets[0].fc); return; }
+    if (targets.length === 1) { game.activateSpell('player', handIndex, targets[0].fc); close(); return; }
     setSel({ mode: 'spell-target', spellHandIndex: handIndex, spellCard: card, hint: t('card_action.hint_spell_own') });
   } else if (card.spellType === 'targeted' && card.target === 'ownDarkMonster') {
-    const fc = state.player.field.monsters.find((m: any) => m && m.card.attribute === Attribute.Dark);
+    const fc = state.player.field.monsters.find(m => m && m.card.attribute === Attribute.Dark);
     if (fc) game.activateSpell('player', handIndex, fc);
   } else if (card.spellType === 'fromGrave') {
-    const monsters = state.player.graveyard.filter((c: any) => isMonsterType(c.type));
+    const monsters = state.player.graveyard.filter(c => isMonsterType(c.type));
     if (!monsters.length) return;
-    openModal({ type: 'grave-select', cards: monsters, resolve: (chosen: any) => game.activateSpell('player', handIndex, chosen) });
+    openModal({ type: 'grave-select', cards: monsters, resolve: (chosen) => game.activateSpell('player', handIndex, chosen) });
   }
 }
 
-function startFieldSpellTargeting(card: any, zone: number, state: any, game: any, setSel: any, openModal: any, close: any, t: any) {
+function startFieldSpellTargeting(card: CardData, zone: number, state: GameState, game: GameEngine, setSel: SetSel, openModal: OpenModal, close: () => void, t: TFunc) {
   if (card.spellType === 'targeted' && card.target === 'ownMonster') {
     const targets = state.player.field.monsters
-      .map((fc: any, i: number) => ({ fc, zone: i }))
-      .filter(({ fc }: any) => fc);
+      .map((fc, i) => ({ fc, zone: i }))
+      .filter((e): e is { fc: FieldCard; zone: number } => e.fc !== null);
     if (!targets.length) return;
     if (targets.length === 1) { game.activateSpellFromField('player', zone, targets[0].fc); close(); return; }
     setSel({ mode: 'field-spell-target', spellFieldZone: zone, spellCard: card, hint: t('card_action.hint_spell_own') });
     close();
   } else if (card.spellType === 'targeted' && card.target === 'ownDarkMonster') {
-    const fc = state.player.field.monsters.find((m: any) => m && m.card.attribute === Attribute.Dark);
+    const fc = state.player.field.monsters.find(m => m && m.card.attribute === Attribute.Dark);
     if (fc) { game.activateSpellFromField('player', zone, fc); close(); }
   } else if (card.spellType === 'fromGrave') {
-    const monsters = state.player.graveyard.filter((c: any) => isMonsterType(c.type));
+    const monsters = state.player.graveyard.filter(c => isMonsterType(c.type));
     if (!monsters.length) return;
-    openModal({ type: 'grave-select', cards: monsters, resolve: (chosen: any) => game.activateSpellFromField('player', zone, chosen) });
+    openModal({ type: 'grave-select', cards: monsters, resolve: (chosen) => game.activateSpellFromField('player', zone, chosen) });
   }
 }
 
-function startTrapTargeting(card: any, handIndex: number, state: any, game: any, setSel: any, close: any, t: any) {
+function startTrapTargeting(card: CardData, handIndex: number, _state: GameState, _game: GameEngine, setSel: SetSel, _close: () => void, t: TFunc) {
   if (card.target === 'oppMonster') {
     setSel({ mode: 'trap-target', spellHandIndex: handIndex, spellCard: card, hint: t('card_action.hint_trap_opp') });
   }

--- a/js/react/screens/CollectionScreen.tsx
+++ b/js/react/screens/CollectionScreen.tsx
@@ -29,8 +29,8 @@ export default function CollectionScreen() {
   const ownedCount = Object.keys(countMap).length;
 
   let allCards = Object.values(CARD_DB) as CardData[];
-  if (raceFilter   !== 'all') allCards = allCards.filter(c => (c as any).race   === raceFilter);
-  if (rarityFilter !== 'all') allCards = allCards.filter(c => (c as any).rarity === rarityFilter);
+  if (raceFilter   !== 'all') allCards = allCards.filter(c => c.race   === raceFilter);
+  if (rarityFilter !== 'all') allCards = allCards.filter(c => c.rarity === rarityFilter);
 
   // Reset visible count when filters change
   const visibleCards = allCards.slice(0, visibleCount);

--- a/js/react/screens/game/HandArea.tsx
+++ b/js/react/screens/game/HandArea.tsx
@@ -6,6 +6,8 @@ import { useSelection } from '../../contexts/SelectionContext.js';
 import { HandCard }     from '../../components/HandCard.js';
 import { checkFusion, resolveFusionChain, CARD_DB } from '../../../cards.js';
 import { isMonsterType } from '../../../types.js';
+import type { CardData } from '../../../types.js';
+import type { FieldCard } from '../../../field.js';
 
 export function HandArea() {
   const { gameState, gameRef, pendingDraw } = useGame();
@@ -36,7 +38,7 @@ export function HandArea() {
     }
   }, [player.hand.length, fusionGroup, setSel, player.hand]);
 
-  const onHandCardClick = useCallback((card: any, index: number) => {
+  const onHandCardClick = useCallback((card: CardData, index: number) => {
     const game = gameRef.current;
     if (!game) return;
 
@@ -47,7 +49,7 @@ export function HandArea() {
       if (!firstCard) { resetSel(); return; }
       const recipe = checkFusion(card.id, firstCard.id);
       if (recipe) {
-        const zone = player.field.monsters.findIndex((z: any) => z === null);
+        const zone = player.field.monsters.findIndex((z): z is null => z === null);
         if (zone !== -1) game.performFusion('player', sel.fusion1!.handIndex, index);
       }
       resetSel();
@@ -66,11 +68,11 @@ export function HandArea() {
     openModal({ type: 'card-detail', card, index, state: gameState });
   }, [gameRef, selMode, sel.fusion1, fusionGroup, player.hand, player.field.monsters, resetSel, setSel, openModal, gameState]);
 
-  const onHandCardLongPress = useCallback((card: any, index: number) => {
+  const onHandCardLongPress = useCallback((card: CardData, index: number) => {
     if (!isMyTurn || phase !== 'main') return;
     if (!isMonsterType(card.type)) return;
     if (player.normalSummonUsed) return;
-    const freeZone = player.field.monsters.findIndex((z: any) => z === null);
+    const freeZone = player.field.monsters.findIndex((z): z is null => z === null);
     if (freeZone === -1) return;
     // Toggle: remove if already in group
     if (fusionGroup.includes(index)) {
@@ -121,7 +123,7 @@ export function HandArea() {
         </div>
       )}
       <div id="player-hand">
-        {player.hand.map((card: any, i: number) => {
+        {player.hand.map((card, i) => {
           const isNewlyDrawn = i >= newDrawBase;
           const playable     = isMyTurn && phase === 'main';
           const inFusion     = fusionGroup.includes(i);

--- a/js/react/screens/game/OpponentField.tsx
+++ b/js/react/screens/game/OpponentField.tsx
@@ -5,6 +5,8 @@ import { useSelection } from '../../contexts/SelectionContext.js';
 import { FieldCardComponent }     from '../../components/FieldCardComponent.js';
 import { FieldSpellTrapComponent } from '../../components/FieldSpellTrapComponent.js';
 import { meetsEquipRequirement }  from '../../../types.js';
+import type { FieldCard } from '../../../field.js';
+import type { FieldSpellTrap } from '../../../field.js';
 
 const FIELD_ZONES = [0, 1, 2, 3, 4] as const;
 
@@ -41,7 +43,7 @@ export function OpponentField() {
     resetSel();
   }, [gameRef, selMode, sel.attackerZone, resetSel]);
 
-  const onTrapTargetSelect = useCallback((fc: any) => {
+  const onTrapTargetSelect = useCallback((fc: FieldCard) => {
     const game = gameRef.current;
     if (!game || selMode !== 'trap-target') return;
     if (sel.spellHandIndex !== null) {
@@ -57,12 +59,12 @@ export function OpponentField() {
     resetSel();
   }, [gameRef, selMode, sel.equipHandIndex, resetSel]);
 
-  const onOppMonsterView = useCallback((fc: any) => {
+  const onOppMonsterView = useCallback((fc: FieldCard) => {
     openModal({ type: 'card-detail', card: fc.card, fc });
   }, [openModal]);
 
   /** Face-up opponent spell/traps are viewable */
-  const onOppSpellTrapView = useCallback((fst: any) => {
+  const onOppSpellTrapView = useCallback((fst: FieldSpellTrap) => {
     openModal({ type: 'card-detail', card: fst.card });
   }, [openModal]);
 

--- a/js/react/screens/game/PlayerField.tsx
+++ b/js/react/screens/game/PlayerField.tsx
@@ -6,6 +6,8 @@ import { useSelection } from '../../contexts/SelectionContext.js';
 import { FieldCardComponent }     from '../../components/FieldCardComponent.js';
 import { FieldSpellTrapComponent } from '../../components/FieldSpellTrapComponent.js';
 import { CardType, meetsEquipRequirement } from '../../../types.js';
+import type { FieldCard } from '../../../field.js';
+import type { FieldSpellTrap } from '../../../field.js';
 
 const FIELD_ZONES = [0, 1, 2, 3, 4] as const;
 
@@ -63,7 +65,7 @@ export function PlayerField({ showDirect, setShowDirect }: Props) {
       && meetsEquipRequirement(sel.equipCard!, fc.card);
   }
 
-  const onOwnFieldCardClick = useCallback((fc: any, zone: number) => {
+  const onOwnFieldCardClick = useCallback((fc: FieldCard, zone: number) => {
     const game = gameRef.current;
     if (!game || !isMyTurn || phase !== 'main') return;
     openModal({ type: 'card-detail', card: fc.card, fc, index: zone, state: gameState, source: 'field' });
@@ -75,7 +77,7 @@ export function PlayerField({ showDirect, setShowDirect }: Props) {
     const fc = player.field.monsters[zone];
     if (!fc || fc.hasAttacked || fc.position !== 'atk') return;
     resetSel();
-    const oppHasMonsters = opp.field.monsters.some((m: any) => m !== null);
+    const oppHasMonsters = opp.field.monsters.some(m => m !== null);
     setSel({ mode: 'attack', attackerZone: zone, hint: t('game.hint_selected', { name: fc.card.name }) });
     setShowDirect(!oppHasMonsters || fc.canDirectAttack);
   }, [gameRef, isMyTurn, phase, player.field.monsters, opp.field.monsters, resetSel, setSel, setShowDirect]);
@@ -97,7 +99,7 @@ export function PlayerField({ showDirect, setShowDirect }: Props) {
     resetSel();
   }, [gameRef, selMode, player.field.monsters, sel.spellHandIndex, sel.spellFieldZone, sel.equipHandIndex, resetSel]);
 
-  const onFieldSpellTrapClick = useCallback((zone: number, fst: any) => {
+  const onFieldSpellTrapClick = useCallback((zone: number, fst: FieldSpellTrap) => {
     const game = gameRef.current;
     if (!game || !isMyTurn || phase !== 'main' || !fst.faceDown) return;
     if (fst.card.type === CardType.Spell) {

--- a/js/types.ts
+++ b/js/types.ts
@@ -389,6 +389,7 @@ export declare class FieldCard {
   equippedCards:    Array<{ zone: number; card: CardData }>;
   effectiveATK():   number;
   effectiveDEF():   number;
+  combatValue():    number;
 }
 
 export declare class FieldSpellTrap {

--- a/tests/ai-behaviors.test.js
+++ b/tests/ai-behaviors.test.js
@@ -507,6 +507,7 @@ function mockFieldCard(overrides = {}) {
     piercing: false,
     effectiveATK() { return this.card.atk + (this._atkBonus ?? 0); },
     effectiveDEF() { return this.card.def + (this._defBonus ?? 0); },
+    combatValue() { return this.position === 'atk' ? this.effectiveATK() : this.effectiveDEF(); },
     _atkBonus: 0,
     _defBonus: 0,
     ...overrides,


### PR DESCRIPTION
- Remove dead code: redundant ternaries in ai-orchestrator that had
  identical branches for both conditions
- Replace hardcoded magic number `5` with GAME_RULES.fieldZones
- Extract findMonsterByATK helper in effect-registry to deduplicate
  bounceStrongestOpp, destroyWeakestOpp, and destroyStrongestOpp
- Add combatValue() method to FieldCard, replacing 10+ inline
  position === 'atk' ? effectiveATK() : effectiveDEF() patterns
- Fix any types: properly type callback params in HandArea, PlayerField,
  OpponentField, CardDetailModal targeting helpers, ModalContext, and
  CollectionScreen
- Fix inconsistent close() call in startSpellTargeting single-target path

https://claude.ai/code/session_011ZVwNK9oeASWJiKVNgKG74