### PR TITLE
feat(ui): add prominent card backgrounds and dim unplayable hand cards

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -517,22 +517,22 @@ button { cursor: pointer; border: none; font-family: inherit; transition: none; 
 .trap-card      { border-color: rgba(180,40,80,0.8); }
 .equipment-card { border-color: rgba(224,128,48,0.8); }
 
-/* Type background tints — subtle color wash layered over attr gradient */
-.normal-card::before { content:''; position:absolute; inset:0; background:rgba(220,220,220,0.04); z-index:0; pointer-events:none; border-radius:0; }
-.effect-card::before { content:''; position:absolute; inset:0; background:rgba(160,80,20,0.08);  z-index:0; pointer-events:none; border-radius:0; }
-.fusion-card::before { content:''; position:absolute; inset:0; background:rgba(120,40,200,0.09); z-index:0; pointer-events:none; border-radius:0; }
-.spell-card::before  { content:''; position:absolute; inset:0; background:rgba(20,140,80,0.08);  z-index:0; pointer-events:none; border-radius:0; }
-.trap-card::before      { content:''; position:absolute; inset:0; background:rgba(180,20,60,0.08);  z-index:0; pointer-events:none; border-radius:0; }
-.equipment-card::before { content:''; position:absolute; inset:0; background:rgba(224,128,48,0.08); z-index:0; pointer-events:none; border-radius:0; }
+/* Type background tints — color wash layered over attr gradient */
+.normal-card::before { content:''; position:absolute; inset:0; background:rgba(220,220,220,0.15); z-index:0; pointer-events:none; border-radius:0; }
+.effect-card::before { content:''; position:absolute; inset:0; background:rgba(160,80,20,0.22);  z-index:0; pointer-events:none; border-radius:0; }
+.fusion-card::before { content:''; position:absolute; inset:0; background:rgba(120,40,200,0.25); z-index:0; pointer-events:none; border-radius:0; }
+.spell-card::before  { content:''; position:absolute; inset:0; background:rgba(20,140,80,0.22);  z-index:0; pointer-events:none; border-radius:0; }
+.trap-card::before      { content:''; position:absolute; inset:0; background:rgba(180,20,60,0.22);  z-index:0; pointer-events:none; border-radius:0; }
+.equipment-card::before { content:''; position:absolute; inset:0; background:rgba(224,128,48,0.22); z-index:0; pointer-events:none; border-radius:0; }
 
 /* Attribute backgrounds */
-.attr-fire  { background: #380800; }
-.attr-water { background: #001830; }
-.attr-earth { background: #181000; }
-.attr-wind  { background: #081020; }
-.attr-light { background: #181400; }
-.attr-dark  { background: #0e0020; }
-.attr-spell { background: #001810; }
+.attr-fire  { background: #451005; }
+.attr-water { background: #002040; }
+.attr-earth { background: #201808; }
+.attr-wind  { background: #101828; }
+.attr-light { background: #201c08; }
+.attr-dark  { background: #160830; }
+.attr-spell { background: #002018; }
 
 /* Face down */
 .face-down { background: #081610 !important; border-color: rgba(40,120,70,0.6) !important; }
@@ -584,6 +584,8 @@ button { cursor: pointer; border: none; font-family: inherit; transition: none; 
 .hand-card { cursor: pointer; transition: none; }
 .hand-card:hover { transform: translateY(-14px) scale(1.08); z-index: 100; box-shadow: none; outline: 2px solid var(--border-glow); }
 .hand-card.playable:hover { box-shadow: none; outline: 2px solid #30c060; }
+.hand-card.dimmed { opacity: 0.5; filter: grayscale(35%); }
+.hand-card.dimmed:hover { outline-color: var(--border-glow); }
 .hand-card.targetable { border-color: #ffdd44 !important; animation: handGlow 0.5s ease-in-out infinite alternate; }
 .hand-card.fusionable { border-color: rgba(190,110,255,0.9) !important; box-shadow: none; outline: 2px solid #be6eff; }
 .hand-card.fusionable::after {

--- a/js/react/components/HandCard.tsx
+++ b/js/react/components/HandCard.tsx
@@ -7,6 +7,7 @@ interface Props {
   card: any;
   index: number;
   playable: boolean;
+  dimmed?: boolean;
   fusionable: boolean;
   targetable: boolean;
   chainSelected?: boolean;
@@ -19,7 +20,7 @@ interface Props {
   onLongPress?: () => void;
 }
 
-export function HandCard({ card, index, playable, fusionable, targetable, chainSelected, chainIndex, fusionSelected, fusionIndex, newlyDrawn, drawDelay, onClick, onLongPress }: Props) {
+export function HandCard({ card, index, playable, dimmed, fusionable, targetable, chainSelected, chainIndex, fusionSelected, fusionIndex, newlyDrawn, drawDelay, onClick, onLongPress }: Props) {
   const ref = useRef<HTMLDivElement>(null);
 
   const isSelected = chainSelected || fusionSelected;
@@ -35,6 +36,7 @@ export function HandCard({ card, index, playable, fusionable, targetable, chainS
     `${cardTypeCss(card)}-card`,
     `attr-${card.attribute ? ATTR_CSS[card.attribute] || 'spell' : 'spell'}`,
     playable       ? 'playable'       : '',
+    dimmed         ? 'dimmed'         : '',
     fusionable     ? 'fusionable'     : '',
     targetable     ? 'targetable'     : '',
     isSelected     ? 'chain-selected' : '',

--- a/js/react/screens/game/HandArea.tsx
+++ b/js/react/screens/game/HandArea.tsx
@@ -125,16 +125,23 @@ export function HandArea() {
       <div id="player-hand">
         {player.hand.map((card, i) => {
           const isNewlyDrawn = i >= newDrawBase;
-          const playable     = isMyTurn && phase === 'main';
+          const isMon        = isMonsterType(card.type);
+          const playable     = isMyTurn && phase === 'main' && (
+            isMon
+              ? !player.normalSummonUsed && player.field.monsters.some(z => z === null)
+              : player.field.spellTraps.some(z => z === null)
+          );
           const inFusion     = fusionGroup.includes(i);
           const fusionIdx    = inFusion ? fusionGroup.indexOf(i) : undefined;
           const fusionable   = selMode === 'fusion1' && i !== sel.fusion1?.handIndex;
           const targetable   = selMode === 'fusion1' && i !== sel.fusion1?.handIndex;
+          const dimmed       = isMyTurn && phase === 'main' && !playable && !inFusion;
           return (
             <HandCard
               key={`${card.id}-${i}`}
               card={card} index={i}
               playable={playable}
+              dimmed={dimmed}
               fusionable={fusionable}
               targetable={targetable}
               fusionSelected={inFusion}


### PR DESCRIPTION
Increase type-based background tint opacity from ~4-9% to ~15-25% so card
types are visually distinguishable by background color. Lighten attribute
base backgrounds slightly to let the type tint show through.

Add dimmed state for hand cards that cannot be played during main phase:
monsters dim after normal summon is used, spells/traps dim when zones are
full. States reset automatically at turn end via existing engine logic.

https://claude.ai/code/session_013rJsU14QCtXzkGFDPvitjH