### PR TITLE
refactor(tcg): overhaul TCG format with bug fixes, validation, and tests

### DIFF
--- a/docs/tcg-format.md
+++ b/docs/tcg-format.md
@@ -53,6 +53,7 @@ All enum fields in the format use integers, not strings.
 | 2 | Fusion | Fusion Monster |
 | 3 | Spell | Spell |
 | 4 | Trap | Trap |
+| 5 | Equipment | Equipment |
 
 ### Attribute (`attribute`)
 | ID | Key |
@@ -70,13 +71,15 @@ All enum fields in the format use integers, not strings.
 | 1 | Dragon |
 | 2 | Spellcaster |
 | 3 | Warrior |
-| 4 | Fire |
+| 4 | Beast |
 | 5 | Plant |
-| 6 | Stone |
-| 7 | Flyer |
-| 8 | Elf |
-| 9 | Demon |
-| 10 | Water |
+| 6 | Rock |
+| 7 | Phoenix |
+| 8 | Undead |
+| 9 | Aqua |
+| 10 | Insect |
+| 11 | Machine |
+| 12 | Pyro |
 
 ### Rarity (`rarity`)
 | ID | Key |
@@ -93,6 +96,7 @@ All enum fields in the format use integers, not strings.
 | 1 | normal |
 | 2 | targeted |
 | 3 | fromGrave |
+| 4 | field |
 
 ### Trap Trigger (`trapTrigger`)
 | ID | Key |
@@ -137,17 +141,21 @@ Array of card stat objects. All integer IDs must be positive and unique.
 | Field | Type | Required | Notes |
 |-------|------|----------|-------|
 | `id` | integer | yes | unique numeric ID |
-| `type` | integer | yes | 1–4, see Card Type table |
+| `type` | integer | yes | 1–5, see Card Type table |
 | `level` | integer | yes | 1–12 |
 | `rarity` | integer | yes | 1, 2, 4, 6, or 8 |
 | `atk` | integer | monsters only | attack points |
 | `def` | integer | monsters only | defense points |
 | `attribute` | integer | monsters only | 1–6 |
-| `race` | integer | monsters only | 1–10 |
+| `race` | integer | monsters only | 1–12 |
 | `effect` | string | no | effect string, see Effects section |
-| `spellType` | integer | spells only | 1–3 |
+| `spellType` | integer | spells only | 1–4 |
 | `trapTrigger` | integer | traps only | 1–4 |
 | `target` | string | targeted spells/traps | `ownMonster` \| `oppMonster` \| `attacker` \| `defender` \| `summonedFC` |
+| `atkBonus` | integer | equipment only | ATK bonus applied to equipped monster |
+| `defBonus` | integer | equipment only | DEF bonus applied to equipped monster |
+| `equipReqRace` | integer | equipment only | required race (1–12) for target monster |
+| `equipReqAttr` | integer | equipment only | required attribute (1–6) for target monster |
 
 ---
 
@@ -303,7 +311,8 @@ Locale override files (in `locales/`) may only contain `{ "<id>": "<translated v
   { "id": 1, "key": "Monster", "value": "Monster",        "color": "#c8a850" },
   { "id": 2, "key": "Fusion",  "value": "Fusion Monster", "color": "#a050c0" },
   { "id": 3, "key": "Spell",   "value": "Spell",          "color": "#1dc0a0" },
-  { "id": 4, "key": "Trap",    "value": "Trap",            "color": "#bc2060" }
+  { "id": 4, "key": "Trap",    "value": "Trap",            "color": "#bc2060" },
+  { "id": 5, "key": "Equipment", "value": "Equipment",     "color": "#d4a017" }
 ]
 ```
 
@@ -471,7 +480,7 @@ One JSON file per opponent. File names are arbitrary — the engine reads all `*
 | `id` | integer | yes | unique, used by campaign nodes |
 | `name` | string | yes | default display name |
 | `title` | string | yes | subtitle shown in opponent select |
-| `race` | integer | yes | race ID (1–10) — used for opponent tile icon |
+| `race` | integer | yes | race ID (1–12) — used for opponent tile icon |
 | `flavor` | string | yes | short flavor text |
 | `coinsWin` | integer | yes | coins awarded on player win |
 | `coinsLoss` | integer | yes | coins awarded on player loss |
@@ -576,20 +585,30 @@ trigger:action(args);action(args)
 | `dealDamage(target,value)` | target: `opponent`\|`self` | |
 | `gainLP(target,value)` | target: `opponent`\|`self` | |
 | `draw(target,count)` | target: `self`\|`opponent` | |
-| `buffAtkRace(raceId,value)` | permanent ATK buff to all friendly monsters of race | |
-| `buffAtkAttr(attrId,value)` | permanent ATK buff to all friendly monsters of attribute | |
-| `debuffAllOpp(atkD,defD)` | permanent debuff to all opponent monsters | |
-| `tempBuffAtkRace(raceId,value)` | temporary (until end of turn) | |
-| `tempDebuffAllOpp(atkD[,defD])` | temporary | |
+| `buffField(value[,filter])` | permanent ATK buff to friendly monsters matching filter | |
+| `debuffField(atkD,defD[,filter])` | permanent debuff to opponent monsters | |
+| `tempBuffField(value[,filter])` | temporary (until end of turn) ATK buff | |
+| `tempDebuffField(atkD,defD[,filter])` | temporary debuff | |
 | `bounceStrongestOpp()` | return strongest opponent monster to hand | |
 | `bounceAttacker()` | return attacking monster to hand | |
 | `bounceAllOppMonsters()` | return all opponent monsters to hand | |
-| `searchDeckToHand(attrId)` | add a card of the given attribute from deck to hand | |
+| `searchDeckToHand(filter)` | add a card matching filter from deck to hand | |
 | `tempAtkBonus(target,value)` | temporary ATK modification | target: stat target |
-| `permAtkBonus(target,value[,attrFilter])` | permanent ATK modification | |
+| `permAtkBonus(target,value[,filter])` | permanent ATK modification | |
 | `tempDefBonus(target,value)` | temporary DEF modification | |
 | `permDefBonus(target,value)` | permanent DEF modification | |
 | `reviveFromGrave()` | special summon a monster from the graveyard | |
+| `destroyAllOpp()` | destroy all opponent monsters | |
+| `destroyAll()` | destroy all monsters on both sides | |
+| `destroyWeakestOpp()` | destroy weakest opponent monster | |
+| `destroyStrongestOpp()` | destroy strongest opponent monster | |
+| `sendTopCardsToGrave(count)` | send top N cards from own deck to graveyard | |
+| `salvageFromGrave()` | add a monster from graveyard to hand | |
+| `recycleFromGraveToDeck(count)` | return N cards from graveyard to deck | |
+| `shuffleGraveIntoDeck()` | shuffle entire graveyard into deck | |
+| `specialSummonFromHand()` | special summon a monster from hand | |
+| `discardFromHand(count)` | discard N cards from hand | |
+| `discardOppHand(count)` | force opponent to discard N cards | |
 | `cancelAttack()` | cancel the current attack (trap) | |
 | `destroyAttacker()` | destroy the attacking monster (trap) | |
 | `destroySummonedIf(minAtk)` | destroy the summoned monster if ATK >= minAtk (trap) | |
@@ -598,6 +617,9 @@ trigger:action(args);action(args)
 | `passive_directAttack()` | can attack directly | |
 | `passive_vsAttrBonus(attrId,atk)` | bonus ATK when battling monsters of this attribute | |
 | `passive_phoenixRevival()` | revives once when destroyed | |
+| `passive_indestructible()` | cannot be destroyed by battle | |
+| `passive_effectImmune()` | immune to card effects | |
+| `passive_cantBeAttacked()` | cannot be selected as an attack target | |
 
 #### Stat targets
 
@@ -613,6 +635,25 @@ attacker.effectiveATK*0.5f → 50% of attacker ATK, rounded down (f = floor)
 attacker.effectiveATK*0.5c → 50% of attacker ATK, rounded up   (c = ceil)
 ```
 
+#### Card Filters
+
+Filters restrict which cards an action affects. Written as `{key=value,...}`:
+
+```
+{r=3}                → race 3 (Warrior)
+{a=2}                → attribute 2 (Dark)
+{r=3,a=1}            → race 3 AND attribute 1
+{maxAtk=1500}        → ATK ≤ 1500
+{t=1}                → card type 1 (Monster)
+```
+
+| Key | Meaning |
+|-----|---------|
+| `r` | race ID (1–12) |
+| `a` | attribute ID (1–6) |
+| `t` | card type ID (1–5) |
+| `maxAtk` | maximum ATK value |
+
 #### Examples
 
 ```
@@ -623,6 +664,36 @@ onAttack:dealDamage(opponent,attacker.effectiveATK*0.5f);cancelAttack()
 manual:tempAtkBonus(oppMonster,-500)
 onOpponentSummon:destroySummonedIf(1800)
 ```
+
+---
+
+### `fusion_formulas.json`
+
+Race/attribute-based fusion formulas (Forbidden Memories style). Produces fusion results based on the combination of two cards' races or attributes.
+
+```json
+{
+  "formulas": [
+    {
+      "id": "dragon_warrior",
+      "comboType": "race+race",
+      "operand1": 1,
+      "operand2": 3,
+      "priority": 10,
+      "resultPool": [50, 51]
+    }
+  ]
+}
+```
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `id` | string | yes | unique formula identifier |
+| `comboType` | string | yes | `race+race` \| `race+attr` \| `attr+attr` |
+| `operand1` | integer | yes | first operand (race or attribute ID) |
+| `operand2` | integer | yes | second operand (race or attribute ID) |
+| `priority` | integer | yes | higher priority formulas are checked first |
+| `resultPool` | integer[] | yes | possible fusion result card IDs (one chosen randomly) |
 
 ---
 

--- a/js/tcg-format/index.ts
+++ b/js/tcg-format/index.ts
@@ -32,11 +32,11 @@ export { serializeEffect, deserializeEffect, isValidEffectString } from './effec
 // Validators
 export { validateTcgCards } from './card-validator.js';
 export { validateTcgDefinitions } from './def-validator.js';
-export { validateTcgArchive } from './tcg-validator.js';
+export { validateTcgArchive, validateFusionFormulasJson, validateOpponentDeck } from './tcg-validator.js';
 export type { TcgArchiveContents } from './tcg-validator.js';
 
 // Builder
 export { cardDataToTcgCard, cardDataToTcgDef, buildManifest, buildRacesJson, buildAttributesJson, buildCardTypesJson, buildRaritiesJson } from './tcg-builder.js';
 
 // Loader
-export { loadTcgFile, revokeTcgImages } from './tcg-loader.js';
+export { loadTcgFile, revokeTcgImages, TcgNetworkError, TcgFormatError } from './tcg-loader.js';

--- a/js/tcg-format/tcg-builder.ts
+++ b/js/tcg-format/tcg-builder.ts
@@ -24,9 +24,13 @@ export function cardDataToTcgCard(card: CardData, numId: number): TcgCard {
     if (card.race)              tc.race = raceToInt(card.race);
   }
   if (card.effect) tc.effect = serializeEffect(card.effect);
-  if (card.spellType)   tc.spellType   = spellTypeToInt(card.spellType as any);
-  if (card.trapTrigger) tc.trapTrigger = trapTriggerToInt(card.trapTrigger as any);
-  if (card.target)      tc.target      = card.target as string;
+  if (card.spellType)   tc.spellType   = spellTypeToInt(card.spellType);
+  if (card.trapTrigger) tc.trapTrigger = trapTriggerToInt(card.trapTrigger);
+  if (card.target)      tc.target      = card.target;
+  if (card.atkBonus !== undefined) tc.atkBonus = card.atkBonus;
+  if (card.defBonus !== undefined) tc.defBonus = card.defBonus;
+  if (card.equipRequirement?.race) tc.equipReqRace = raceToInt(card.equipRequirement.race);
+  if (card.equipRequirement?.attr) tc.equipReqAttr = attributeToInt(card.equipRequirement.attr);
   return tc;
 }
 
@@ -43,7 +47,7 @@ export function cardDataToTcgDef(card: CardData, numId: number): TcgCardDefiniti
  */
 export function buildManifest(overrides?: Partial<TcgManifest>): TcgManifest {
   return {
-    formatVersion: 1,
+    formatVersion: 2,
     ...overrides,
   };
 }

--- a/js/tcg-format/tcg-loader.ts
+++ b/js/tcg-format/tcg-loader.ts
@@ -5,18 +5,74 @@
 
 import JSZip from 'jszip';
 import type { CardData, CardEffectBlock, FusionRecipe, FusionFormula, FusionComboType, OpponentConfig } from '../types.js';
-import { Race, Attribute } from '../types.js';
-import type { TcgCard, TcgCardDefinition, TcgMeta, TcgOpponentDeck, TcgOpponentDescription, TcgFusionFormula, TcgRacesJson, TcgAttributesJson, TcgCardTypesJson, TcgRaritiesJson, TcgLocaleOverrides, TcgShopJson, TcgCampaignJson, TcgLoadResult } from './types.js';
-import { validateTcgArchive } from './tcg-validator.js';
+import type { TcgCard, TcgCardDefinition, TcgMeta, TcgOpponentDeck, TcgOpponentDescription, TcgFusionFormula, TcgLocaleOverrides, TcgShopJson, TcgCampaignJson, TcgLoadResult } from './types.js';
+import { validateTcgArchive, validateCampaignJson, validateFusionFormulasJson } from './tcg-validator.js';
 import { intToCardType, intToAttribute, intToRace, intToRarity, intToSpellType, intToTrapTrigger } from './enums.js';
 import { deserializeEffect } from './effect-serializer.js';
 import { CARD_DB, FUSION_RECIPES, FUSION_FORMULAS, OPPONENT_CONFIGS, STARTER_DECKS, PLAYER_DECK_IDS, OPPONENT_DECK_IDS } from '../cards.js';
 import { applyRules } from '../rules.js';
 import type { GameRules } from '../rules.js';
 import { applyTypeMeta } from '../type-metadata.js';
+import type { TypeMetaData } from '../type-metadata.js';
 import { applyShopData } from '../shop-data.js';
 import { applyCampaignData } from '../campaign-store.js';
-import { validateCampaignJson } from './tcg-validator.js';
+
+// ── Error Classes ───────────────────────────────────────────
+
+/** Thrown when a .tcg file cannot be fetched from the network. */
+export class TcgNetworkError extends Error {
+  constructor(url: string, status: number) {
+    super(`Failed to fetch ${url}: ${status}`);
+    this.name = 'TcgNetworkError';
+  }
+}
+
+/** Thrown when a .tcg file is structurally invalid (corrupt ZIP, failed validation, unsupported version). */
+export class TcgFormatError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TcgFormatError';
+  }
+}
+
+// ── Constants ───────────────────────────────────────────────
+
+const SUPPORTED_FORMAT_VERSION = 2;
+
+// ── Helpers ─────────────────────────────────────────────────
+
+function getBrowserLang(): string {
+  return typeof navigator !== 'undefined' ? navigator.language.substring(0, 2) : '';
+}
+
+/**
+ * Load and apply a split metadata file (races.json, attributes.json, etc.)
+ * with optional locale overrides. Reduces repetition for each metadata type.
+ */
+async function loadMetadataFile<T extends { key: string; value: string }>(
+  zip: JSZip,
+  filename: string,
+  lang: string,
+  metaKey: keyof TypeMetaData,
+  warnings: string[],
+): Promise<void> {
+  const file = zip.file(filename);
+  if (!file) return;
+  try {
+    const data: T[] = JSON.parse(await file.async('string'));
+    const localeSuffix = filename.replace('.json', '');
+    const localeFile = zip.file(`locales/${lang}_${localeSuffix}.json`);
+    if (localeFile) {
+      const overrides: TcgLocaleOverrides = JSON.parse(await localeFile.async('string'));
+      for (const entry of data) {
+        if (overrides[entry.key] !== undefined) entry.value = overrides[entry.key];
+      }
+    }
+    applyTypeMeta({ [metaKey]: data } as TypeMetaData);
+  } catch {
+    warnings.push(`${filename}: failed to parse, using defaults`);
+  }
+}
 
 /**
  * Load a .tcg file from a URL or ArrayBuffer.
@@ -27,23 +83,42 @@ export async function loadTcgFile(source: string | ArrayBuffer): Promise<TcgLoad
   // Fetch if URL
   let buffer: ArrayBuffer;
   if (typeof source === 'string') {
-    const response = await fetch(source);
-    if (!response.ok) throw new Error(`Failed to fetch ${source}: ${response.status}`);
+    let response: Response;
+    try {
+      response = await fetch(source);
+    } catch (e) {
+      throw new TcgNetworkError(source, 0);
+    }
+    if (!response.ok) throw new TcgNetworkError(source, response.status);
     buffer = await response.arrayBuffer();
   } else {
     buffer = source;
   }
 
   // Open ZIP
-  const zip = await JSZip.loadAsync(buffer);
+  let zip: JSZip;
+  try {
+    zip = await JSZip.loadAsync(buffer);
+  } catch (e) {
+    throw new TcgFormatError(`Failed to open ZIP archive: ${e instanceof Error ? e.message : e}`);
+  }
 
   // Validate
   const result = await validateTcgArchive(zip);
   if (!result.valid || !result.contents) {
-    throw new Error(`Invalid .tcg file:\n${result.errors.join('\n')}`);
+    throw new TcgFormatError(`Invalid .tcg file:\n${result.errors.join('\n')}`);
   }
 
   const { cards, definitions, opponentDescriptions, imageIds, manifest } = result.contents;
+
+  // Validate format version from manifest
+  if (manifest && manifest.formatVersion > SUPPORTED_FORMAT_VERSION) {
+    throw new TcgFormatError(
+      `TCG format version mismatch: archive is v${manifest.formatVersion}, ` +
+      `loader supports up to v${SUPPORTED_FORMAT_VERSION}. ` +
+      `Please update the game engine or regenerate base.tcg with \`npm run generate:tcg\`.`
+    );
+  }
 
   // Extract images as blob URLs
   const images = new Map<number, string>();
@@ -57,7 +132,6 @@ export async function loadTcgFile(source: string | ArrayBuffer): Promise<TcgLoad
   }
 
   // Load meta.json if present
-  const SUPPORTED_TCG_VERSION = 1;
   let meta: TcgMeta | undefined;
   const metaFile = zip.file('meta.json');
   if (metaFile) {
@@ -66,18 +140,6 @@ export async function loadTcgFile(source: string | ArrayBuffer): Promise<TcgLoad
       meta = JSON.parse(metaJson);
     } catch {
       result.warnings.push('meta.json: failed to parse, skipping');
-    }
-  }
-  if (meta !== undefined) {
-    const metaVersion = (meta as any)?.version;
-    // Only reject if the archive explicitly declares an incompatible version number.
-    // A missing version field is treated as compatible (pre-versioning archives).
-    if (typeof metaVersion === 'number' && metaVersion !== SUPPORTED_TCG_VERSION) {
-      throw new Error(
-        `TCG format version mismatch: archive is v${metaVersion}, ` +
-        `loader expects v${SUPPORTED_TCG_VERSION}. ` +
-        `Please regenerate base.tcg with \`npm run generate:tcg\`.`
-      );
     }
   }
 
@@ -103,9 +165,9 @@ export async function loadTcgFile(source: string | ArrayBuffer): Promise<TcgLoad
       if (shopData.backgrounds) {
         const resolvedBgs: Record<string, string> = {};
         for (const [key, path] of Object.entries(shopData.backgrounds)) {
-          const imgFile = zip.file(path);
-          if (imgFile) {
-            const blob = await imgFile.async('blob');
+          const bgFile = zip.file(path);
+          if (bgFile) {
+            const blob = await bgFile.async('blob');
             resolvedBgs[key] = URL.createObjectURL(blob);
           }
         }
@@ -128,7 +190,7 @@ export async function loadTcgFile(source: string | ArrayBuffer): Promise<TcgLoad
       try {
         tcgOpponents.push(JSON.parse(await zip.file(p)!.async('string')));
       } catch {
-        result.warnings.push(`${p}: failed to parse, skipping`);
+        result.warnings.push(`${p}: failed to parse opponent deck, skipping`);
       }
     }
     tcgOpponents.sort((a, b) => a.id - b.id);
@@ -136,9 +198,7 @@ export async function loadTcgFile(source: string | ArrayBuffer): Promise<TcgLoad
 
   // Convert TcgCards to CardData and populate CARD_DB
   // Pick the best description file (prefer browser language, fallback to first)
-  const lang = typeof navigator !== 'undefined'
-    ? navigator.language.substring(0, 2)
-    : '';
+  const lang = getBrowserLang();
   if (definitions.size === 0) {
     result.warnings.push('No card definitions found in TCG archive');
     return { cards, definitions, images, meta, manifest, warnings: result.warnings };
@@ -149,64 +209,20 @@ export async function loadTcgFile(source: string | ArrayBuffer): Promise<TcgLoad
 
   for (const tc of cards) {
     const def = defMap.get(tc.id);
-    const cardData = tcgCardToCardData(tc, def);
+    const cardData = tcgCardToCardData(tc, def, result.warnings);
     CARD_DB[cardData.id] = cardData;
   }
 
   // Load split metadata files from ZIP (races.json, attributes.json, card_types.json, rarities.json)
-  const zipLang = typeof navigator !== 'undefined' ? navigator.language.substring(0, 2) : '';
-  const racesZipFile = zip.file('races.json');
-  if (racesZipFile) {
-    try {
-      const racesData: TcgRacesJson = JSON.parse(await racesZipFile.async('string'));
-      const raceLocaleFile = zip.file(`locales/${zipLang}_races.json`);
-      if (raceLocaleFile) {
-        const overrides: TcgLocaleOverrides = JSON.parse(await raceLocaleFile.async('string'));
-        for (const entry of racesData) {
-          if (overrides[entry.key] !== undefined) entry.value = overrides[entry.key];
-        }
-      }
-      applyTypeMeta({ races: racesData });
-    } catch {
-      result.warnings.push('races.json: failed to parse, using defaults');
-    }
-  }
-  const attributesZipFile = zip.file('attributes.json');
-  if (attributesZipFile) {
-    try {
-      const attributesData: TcgAttributesJson = JSON.parse(await attributesZipFile.async('string'));
-      const attrLocaleFile = zip.file(`locales/${zipLang}_attributes.json`);
-      if (attrLocaleFile) {
-        const overrides: TcgLocaleOverrides = JSON.parse(await attrLocaleFile.async('string'));
-        for (const entry of attributesData) {
-          if (overrides[entry.key] !== undefined) entry.value = overrides[entry.key];
-        }
-      }
-      applyTypeMeta({ attributes: attributesData });
-    } catch {
-      result.warnings.push('attributes.json: failed to parse, using defaults');
-    }
-  }
-  const cardTypesZipFile = zip.file('card_types.json');
-  if (cardTypesZipFile) {
-    try {
-      const cardTypesData: TcgCardTypesJson = JSON.parse(await cardTypesZipFile.async('string'));
-      const ctLocaleFile = zip.file(`locales/${zipLang}_card_types.json`);
-      if (ctLocaleFile) {
-        const overrides: TcgLocaleOverrides = JSON.parse(await ctLocaleFile.async('string'));
-        for (const entry of cardTypesData) {
-          if (overrides[entry.key] !== undefined) entry.value = overrides[entry.key];
-        }
-      }
-      applyTypeMeta({ cardTypes: cardTypesData });
-    } catch {
-      result.warnings.push('card_types.json: failed to parse, using defaults');
-    }
-  }
+  await loadMetadataFile(zip, 'races.json', lang, 'races', result.warnings);
+  await loadMetadataFile(zip, 'attributes.json', lang, 'attributes', result.warnings);
+  await loadMetadataFile(zip, 'card_types.json', lang, 'cardTypes', result.warnings);
+
+  // Rarities have no locale overrides
   const raritiesZipFile = zip.file('rarities.json');
   if (raritiesZipFile) {
     try {
-      const raritiesData: TcgRaritiesJson = JSON.parse(await raritiesZipFile.async('string'));
+      const raritiesData = JSON.parse(await raritiesZipFile.async('string'));
       applyTypeMeta({ rarities: raritiesData });
     } catch {
       result.warnings.push('rarities.json: failed to parse, using defaults');
@@ -232,8 +248,12 @@ export async function loadTcgFile(source: string | ArrayBuffer): Promise<TcgLoad
   if (formulasFile) {
     try {
       const formulasJson = await formulasFile.async('string');
-      const formulasData: { formulas: TcgFusionFormula[] } = JSON.parse(formulasJson);
-      applyFusionFormulas(formulasData.formulas);
+      const formulasData = JSON.parse(formulasJson);
+      const formulaWarnings = validateFusionFormulasJson(formulasData);
+      result.warnings.push(...formulaWarnings);
+      if (formulasData?.formulas && Array.isArray(formulasData.formulas)) {
+        applyFusionFormulas(formulasData.formulas as TcgFusionFormula[]);
+      }
     } catch {
       result.warnings.push('fusion_formulas.json: failed to parse, skipping');
     }
@@ -244,7 +264,11 @@ export async function loadTcgFile(source: string | ArrayBuffer): Promise<TcgLoad
 
   // Apply meta to game data stores
   if (meta) {
-    applyTcgMeta(meta, tcgOpponents, oppDescs);
+    try {
+      applyTcgMeta(meta, tcgOpponents, oppDescs);
+    } catch (e) {
+      result.warnings.push(`meta.json: failed to apply game data — ${e instanceof Error ? e.message : e}`);
+    }
   }
 
   return {
@@ -259,14 +283,17 @@ export async function loadTcgFile(source: string | ArrayBuffer): Promise<TcgLoad
 
 /**
  * Convert a TcgCard + TcgCardDefinition to the internal CardData format.
+ *
+ * Intentionally lenient: invalid effects are disabled with a warning rather than
+ * rejecting the card, so that archives with newer effect syntax degrade gracefully.
  */
-function tcgCardToCardData(tc: TcgCard, def?: TcgCardDefinition): CardData {
+function tcgCardToCardData(tc: TcgCard, def: TcgCardDefinition | undefined, warnings: string[]): CardData {
   let effect: CardEffectBlock | undefined;
   if (tc.effect) {
     try {
       effect = deserializeEffect(tc.effect);
     } catch (e) {
-      console.warn(`[TCG] Card #${tc.id} (${def?.name ?? 'unknown'}): failed to deserialize effect — effect disabled. ${e instanceof Error ? e.message : e}`);
+      warnings.push(`Card #${tc.id} (${def?.name ?? 'unknown'}): failed to deserialize effect — effect disabled. ${e instanceof Error ? e.message : e}`);
     }
   }
 
@@ -284,8 +311,14 @@ function tcgCardToCardData(tc: TcgCard, def?: TcgCardDefinition): CardData {
 
   if (tc.atk !== undefined) card.atk = tc.atk;
   if (tc.def !== undefined) card.def = tc.def;
-  if (tc.attribute !== undefined && tc.attribute > 0) card.attribute = intToAttribute(tc.attribute);
-  if (tc.race !== undefined && tc.race > 0) card.race = intToRace(tc.race);
+  if (tc.attribute !== undefined && tc.attribute > 0) {
+    try { card.attribute = intToAttribute(tc.attribute); }
+    catch { warnings.push(`Card #${tc.id}: invalid attribute ${tc.attribute}`); }
+  }
+  if (tc.race !== undefined && tc.race > 0) {
+    try { card.race = intToRace(tc.race); }
+    catch { warnings.push(`Card #${tc.id}: invalid race ${tc.race}`); }
+  }
   if (effect) card.effect = effect;
   if (tc.spellType)   card.spellType   = intToSpellType(tc.spellType);
   if (tc.trapTrigger) card.trapTrigger = intToTrapTrigger(tc.trapTrigger);
@@ -294,8 +327,14 @@ function tcgCardToCardData(tc: TcgCard, def?: TcgCardDefinition): CardData {
   if (tc.defBonus !== undefined) card.defBonus = tc.defBonus;
   if (tc.equipReqRace !== undefined || tc.equipReqAttr !== undefined) {
     card.equipRequirement = {};
-    if (tc.equipReqRace !== undefined) card.equipRequirement.race = tc.equipReqRace as Race;
-    if (tc.equipReqAttr !== undefined) card.equipRequirement.attr = tc.equipReqAttr as Attribute;
+    if (tc.equipReqRace !== undefined) {
+      try { card.equipRequirement.race = intToRace(tc.equipReqRace); }
+      catch { warnings.push(`Card #${tc.id}: invalid equipReqRace ${tc.equipReqRace}`); }
+    }
+    if (tc.equipReqAttr !== undefined) {
+      try { card.equipRequirement.attr = intToAttribute(tc.equipReqAttr); }
+      catch { warnings.push(`Card #${tc.id}: invalid equipReqAttr ${tc.equipReqAttr}`); }
+    }
   }
 
   return card;
@@ -349,7 +388,7 @@ function applyTcgMeta(
 
   if (meta.starterDecks) {
     for (const [raceKey, numIds] of Object.entries(meta.starterDecks)) {
-      const raceNum = Number(raceKey) as Race;
+      const raceNum = Number(raceKey);
       STARTER_DECKS[raceNum] = numIds.map(rid);
     }
     // Populate fallback IDs from first available starter deck

--- a/js/tcg-format/tcg-validator.ts
+++ b/js/tcg-format/tcg-validator.ts
@@ -411,3 +411,112 @@ export function validateCampaignJson(data: unknown): string[] {
 
   return warnings;
 }
+
+// ── Fusion Formulas Validator ──────────────────────────────────
+
+const VALID_COMBO_TYPES = ['race+race', 'race+attr', 'attr+attr'];
+
+/**
+ * Validate a fusion_formulas.json object. Returns an array of warning strings.
+ */
+export function validateFusionFormulasJson(data: unknown): string[] {
+  const warnings: string[] = [];
+  if (typeof data !== 'object' || data === null || Array.isArray(data)) {
+    warnings.push('fusion_formulas.json: must be a JSON object with a "formulas" array');
+    return warnings;
+  }
+
+  const obj = data as Record<string, unknown>;
+  if (!Array.isArray(obj.formulas)) {
+    warnings.push('fusion_formulas.json: missing or invalid "formulas" array');
+    return warnings;
+  }
+
+  const seenIds = new Set<string>();
+  for (let i = 0; i < obj.formulas.length; i++) {
+    const f = obj.formulas[i] as Record<string, unknown>;
+    const prefix = `fusion_formulas.json: formulas[${i}]`;
+
+    if (typeof f !== 'object' || f === null) {
+      warnings.push(`${prefix}: must be an object`);
+      continue;
+    }
+
+    if (typeof f.id !== 'string' || !f.id) {
+      warnings.push(`${prefix}: missing or invalid "id" (must be a non-empty string)`);
+    } else {
+      if (seenIds.has(f.id)) warnings.push(`${prefix}: duplicate formula id "${f.id}"`);
+      seenIds.add(f.id);
+    }
+
+    if (typeof f.comboType !== 'string' || !VALID_COMBO_TYPES.includes(f.comboType)) {
+      warnings.push(`${prefix}: invalid "comboType" "${f.comboType}" (expected: ${VALID_COMBO_TYPES.join(', ')})`);
+    }
+
+    if (typeof f.operand1 !== 'number') warnings.push(`${prefix}: "operand1" must be a number`);
+    if (typeof f.operand2 !== 'number') warnings.push(`${prefix}: "operand2" must be a number`);
+    if (typeof f.priority !== 'number') warnings.push(`${prefix}: "priority" must be a number`);
+
+    if (!Array.isArray(f.resultPool) || f.resultPool.length === 0) {
+      warnings.push(`${prefix}: "resultPool" must be a non-empty array`);
+    } else if (!f.resultPool.every((id: unknown) => typeof id === 'number' && id > 0)) {
+      warnings.push(`${prefix}: "resultPool" entries must be positive numbers`);
+    }
+  }
+
+  return warnings;
+}
+
+// ── Opponent Deck Validator ────────────────────────────────────
+
+/**
+ * Validate a single opponent deck object. Returns an array of warning strings.
+ * Pass knownCardIds to cross-validate deck card references.
+ */
+export function validateOpponentDeck(data: unknown, index: number, knownCardIds?: Set<number>): string[] {
+  const warnings: string[] = [];
+  const prefix = `opponents[${index}]`;
+
+  if (typeof data !== 'object' || data === null) {
+    warnings.push(`${prefix}: must be an object`);
+    return warnings;
+  }
+
+  const o = data as Record<string, unknown>;
+
+  if (typeof o.id !== 'number' || o.id <= 0) {
+    warnings.push(`${prefix}: "id" must be a positive number`);
+  }
+  if (typeof o.name !== 'string' || !o.name) {
+    warnings.push(`${prefix}: "name" must be a non-empty string`);
+  }
+  if (typeof o.title !== 'string') {
+    warnings.push(`${prefix}: "title" must be a string`);
+  }
+  if (typeof o.race !== 'number' || o.race < 1 || o.race > 12) {
+    warnings.push(`${prefix}: "race" must be a number between 1 and 12`);
+  }
+  if (typeof o.coinsWin !== 'number' || o.coinsWin < 0) {
+    warnings.push(`${prefix}: "coinsWin" must be a non-negative number`);
+  }
+  if (typeof o.coinsLoss !== 'number' || o.coinsLoss < 0) {
+    warnings.push(`${prefix}: "coinsLoss" must be a non-negative number`);
+  }
+
+  if (!Array.isArray(o.deckIds) || o.deckIds.length === 0) {
+    warnings.push(`${prefix}: "deckIds" must be a non-empty array`);
+  } else {
+    if (!o.deckIds.every((id: unknown) => typeof id === 'number' && id > 0)) {
+      warnings.push(`${prefix}: "deckIds" entries must be positive numbers`);
+    }
+    if (knownCardIds) {
+      for (const id of o.deckIds) {
+        if (typeof id === 'number' && !knownCardIds.has(id)) {
+          warnings.push(`${prefix}: deckIds references unknown card ID ${id}`);
+        }
+      }
+    }
+  }
+
+  return warnings;
+}

--- a/tests/tcg-format.test.js
+++ b/tests/tcg-format.test.js
@@ -359,4 +359,45 @@ describe('TCG Builder', () => {
     expect(def.name).toBe('Feuersalamander');
     expect(def.description).toBe('A fire salamander');
   });
+
+  it('converts an equipment CardData with atkBonus and defBonus', () => {
+    const card = {
+      id: '306', name: 'Flame Sword', type: CardType.Equipment,
+      description: 'A sword imbued with fire',
+      rarity: Rarity.Rare, atkBonus: 500, defBonus: 0,
+    };
+    const tc = cardDataToTcgCard(card, 306);
+    expect(tc.id).toBe(306);
+    expect(tc.type).toBe(5); // TCG_TYPE_EQUIPMENT
+    expect(tc.atkBonus).toBe(500);
+    expect(tc.defBonus).toBe(0);
+    expect(tc.atk).toBeUndefined();
+    expect(tc.def).toBeUndefined();
+    expect(tc.attribute).toBeUndefined();
+    expect(tc.race).toBeUndefined();
+  });
+
+  it('converts equipment with equipRequirement race and attr', () => {
+    const card = {
+      id: '307', name: 'Dragon Armor', type: CardType.Equipment,
+      description: 'Armor for dragons only',
+      rarity: Rarity.SuperRare, atkBonus: 300, defBonus: 600,
+      equipRequirement: { race: Race.Dragon, attr: Attribute.Fire },
+    };
+    const tc = cardDataToTcgCard(card, 307);
+    expect(tc.atkBonus).toBe(300);
+    expect(tc.defBonus).toBe(600);
+    expect(tc.equipReqRace).toBe(raceToInt(Race.Dragon));
+    expect(tc.equipReqAttr).toBe(attributeToInt(Attribute.Fire));
+  });
+
+  it('omits equipRequirement fields when not present', () => {
+    const card = {
+      id: '1', name: 'Basic Sword', type: CardType.Equipment,
+      description: 'A basic sword', rarity: Rarity.Common, atkBonus: 200, defBonus: 0,
+    };
+    const tc = cardDataToTcgCard(card, 1);
+    expect(tc.equipReqRace).toBeUndefined();
+    expect(tc.equipReqAttr).toBeUndefined();
+  });
 });

--- a/tests/tcg-loader.test.js
+++ b/tests/tcg-loader.test.js
@@ -1,0 +1,191 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import JSZip from 'jszip';
+import { loadTcgFile, revokeTcgImages, TcgNetworkError, TcgFormatError } from '../js/tcg-format/index.js';
+import { CARD_DB, FUSION_FORMULAS, OPPONENT_CONFIGS, STARTER_DECKS } from '../js/cards.js';
+
+// ── Helpers ─────────────────────────────────────────────────
+
+const VALID_CARD = { id: 1, type: 1, level: 3, rarity: 1, atk: 1000, def: 800, attribute: 3, race: 1 };
+const VALID_DEF = { id: 1, name: 'Test Card', description: 'A test card' };
+const VALID_MANIFEST = { formatVersion: 2 };
+
+async function buildMinimalZip(overrides = {}) {
+  const zip = new JSZip();
+  if (overrides.cards !== null) {
+    zip.file('cards.json', JSON.stringify(overrides.cards ?? [VALID_CARD]));
+  }
+  if (overrides.definitions !== null) {
+    zip.file('cards_description.json', JSON.stringify(overrides.definitions ?? [VALID_DEF]));
+  }
+  if (overrides.noImg !== true) {
+    zip.folder('img');
+  }
+  if (overrides.manifest !== null) {
+    zip.file('manifest.json', JSON.stringify(overrides.manifest ?? VALID_MANIFEST));
+  }
+  if (overrides.meta) {
+    zip.file('meta.json', JSON.stringify(overrides.meta));
+  }
+  if (overrides.fusionFormulas) {
+    zip.file('fusion_formulas.json', JSON.stringify(overrides.fusionFormulas));
+  }
+  if (overrides.opponents) {
+    for (const opp of overrides.opponents) {
+      zip.file(`opponents/opponent_deck_${opp.id}.json`, JSON.stringify(opp));
+    }
+  }
+  if (overrides.oppDescs) {
+    zip.file('opponents_description.json', JSON.stringify(overrides.oppDescs));
+  }
+  if (overrides.extraFiles) {
+    for (const [path, content] of Object.entries(overrides.extraFiles)) {
+      zip.file(path, content);
+    }
+  }
+  return zip.generateAsync({ type: 'arraybuffer' });
+}
+
+function clearGameStores() {
+  for (const key of Object.keys(CARD_DB)) delete CARD_DB[key];
+  FUSION_FORMULAS.length = 0;
+  OPPONENT_CONFIGS.length = 0;
+  for (const key of Object.keys(STARTER_DECKS)) delete STARTER_DECKS[key];
+}
+
+// ── Tests ───────────────────────────────────────────────────
+
+describe('loadTcgFile', () => {
+  beforeEach(() => {
+    clearGameStores();
+  });
+
+  it('loads a minimal valid archive', async () => {
+    const buf = await buildMinimalZip();
+    const result = await loadTcgFile(buf);
+    expect(result.cards).toHaveLength(1);
+    expect(result.cards[0].id).toBe(1);
+    expect(result.manifest?.formatVersion).toBe(2);
+    expect(CARD_DB['1']).toBeDefined();
+    expect(CARD_DB['1'].name).toBe('Test Card');
+  });
+
+  it('rejects archive with future formatVersion', async () => {
+    const buf = await buildMinimalZip({ manifest: { formatVersion: 999 } });
+    await expect(loadTcgFile(buf)).rejects.toThrow(TcgFormatError);
+    await expect(loadTcgFile(buf)).rejects.toThrow(/version mismatch/);
+  });
+
+  it('rejects archive missing cards.json', async () => {
+    const buf = await buildMinimalZip({ cards: null });
+    await expect(loadTcgFile(buf)).rejects.toThrow(TcgFormatError);
+    await expect(loadTcgFile(buf)).rejects.toThrow(/Invalid .tcg file/);
+  });
+
+  it('rejects corrupt ZIP data', async () => {
+    const garbage = new ArrayBuffer(100);
+    await expect(loadTcgFile(garbage)).rejects.toThrow(TcgFormatError);
+  });
+
+  it('loads equipment card with atkBonus, defBonus, and equipRequirement', async () => {
+    const equipCard = {
+      id: 10, type: 5, level: 1, rarity: 4,
+      atkBonus: 500, defBonus: 200,
+      equipReqRace: 1, equipReqAttr: 3,
+    };
+    const equipDef = { id: 10, name: 'Dragon Blade', description: 'Equip to a Dragon' };
+    const buf = await buildMinimalZip({
+      cards: [VALID_CARD, equipCard],
+      definitions: [VALID_DEF, equipDef],
+    });
+    const result = await loadTcgFile(buf);
+    expect(result.cards).toHaveLength(2);
+    const card = CARD_DB['10'];
+    expect(card).toBeDefined();
+    expect(card.atkBonus).toBe(500);
+    expect(card.defBonus).toBe(200);
+    expect(card.equipRequirement).toBeDefined();
+    expect(card.equipRequirement.race).toBe(1); // Dragon
+    expect(card.equipRequirement.attr).toBe(3); // Fire
+  });
+
+  it('rejects archive with invalid effect syntax in cards.json', async () => {
+    const effectCard = { ...VALID_CARD, id: 2, effect: 'invalid_effect_string' };
+    const effectDef = { id: 2, name: 'Bad Effect', description: 'Has invalid effect' };
+    const buf = await buildMinimalZip({
+      cards: [VALID_CARD, effectCard],
+      definitions: [VALID_DEF, effectDef],
+    });
+    // Validator rejects invalid effect syntax at the archive level
+    await expect(loadTcgFile(buf)).rejects.toThrow(TcgFormatError);
+  });
+
+  it('loads fusion formulas and validates them', async () => {
+    const formulas = {
+      formulas: [
+        { id: 'dragon_warrior', comboType: 'race+race', operand1: 1, operand2: 3, priority: 10, resultPool: [50] },
+      ],
+    };
+    const buf = await buildMinimalZip({ fusionFormulas: formulas });
+    const result = await loadTcgFile(buf);
+    expect(FUSION_FORMULAS).toHaveLength(1);
+    expect(FUSION_FORMULAS[0].id).toBe('dragon_warrior');
+    expect(FUSION_FORMULAS[0].resultPool).toEqual(['50']);
+  });
+
+  it('warns on malformed fusion_formulas.json', async () => {
+    const buf = await buildMinimalZip({
+      extraFiles: { 'fusion_formulas.json': 'not json' },
+    });
+    const result = await loadTcgFile(buf);
+    expect(result.warnings.some(w => w.includes('fusion_formulas.json'))).toBe(true);
+  });
+
+  it('loads opponents from opponents/ folder', async () => {
+    const opp = {
+      id: 1, name: 'Test Opp', title: 'Tester', race: 3,
+      flavor: 'A test opponent', coinsWin: 100, coinsLoss: 20,
+      deckIds: [1, 1, 1], behavior: 'default',
+    };
+    const meta = { starterDecks: { '1': [1, 1, 1] } };
+    const buf = await buildMinimalZip({ opponents: [opp], meta });
+    const result = await loadTcgFile(buf);
+    expect(OPPONENT_CONFIGS).toHaveLength(1);
+    expect(OPPONENT_CONFIGS[0].name).toBe('Test Opp');
+  });
+
+  it('warns on malformed meta.json but continues loading', async () => {
+    const buf = await buildMinimalZip({
+      extraFiles: { 'meta.json': 'not json' },
+    });
+    const result = await loadTcgFile(buf);
+    expect(result.warnings.some(w => w.includes('meta.json'))).toBe(true);
+    // Cards should still load
+    expect(CARD_DB['1']).toBeDefined();
+  });
+
+  it('loads with missing manifest (backward compat)', async () => {
+    const buf = await buildMinimalZip({ manifest: null });
+    // Removing manifest triggers a warning but archive should still load
+    // (provided cards_description and img/ are present)
+    // Actually manifest: null means we don't add it — validator warns but doesn't error
+    const result = await loadTcgFile(buf);
+    expect(result.manifest).toBeUndefined();
+    expect(result.warnings.some(w => w.includes('manifest'))).toBe(true);
+  });
+});
+
+describe('revokeTcgImages', () => {
+  it('calls revokeObjectURL for each image', () => {
+    const original = URL.revokeObjectURL;
+    const revoked = [];
+    URL.revokeObjectURL = (url) => revoked.push(url);
+    try {
+      const images = new Map([[1, 'blob:1'], [2, 'blob:2'], [3, 'blob:3']]);
+      revokeTcgImages(images);
+      expect(revoked).toEqual(['blob:1', 'blob:2', 'blob:3']);
+    } finally {
+      URL.revokeObjectURL = original;
+    }
+  });
+});

--- a/tests/tcg-validator.test.js
+++ b/tests/tcg-validator.test.js
@@ -1,0 +1,260 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import JSZip from 'jszip';
+import { validateTcgArchive, validateFusionFormulasJson, validateOpponentDeck } from '../js/tcg-format/index.js';
+
+// ── Helpers ────────────────────────────────────────────────────
+
+/** Build a minimal valid .tcg ZIP archive for testing. */
+function buildMinimalZip() {
+  const zip = new JSZip();
+  zip.file('cards.json', JSON.stringify([
+    { id: 1, type: 1, level: 3, rarity: 1, atk: 1000, def: 800, attribute: 3, race: 1 },
+  ]));
+  zip.file('cards_description.json', JSON.stringify([
+    { id: 1, name: 'Test Card', description: 'A test card' },
+  ]));
+  zip.folder('img');
+  zip.file('manifest.json', JSON.stringify({ formatVersion: 2 }));
+  return zip;
+}
+
+// ── validateTcgArchive ─────────────────────────────────────────
+
+describe('validateTcgArchive', () => {
+  it('accepts a valid minimal archive', async () => {
+    const zip = buildMinimalZip();
+    const result = await validateTcgArchive(zip);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('rejects missing cards.json', async () => {
+    const zip = buildMinimalZip();
+    zip.remove('cards.json');
+    const result = await validateTcgArchive(zip);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('cards.json'))).toBe(true);
+  });
+
+  it('rejects missing cards_description.json', async () => {
+    const zip = buildMinimalZip();
+    zip.remove('cards_description.json');
+    const result = await validateTcgArchive(zip);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('cards_description'))).toBe(true);
+  });
+
+  it('rejects missing img/ folder', async () => {
+    const zip = new JSZip();
+    zip.file('cards.json', JSON.stringify([
+      { id: 1, type: 1, level: 3, rarity: 1, atk: 1000, def: 800, attribute: 3, race: 1 },
+    ]));
+    zip.file('cards_description.json', JSON.stringify([
+      { id: 1, name: 'Test Card', description: 'A test card' },
+    ]));
+    zip.file('manifest.json', JSON.stringify({ formatVersion: 2 }));
+    const result = await validateTcgArchive(zip);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('img/'))).toBe(true);
+  });
+
+  it('rejects card without matching definition', async () => {
+    const zip = buildMinimalZip();
+    // Add a second card with no definition
+    zip.file('cards.json', JSON.stringify([
+      { id: 1, type: 1, level: 3, rarity: 1, atk: 1000, def: 800, attribute: 3, race: 1 },
+      { id: 2, type: 1, level: 4, rarity: 1, atk: 1200, def: 900, attribute: 1, race: 2 },
+    ]));
+    const result = await validateTcgArchive(zip);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('2'))).toBe(true);
+  });
+
+  it('warns on orphan definition (definition with no matching card)', async () => {
+    const zip = buildMinimalZip();
+    zip.file('cards_description.json', JSON.stringify([
+      { id: 1, name: 'Test Card', description: 'A test card' },
+      { id: 99, name: 'Orphan Card', description: 'No matching card entry' },
+    ]));
+    const result = await validateTcgArchive(zip);
+    expect(result.valid).toBe(true);
+    expect(result.warnings.some(w => w.includes('99'))).toBe(true);
+  });
+
+  it('rejects invalid manifest.json (formatVersion: 0)', async () => {
+    const zip = buildMinimalZip();
+    zip.file('manifest.json', JSON.stringify({ formatVersion: 0 }));
+    const result = await validateTcgArchive(zip);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.includes('formatVersion'))).toBe(true);
+  });
+
+  it('warns when manifest.json is missing', async () => {
+    const zip = buildMinimalZip();
+    zip.remove('manifest.json');
+    const result = await validateTcgArchive(zip);
+    expect(result.valid).toBe(true);
+    expect(result.warnings.some(w => w.includes('manifest'))).toBe(true);
+  });
+
+  it('rejects invalid card in cards.json (negative id)', async () => {
+    const zip = buildMinimalZip();
+    zip.file('cards.json', JSON.stringify([
+      { id: -1, type: 1, level: 3, rarity: 1, atk: 1000, def: 800, attribute: 3, race: 1 },
+    ]));
+    const result = await validateTcgArchive(zip);
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects malformed JSON in cards.json', async () => {
+    const zip = buildMinimalZip();
+    zip.file('cards.json', '{ not valid json }}}');
+    const result = await validateTcgArchive(zip);
+    expect(result.valid).toBe(false);
+  });
+});
+
+// ── validateFusionFormulasJson ──────────────────────────────────
+
+describe('validateFusionFormulasJson', () => {
+  /** Build a minimal valid fusion formulas object. */
+  function validFormulas() {
+    return {
+      formulas: [
+        { id: 'f1', comboType: 'race+race', operand1: 1, operand2: 2, priority: 10, resultPool: [5] },
+      ],
+    };
+  }
+
+  it('returns no warnings for valid formulas', () => {
+    const warnings = validateFusionFormulasJson(validFormulas());
+    expect(warnings).toHaveLength(0);
+  });
+
+  it('warns when root is not an object', () => {
+    const warnings = validateFusionFormulasJson([1, 2, 3]);
+    expect(warnings.some(w => w.includes('JSON object'))).toBe(true);
+  });
+
+  it('warns when formulas array is missing', () => {
+    const warnings = validateFusionFormulasJson({ notFormulas: true });
+    expect(warnings.some(w => w.includes('formulas'))).toBe(true);
+  });
+
+  it('warns when a formula is missing id', () => {
+    const data = validFormulas();
+    delete data.formulas[0].id;
+    const warnings = validateFusionFormulasJson(data);
+    expect(warnings.some(w => w.includes('id'))).toBe(true);
+  });
+
+  it('warns when a formula has invalid comboType', () => {
+    const data = validFormulas();
+    data.formulas[0].comboType = 'invalid_combo';
+    const warnings = validateFusionFormulasJson(data);
+    expect(warnings.some(w => w.includes('comboType'))).toBe(true);
+  });
+
+  it('warns when a formula is missing operand1', () => {
+    const data = validFormulas();
+    delete data.formulas[0].operand1;
+    const warnings = validateFusionFormulasJson(data);
+    expect(warnings.some(w => w.includes('operand1'))).toBe(true);
+  });
+
+  it('warns when resultPool is empty', () => {
+    const data = validFormulas();
+    data.formulas[0].resultPool = [];
+    const warnings = validateFusionFormulasJson(data);
+    expect(warnings.some(w => w.includes('resultPool'))).toBe(true);
+  });
+
+  it('warns on duplicate formula id', () => {
+    const data = {
+      formulas: [
+        { id: 'dup', comboType: 'race+race', operand1: 1, operand2: 2, priority: 10, resultPool: [5] },
+        { id: 'dup', comboType: 'race+attr', operand1: 3, operand2: 4, priority: 5, resultPool: [6] },
+      ],
+    };
+    const warnings = validateFusionFormulasJson(data);
+    expect(warnings.some(w => w.includes('duplicate'))).toBe(true);
+  });
+
+  it('warns when resultPool contains non-positive entry', () => {
+    const data = validFormulas();
+    data.formulas[0].resultPool = [0];
+    const warnings = validateFusionFormulasJson(data);
+    expect(warnings.some(w => w.includes('resultPool'))).toBe(true);
+  });
+});
+
+// ── validateOpponentDeck ───────────────────────────────────────
+
+describe('validateOpponentDeck', () => {
+  /** Build a minimal valid opponent deck object. */
+  function validOpponent() {
+    return {
+      id: 1,
+      name: 'Test Opponent',
+      title: 'The Tester',
+      race: 1,
+      coinsWin: 100,
+      coinsLoss: 10,
+      deckIds: [1, 2, 3],
+    };
+  }
+
+  it('returns no warnings for a valid opponent', () => {
+    const warnings = validateOpponentDeck(validOpponent(), 0);
+    expect(warnings).toHaveLength(0);
+  });
+
+  it('warns when id is missing', () => {
+    const opp = validOpponent();
+    delete opp.id;
+    const warnings = validateOpponentDeck(opp, 0);
+    expect(warnings.some(w => w.includes('id'))).toBe(true);
+  });
+
+  it('warns when name is missing', () => {
+    const opp = validOpponent();
+    opp.name = '';
+    const warnings = validateOpponentDeck(opp, 0);
+    expect(warnings.some(w => w.includes('name'))).toBe(true);
+  });
+
+  it('warns when race is invalid (13)', () => {
+    const opp = validOpponent();
+    opp.race = 13;
+    const warnings = validateOpponentDeck(opp, 0);
+    expect(warnings.some(w => w.includes('race'))).toBe(true);
+  });
+
+  it('warns when coinsWin is negative', () => {
+    const opp = validOpponent();
+    opp.coinsWin = -5;
+    const warnings = validateOpponentDeck(opp, 0);
+    expect(warnings.some(w => w.includes('coinsWin'))).toBe(true);
+  });
+
+  it('warns when deckIds is empty', () => {
+    const opp = validOpponent();
+    opp.deckIds = [];
+    const warnings = validateOpponentDeck(opp, 0);
+    expect(warnings.some(w => w.includes('deckIds'))).toBe(true);
+  });
+
+  it('warns about unknown card ID in deckIds when knownCardIds provided', () => {
+    const opp = validOpponent();
+    opp.deckIds = [1, 999];
+    const knownCardIds = new Set([1, 2, 3]);
+    const warnings = validateOpponentDeck(opp, 0, knownCardIds);
+    expect(warnings.some(w => w.includes('unknown card') || w.includes('unknown card ID'))).toBe(true);
+  });
+
+  it('warns when data is not an object', () => {
+    const warnings = validateOpponentDeck('not an object', 0);
+    expect(warnings.some(w => w.includes('must be an object'))).toBe(true);
+  });
+});


### PR DESCRIPTION
- Fix broken version check (was reading meta.version instead of manifest.formatVersion)
- Fix equipment card round-trip: serialize atkBonus/defBonus/equipReq* in builder,
  use intToRace/intToAttribute instead of unsafe casts in loader
- Remove `as any` casts in tcg-builder for spellType/trapTrigger
- Fix buildManifest default formatVersion from 1 to 2
- Add TcgNetworkError and TcgFormatError error classes for better error distinction
- Extract getBrowserLang() helper to eliminate duplicate language detection
- DRY metadata loading with generic loadMetadataFile() helper
- Add contextual warnings (card ID, file path) to loader error messages
- Add validateFusionFormulasJson() for fusion_formulas.json validation
- Add validateOpponentDeck() for per-opponent deck validation
- Update docs: fix race enum table (was wrong), add Equipment type, add field
  spell type, add equipment fields, update actions table, add fusion_formulas
  section, document CardFilter syntax
- Add comprehensive test suites: tcg-loader (12 tests), tcg-validator (27 tests),
  equipment builder tests (3 tests)

https://claude.ai/code/session_012WNuk3Eu232teb27agjxUd