### PR TITLE
fix(ui): eliminate screen flash when skipping effect animation

### DIFF
--- a/js/react/components/CardActivationOverlay.tsx
+++ b/js/react/components/CardActivationOverlay.tsx
@@ -34,7 +34,7 @@ export function CardActivationOverlay() {
     gsap.set(con, { y: 50, scale: 0.75, opacity: 0 });
 
     pushAnim();
-    const unsub = onSkip(() => { tl.timeScale(8); });
+    const unsub = onSkip(() => { tl.progress(1); });
 
     const tl = gsap.timeline({
       onComplete() { popAnim(); unsub(); setAct(null); act.resolve(); },


### PR DESCRIPTION
Replace tl.timeScale(8) with tl.progress(1) in CardActivationOverlay
so the dark overlay jumps to its final transparent state in one frame
instead of rapidly fading over ~60ms, which caused a perceived flash.

https://claude.ai/code/session_01Byqjm4S3WUzYwDkQjP9Nhp