### PR TITLE
feat(ui): add card type placeholder artwork and square art area

### DIFF
--- a/js/react/components/Card.module.css
+++ b/js/react/components/Card.module.css
@@ -33,9 +33,10 @@
   letter-spacing: -1px; flex-shrink: 0;
 }
 
-/* Art area — takes remaining vertical space */
+/* Art area — square aspect ratio */
 .cardArt {
-  flex: 1;
+  aspect-ratio: 1 / 1;
+  width: calc(100% - 10px);
   position: relative; overflow: hidden;
   display: flex; align-items: center; justify-content: center;
   min-height: 0;

--- a/js/react/components/Card.tsx
+++ b/js/react/components/Card.tsx
@@ -10,6 +10,20 @@ import {
 import { highlightCardText, highlightCardTextHTML } from '../utils/highlightCardText.js';
 import styles from './Card.module.css';
 
+/** Map a card to its type-based placeholder art URL, or null for normal/effect monsters. */
+function getPlaceholderUrl(card: CardData): string | null {
+  switch (card.type) {
+    case CardType.Fusion:     return './img/placeholders/fusion.svg';
+    case CardType.Trap:       return './img/placeholders/trap.svg';
+    case CardType.Equipment:  return './img/placeholders/equipment.svg';
+    case CardType.Spell:
+      return card.spellType === 'field'
+        ? './img/placeholders/field-spell.svg'
+        : './img/placeholders/spell.svg';
+    default:                  return null;
+  }
+}
+
 function getTypeLabel(card: CardData): string {
   if (card.type === CardType.Monster && card.effect) return i18next.t('card_detail.type_effect');
   return getCardTypeById(card.type)?.value ?? '';
@@ -44,6 +58,10 @@ export function Card({ card, fc = null, dimmed = false, rotated = false, big = f
   const attrMeta   = card.attribute ? getAttrById(card.attribute) : undefined;
   const attrSym    = attrMeta?.symbol ?? '\u2726';
   const typeLabel  = getTypeLabel(card);
+  const placeholderUrl = getPlaceholderUrl(card);
+  const artStyle: React.CSSProperties | undefined = placeholderUrl
+    ? { backgroundImage: `url(${placeholderUrl})`, backgroundSize: 'cover', backgroundPosition: 'center' }
+    : undefined;
   const baseATK    = card.atk ?? 0;
   const baseDEF    = card.def ?? 0;
   const effATK     = fc ? fc.effectiveATK() : baseATK;
@@ -117,7 +135,7 @@ export function Card({ card, fc = null, dimmed = false, rotated = false, big = f
   if (small) {
     return (
       <div className={cls}>
-        <div className={styles.cardArt}>
+        <div className={styles.cardArt} style={artStyle}>
           {raceBadge}
         </div>
         {isMonster
@@ -145,7 +163,7 @@ export function Card({ card, fc = null, dimmed = false, rotated = false, big = f
         {attrOrb}
       </div>
       <div className={styles.cardLevel}>{levelStars}</div>
-      <div className={styles.cardArt}>
+      <div className={styles.cardArt} style={artStyle}>
         {raceBadge}
         {rarityText}
       </div>
@@ -183,6 +201,10 @@ export function cardInnerHTML(card: CardData, _dimmed = false, _rotated = false,
   const attrMeta   = card.attribute ? getAttrById(card.attribute) : undefined;
   const attrSym    = attrMeta?.symbol ?? '\u2726';
   const typeLabel  = getTypeLabel(card);
+  const phUrl = getPlaceholderUrl(card);
+  const artStyleStr = phUrl
+    ? `background-image:url(${phUrl});background-size:cover;background-position:center`
+    : '';
   const baseATK    = card.atk ?? 0;
   const baseDEF    = card.def ?? 0;
   const effATK     = fc ? fc.effectiveATK() : baseATK;
@@ -232,7 +254,7 @@ export function cardInnerHTML(card: CardData, _dimmed = false, _rotated = false,
       <span class="card-name-short">${card.name}</span>${orbHTML}
     </div>
     <div class="card-level">${levelStars}</div>
-    <div class="card-art">
+    <div class="card-art"${artStyleStr ? ` style="${artStyleStr}"` : ''}>
       ${raceBadge}${rarityTextH}
     </div>
     <div class="card-body">

--- a/public/img/placeholders/equipment.svg
+++ b/public/img/placeholders/equipment.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <defs>
+    <linearGradient id="ebg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#001830"/>
+      <stop offset="100%" stop-color="#002040"/>
+    </linearGradient>
+    <linearGradient id="blade" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#c0d0e0"/>
+      <stop offset="50%" stop-color="#e0e8f0"/>
+      <stop offset="100%" stop-color="#a0b0c0"/>
+    </linearGradient>
+  </defs>
+  <rect width="256" height="256" fill="url(#ebg)"/>
+  <!-- Energy wisps -->
+  <path d="M60,200 Q80,160 70,120 Q60,80 90,60" fill="none" stroke="#40a0c0" stroke-width="2" opacity="0.3"/>
+  <path d="M180,210 Q200,170 190,130 Q180,90 200,50" fill="none" stroke="#40a0c0" stroke-width="2" opacity="0.3"/>
+  <!-- Sword blade (diagonal) -->
+  <polygon points="80,200 128,50 136,54 92,204" fill="url(#blade)"/>
+  <!-- Blade edge highlight -->
+  <line x1="82" y1="198" x2="129" y2="52" stroke="#f0f4ff" stroke-width="1" opacity="0.6"/>
+  <!-- Guard (crossguard) -->
+  <rect x="72" y="192" width="52" height="8" rx="2" fill="#60a080" transform="rotate(-10, 98, 196)"/>
+  <!-- Guard jade orb -->
+  <circle cx="98" cy="196" r="6" fill="#70c090" opacity="0.8"/>
+  <circle cx="96" cy="194" r="2" fill="#a0e0b0" opacity="0.6"/>
+  <!-- Handle -->
+  <rect x="90" y="200" width="10" height="30" rx="2" fill="#604830" transform="rotate(-10, 95, 215)"/>
+  <!-- Pommel -->
+  <circle cx="92" cy="232" r="6" fill="#60a080" opacity="0.7"/>
+  <!-- Energy glow around blade -->
+  <polygon points="80,200 128,50 136,54 92,204" fill="none" stroke="#40a0e0" stroke-width="3" opacity="0.2"/>
+  <!-- Sparkle -->
+  <text x="130" y="70" font-size="14" fill="#a0d0ff" opacity="0.7">✦</text>
+</svg>

--- a/public/img/placeholders/field-spell.svg
+++ b/public/img/placeholders/field-spell.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <defs>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#4a90c2"/>
+      <stop offset="60%" stop-color="#7ab8d4"/>
+      <stop offset="100%" stop-color="#a8d8a0"/>
+    </linearGradient>
+    <linearGradient id="water" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#2a6888"/>
+      <stop offset="100%" stop-color="#1a3850"/>
+    </linearGradient>
+  </defs>
+  <rect width="256" height="256" fill="url(#sky)"/>
+  <!-- Mountains -->
+  <polygon points="0,160 60,80 120,160" fill="#5a7a5a" opacity="0.7"/>
+  <polygon points="80,160 160,60 240,160" fill="#4a6a4a" opacity="0.8"/>
+  <polygon points="160,160 220,90 280,160" fill="#3a5a3a" opacity="0.6"/>
+  <!-- Snow caps -->
+  <polygon points="145,70 160,60 175,70 165,75 155,75" fill="#e8e8f0" opacity="0.9"/>
+  <!-- Ground -->
+  <rect y="160" width="256" height="30" fill="#3a6a3a"/>
+  <!-- Water -->
+  <rect y="190" width="256" height="66" fill="url(#water)"/>
+  <!-- Water waves -->
+  <path d="M0,210 Q32,205 64,210 Q96,215 128,210 Q160,205 192,210 Q224,215 256,210" fill="none" stroke="#4a9ac8" stroke-width="1.5" opacity="0.5"/>
+  <path d="M0,225 Q32,220 64,225 Q96,230 128,225 Q160,220 192,225 Q224,230 256,225" fill="none" stroke="#4a9ac8" stroke-width="1" opacity="0.4"/>
+  <!-- Trees -->
+  <polygon points="20,160 30,120 40,160" fill="#2a5a2a"/>
+  <polygon points="230,160 240,125 250,160" fill="#2a5a2a"/>
+  <!-- Chinese pavilion hint -->
+  <rect x="105" y="145" width="20" height="15" fill="#3a3028" opacity="0.6"/>
+  <polygon points="100,145 115,132 130,145" fill="#2a2820" opacity="0.7"/>
+</svg>

--- a/public/img/placeholders/fusion.svg
+++ b/public/img/placeholders/fusion.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <defs>
+    <radialGradient id="fg" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#c060e0"/>
+      <stop offset="50%" stop-color="#8030a0"/>
+      <stop offset="100%" stop-color="#200830"/>
+    </radialGradient>
+  </defs>
+  <rect width="256" height="256" fill="#0a0418"/>
+  <circle cx="128" cy="128" r="120" fill="url(#fg)" opacity="0.8"/>
+  <!-- Swirl arms -->
+  <path d="M128,128 Q80,60 40,128 Q0,196 128,128" fill="none" stroke="#40c890" stroke-width="4" opacity="0.7"/>
+  <path d="M128,128 Q176,196 216,128 Q256,60 128,128" fill="none" stroke="#e0e0e0" stroke-width="4" opacity="0.7"/>
+  <!-- Inner glow -->
+  <circle cx="128" cy="128" r="30" fill="#c040a0" opacity="0.4"/>
+  <circle cx="128" cy="128" r="15" fill="#e060c0" opacity="0.5"/>
+  <!-- Orbiting sparks -->
+  <circle cx="70" cy="80" r="3" fill="#60e0a0" opacity="0.8"/>
+  <circle cx="186" cy="176" r="3" fill="#e0e0f0" opacity="0.8"/>
+  <circle cx="90" cy="190" r="2" fill="#a0c0ff" opacity="0.6"/>
+  <circle cx="170" cy="70" r="2" fill="#ffa0c0" opacity="0.6"/>
+  <!-- Yin-yang hint -->
+  <path d="M128,88 A40,40 0 0 1 128,168 A20,20 0 0 0 128,128 A20,20 0 0 1 128,88" fill="#40c890" opacity="0.3"/>
+  <path d="M128,88 A40,40 0 0 0 128,168 A20,20 0 0 1 128,128 A20,20 0 0 0 128,88" fill="#e0e0e0" opacity="0.3"/>
+</svg>

--- a/public/img/placeholders/spell.svg
+++ b/public/img/placeholders/spell.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <defs>
+    <radialGradient id="sg" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#60c0e0"/>
+      <stop offset="40%" stop-color="#8060c0"/>
+      <stop offset="100%" stop-color="#100820"/>
+    </radialGradient>
+  </defs>
+  <rect width="256" height="256" fill="#0c0818"/>
+  <circle cx="128" cy="100" r="110" fill="url(#sg)" opacity="0.6"/>
+  <!-- Swirling energy -->
+  <path d="M128,180 Q100,140 110,100 Q120,60 128,40 Q136,60 146,100 Q156,140 128,180" fill="none" stroke="#80e0ff" stroke-width="3" opacity="0.5"/>
+  <path d="M128,180 Q80,150 90,100 Q100,50 128,30 Q156,50 166,100 Q176,150 128,180" fill="none" stroke="#a060e0" stroke-width="2" opacity="0.4"/>
+  <!-- Inner glow -->
+  <circle cx="128" cy="100" r="25" fill="#60c0e0" opacity="0.2"/>
+  <circle cx="128" cy="100" r="12" fill="#a0e0ff" opacity="0.3"/>
+  <!-- Stone altar base -->
+  <polygon points="88,200 168,200 178,220 78,220" fill="#404048"/>
+  <polygon points="95,185 161,185 168,200 88,200" fill="#505058"/>
+  <rect x="100" y="178" width="56" height="7" fill="#585860"/>
+  <!-- Altar crack -->
+  <line x1="128" y1="200" x2="130" y2="218" stroke="#303038" stroke-width="1.5"/>
+  <!-- Floating particles -->
+  <circle cx="100" cy="70" r="2" fill="#c0a0ff" opacity="0.7"/>
+  <circle cx="156" cy="60" r="2" fill="#80e0ff" opacity="0.7"/>
+  <circle cx="110" cy="45" r="1.5" fill="#e0c0ff" opacity="0.5"/>
+  <circle cx="148" cy="80" r="1.5" fill="#a0f0ff" opacity="0.5"/>
+  <circle cx="85" cy="100" r="2" fill="#c0a0ff" opacity="0.4"/>
+  <circle cx="172" cy="95" r="2" fill="#80e0ff" opacity="0.4"/>
+  <!-- Star sparkles -->
+  <text x="70" y="50" font-size="10" fill="#c0a0ff" opacity="0.6">✦</text>
+  <text x="175" y="45" font-size="8" fill="#80e0ff" opacity="0.5">✦</text>
+  <text x="55" y="130" font-size="8" fill="#a080e0" opacity="0.4">✦</text>
+</svg>

--- a/public/img/placeholders/trap.svg
+++ b/public/img/placeholders/trap.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <defs>
+    <radialGradient id="tg" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#a02050"/>
+      <stop offset="60%" stop-color="#601040"/>
+      <stop offset="100%" stop-color="#180818"/>
+    </radialGradient>
+  </defs>
+  <rect width="256" height="256" fill="url(#tg)"/>
+  <!-- Vortex rings -->
+  <circle cx="128" cy="128" r="100" fill="none" stroke="#c03060" stroke-width="2" opacity="0.4"/>
+  <circle cx="128" cy="128" r="75" fill="none" stroke="#a02050" stroke-width="2" opacity="0.5"/>
+  <circle cx="128" cy="128" r="50" fill="none" stroke="#801840" stroke-width="2" opacity="0.6"/>
+  <!-- Trap jaws (bear trap shape) -->
+  <path d="M68,148 L88,108 L98,138" fill="none" stroke="#808890" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M98,138 L108,108 L118,138" fill="none" stroke="#808890" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M118,138 L128,108" fill="none" stroke="#808890" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M128,108 L138,138 L148,108 L158,138 L168,108 L188,148" fill="none" stroke="#808890" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Base plate -->
+  <ellipse cx="128" cy="155" rx="50" ry="12" fill="#606870" opacity="0.7"/>
+  <!-- Chain -->
+  <path d="M128,167 L128,200 L108,220" fill="none" stroke="#505860" stroke-width="3" opacity="0.6"/>
+  <!-- Danger sparkles -->
+  <text x="60" y="80" font-size="16" fill="#ff4070" opacity="0.6">✦</text>
+  <text x="180" y="90" font-size="12" fill="#ff4070" opacity="0.4">✦</text>
+  <text x="170" y="200" font-size="14" fill="#ff4070" opacity="0.5">✦</text>
+</svg>


### PR DESCRIPTION
Add type-based SVG placeholder images (256x256) for fusion, spell,
field spell, trap, and equipment cards. Change card art area to
aspect-ratio 1:1 for consistent square rendering.

https://claude.ai/code/session_01Q6cfb9szZ97VmtzMkxekmi