### PR TITLE
fix(ui): replace Silkscreen font with Pixelify Sans for better number readability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,4 +198,4 @@ GitHub Actions (`.github/workflows/`):
 | Testing | Vitest 4 + Playwright 1.58 |
 | i18n | i18next |
 | Mobile | Capacitor 8 (Android) |
-| Fonts | Press Start 2P, Silkscreen (pixel art theme) |
+| Fonts | Press Start 2P, Pixelify Sans (pixel art theme) |

--- a/css/style.css
+++ b/css/style.css
@@ -50,7 +50,7 @@ html {
 html, body {
   width: 100%; height: 100%;
   overflow: hidden;
-  font-family: 'Silkscreen', monospace;
+  font-family: 'Pixelify Sans', monospace;
   background: var(--bg);
   color: var(--text);
   user-select: none;
@@ -621,7 +621,7 @@ button { cursor: pointer; border: none; font-family: inherit; transition: none; 
   background: rgba(0, 0, 0, 0.85);
   border: 2px solid #ffd700;
   border-radius: 8px;
-  font-family: 'Silkscreen', 'Press Start 2P', monospace;
+  font-family: 'Pixelify Sans', 'Press Start 2P', monospace;
   font-size: 10px;
   color: #eee;
   position: absolute;
@@ -831,7 +831,7 @@ button { cursor: pointer; border: none; font-family: inherit; transition: none; 
   padding: 8px 12px;
   margin: 8px 0 4px;
   text-align: center;
-  font-family: 'Silkscreen', monospace;
+  font-family: 'Pixelify Sans', monospace;
   font-size: 0.75rem;
   color: #ffcccc;
   line-height: 1.5;

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>Echoes of Sanguo</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=Silkscreen:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Pixelify+Sans:wght@400;700&family=Press+Start+2P&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/style.css">
   <link rel="stylesheet" href="css/progression.css">
 </head>

--- a/js/react/components/Card.module.css
+++ b/js/react/components/Card.module.css
@@ -149,7 +149,7 @@
 :global(.opponent-side) .descText     { font-size: 5px; -webkit-line-clamp: 1; }
 :global(.opponent-side) .cardStats    { padding: 1px 3px 2px; min-height: 13px; }
 :global(.opponent-side) .atkVal,
-:global(.opponent-side) .defVal       { font-size: 7px; }
+:global(.opponent-side) .defVal       { font-size: 8px; }
 
 /* ── Small-card layout (art + ATK/DEF + name) ───────────────────── */
 :global(.small-card) .cardArt { max-height: 80px; }

--- a/js/react/screens/CampaignScreen.module.css
+++ b/js/react/screens/CampaignScreen.module.css
@@ -160,7 +160,7 @@
   color: #8090a0;
   text-align: center;
   margin-top: 2px;
-  font-family: 'Silkscreen', monospace;
+  font-family: 'Pixelify Sans', monospace;
   max-width: 60px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -178,7 +178,7 @@
 .nodeStatus {
   font-size: 0.4rem;
   margin-top: 1px;
-  font-family: 'Silkscreen', monospace;
+  font-family: 'Pixelify Sans', monospace;
 }
 
 .statusCompleted {
@@ -219,7 +219,7 @@
   font-size: 0.75rem;
   line-height: 1.6;
   margin-bottom: 16px;
-  font-family: 'Silkscreen', monospace;
+  font-family: 'Pixelify Sans', monospace;
 }
 
 .dialogueClose {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -5,7 +5,7 @@ export default {
   theme: {
     extend: {
       fontFamily: {
-        pixel: ['"Silkscreen"', 'monospace'],
+        pixel: ['"Pixelify Sans"', 'monospace'],
         title: ['"Press Start 2P"', 'monospace'],
       },
       borderRadius: {


### PR DESCRIPTION
Silkscreen made digits like 4 and 9 nearly indistinguishable at small sizes.
Pixelify Sans is a modern pixel font with clearly distinct numerals while
preserving the retro aesthetic. Also bumps opponent-side ATK/DEF from 7px to 8px.

https://claude.ai/code/session_01442MnQ7oMdJj4AcmpADSxk