### PR TITLE
feat(campaign): hide locked nodes, chapters, and opponents instead of disabling them

### DIFF
--- a/js/campaign-types.ts
+++ b/js/campaign-types.ts
@@ -18,6 +18,7 @@ export interface CampaignNode {
   opponentId?: number;        // for duel nodes
   completeOnLoss?: boolean;   // node completes even on defeat (e.g. scripted loss)
   gauntlet?: number[];        // ordered opponent IDs for back-to-back duels (no saving between)
+  alwaysVisible?: boolean;    // if true, node is shown on the map even when locked (default: false = hidden when locked)
   position: { x: number; y: number };  // for map rendering
   unlockCondition: UnlockCondition | null;  // null = always unlocked (start node)
   rewards?: NodeRewards;

--- a/js/react/screens/CampaignScreen.tsx
+++ b/js/react/screens/CampaignScreen.tsx
@@ -43,10 +43,10 @@ export default function CampaignScreen() {
   const PADDING_BOTTOM = 50; // px bottom padding
 
   const { nodePositions, mapHeight } = useMemo(() => {
-    if (!activeChapter) return { nodePositions: new Map<string, { leftPct: number; topPx: number }>(), mapHeight: 300 };
+    if (visibleNodes.length === 0) return { nodePositions: new Map<string, { leftPct: number; topPx: number }>(), mapHeight: 300 };
 
     let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
-    for (const node of activeChapter.nodes) {
+    for (const node of visibleNodes) {
       if (node.position.x < minX) minX = node.position.x;
       if (node.position.x > maxX) maxX = node.position.x;
       if (node.position.y < minY) minY = node.position.y;
@@ -57,7 +57,7 @@ export default function CampaignScreen() {
     const rangeY = maxY - minY;
 
     const positions = new Map<string, { leftPct: number; topPx: number }>();
-    for (const node of activeChapter.nodes) {
+    for (const node of visibleNodes) {
       const leftPct = rangeX === 0
         ? 50
         : PADDING_X + ((node.position.x - minX) / rangeX) * (100 - 2 * PADDING_X);
@@ -69,13 +69,23 @@ export default function CampaignScreen() {
 
     const maxTop = Math.max(...Array.from(positions.values()).map(p => p.topPx));
     return { nodePositions: positions, mapHeight: maxTop + PADDING_BOTTOM };
-  }, [activeChapter]);
+  }, [visibleNodes]);
 
   function getNodeState(node: CampaignNode): 'completed' | 'available' | 'locked' {
     if (progress.completedNodes.includes(node.id)) return 'completed';
     if (isNodeUnlocked(node.id)) return 'available';
     return 'locked';
   }
+
+  // Only show nodes that are available/completed, or locked but marked alwaysVisible
+  const visibleNodes = useMemo(() => {
+    if (!activeChapter) return [];
+    return activeChapter.nodes.filter(node => {
+      const state = getNodeState(node);
+      if (state !== 'locked') return true;
+      return node.alwaysVisible === true;
+    });
+  }, [activeChapter, progress.completedNodes]);
 
   function handleNodeClick(node: CampaignNode) {
     const state = getNodeState(node);
@@ -142,14 +152,16 @@ export default function CampaignScreen() {
     setDialogueNode(null);
   }
 
-  // Build connection lines from node.connections
+  // Build connection lines between visible nodes only
   const connections = useMemo(() => {
     if (!activeChapter) return [];
+    const visibleSet = new Set(visibleNodes.map(n => n.id));
     const nodeMap = new Map(activeChapter.nodes.map(n => [n.id, n]));
     const lines: Array<{ from: CampaignNode; to: CampaignNode; completed: boolean }> = [];
-    for (const node of activeChapter.nodes) {
+    for (const node of visibleNodes) {
       if (node.connections) {
         for (const targetId of node.connections) {
+          if (!visibleSet.has(targetId)) continue;
           const target = nodeMap.get(targetId);
           if (target) {
             const completed = progress.completedNodes.includes(node.id) && progress.completedNodes.includes(targetId);
@@ -159,7 +171,7 @@ export default function CampaignScreen() {
       }
     }
     return lines;
-  }, [activeChapter, progress.completedNodes]);
+  }, [activeChapter, visibleNodes, progress.completedNodes]);
 
   if (!activeChapter) {
     return (
@@ -190,16 +202,22 @@ export default function CampaignScreen() {
               if (chapterUnlocked[idx]) setActiveChapterIdx(idx);
             }}
           >
-            {chapters.map((ch, idx) => (
-              <option key={ch.id} value={idx} disabled={!chapterUnlocked[idx]}>
-                {t(`campaign.chapter_${ch.id}`, ch.id)}{!chapterUnlocked[idx] ? ` 🔒` : ''}
-              </option>
-            ))}
+            {chapters.map((ch, idx) => {
+              if (!chapterUnlocked[idx]) return null;
+              return (
+                <option key={ch.id} value={idx}>
+                  {t(`campaign.chapter_${ch.id}`, ch.id)}
+                </option>
+              );
+            })}
           </select>
         </div>
       )}
 
       <div className={styles.mapContainer}>
+        {visibleNodes.length === 0 && (
+          <p style={{ color: '#6080a0', textAlign: 'center', marginTop: 40 }}>{t('campaign.no_missions')}</p>
+        )}
         <div className={styles.mapInner} style={{ height: mapHeight }}>
           {/* Connection lines (SVG overlay) */}
           <svg
@@ -224,7 +242,7 @@ export default function CampaignScreen() {
           </svg>
 
           {/* Nodes */}
-          {activeChapter.nodes.map(node => {
+          {visibleNodes.map(node => {
             const state = getNodeState(node);
             const pos = nodePositions.get(node.id);
             if (!pos) return null;

--- a/js/react/screens/OpponentScreen.module.css
+++ b/js/react/screens/OpponentScreen.module.css
@@ -65,14 +65,8 @@
   cursor: pointer;
 }
 
-.tile:not(.locked):hover {
+.tile:hover {
   border-color: #c8a84b;
-}
-
-.tile.locked {
-  cursor: default;
-  opacity: 0.55;
-  filter: grayscale(60%);
 }
 
 .frame {
@@ -96,16 +90,6 @@
 .symbol {
   font-size: clamp(1.4rem, 4vw, 2.2rem);
   opacity: 0.9;
-}
-
-.lockedOverlay {
-  position: absolute;
-  inset: 0;
-  background: #000000;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 1.6rem;
 }
 
 .name {

--- a/js/react/screens/OpponentScreen.tsx
+++ b/js/react/screens/OpponentScreen.tsx
@@ -44,33 +44,32 @@ export default function OpponentScreen() {
       </div>
 
       <div className={styles.grid}>
-        {(OPPONENT_CONFIGS as OpponentConfig[]).map(cfg => {
-          const oppData = opponents[cfg.id] || { unlocked: cfg.id === 1, wins: 0, losses: 0 };
-          const isAvailable = beatenInCampaign.has(cfg.id);
+        {(OPPONENT_CONFIGS as OpponentConfig[]).filter(cfg => beatenInCampaign.has(cfg.id)).map(cfg => {
+          const oppData = opponents[cfg.id] || { wins: 0, losses: 0 };
           const raceMeta = getRaceById(cfg.race);
           const accent = raceMeta?.color ?? '#888';
 
           return (
             <div
               key={cfg.id}
-              className={`${styles.tile}${isAvailable ? '' : ` ${styles.locked}`}`}
-              onClick={() => isAvailable && selectOpponent(cfg)}
-              onMouseEnter={() => isAvailable && setHovered(cfg)}
+              className={styles.tile}
+              onClick={() => selectOpponent(cfg)}
+              onMouseEnter={() => setHovered(cfg)}
               onMouseLeave={() => setHovered(null)}
             >
               <div className={styles.frame} style={{ borderColor: accent }}>
                 <div className={styles.art} style={{ background: `linear-gradient(135deg,${accent}44,#111830)` }}>
                   <div className={styles.symbol}>{raceMeta?.icon ?? '?'}</div>
                 </div>
-                {!isAvailable && <div className={styles.lockedOverlay}>🔒</div>}
               </div>
-              <div className={styles.name}>{isAvailable ? cfg.name : '???'}</div>
-              {isAvailable && (
-                <div className={styles.record}>{(oppData as any).wins ?? 0}W / {(oppData as any).losses ?? 0}L</div>
-              )}
+              <div className={styles.name}>{cfg.name}</div>
+              <div className={styles.record}>{(oppData as any).wins ?? 0}W / {(oppData as any).losses ?? 0}L</div>
             </div>
           );
         })}
+        {beatenInCampaign.size === 0 && (
+          <p style={{ color: '#6080a0', gridColumn: '1 / -1', textAlign: 'center', marginTop: 20 }}>{t('opponent.none_unlocked')}</p>
+        )}
       </div>
 
       <div className={styles.info}>

--- a/locales/de.json
+++ b/locales/de.json
@@ -48,7 +48,8 @@
   "opponent": {
     "headline": "FREIES DUELL",
     "subtitle": "Wähle deinen Gegner",
-    "back": "← Zurück"
+    "back": "← Zurück",
+    "none_unlocked": "Noch keine Gegner freigeschaltet. Besiege sie zuerst in der Kampagne!"
   },
   "save": {
     "headline": "SPEICHERPUNKT",
@@ -268,6 +269,7 @@
     "completed": "Abgeschlossen",
     "available": "Verfügbar",
     "no_data": "Keine Kampagnendaten geladen.",
+    "no_missions": "Noch keine Missionen verfügbar.",
     "ch_han_court": "Der Kaiserliche Hof",
     "ch_tournament": "Neo-Shanghai Turnier",
     "ch_return": "Rückkehr in die Vergangenheit",

--- a/locales/en.json
+++ b/locales/en.json
@@ -48,7 +48,8 @@
   "opponent": {
     "headline": "FREE DUEL",
     "subtitle": "Choose your opponent",
-    "back": "← Back"
+    "back": "← Back",
+    "none_unlocked": "No opponents unlocked yet. Beat them in the campaign first!"
   },
   "save": {
     "headline": "SAVE POINT",
@@ -268,6 +269,7 @@
     "completed": "Completed",
     "available": "Available",
     "no_data": "No campaign data loaded.",
+    "no_missions": "No missions available yet.",
     "ch_han_court": "The Imperial Court",
     "ch_tournament": "Neo-Shanghai Tournament",
     "ch_return": "Return to the Past",


### PR DESCRIPTION
Only show available/completed campaign nodes and unlocked chapters.
Free duel screen only shows opponents beaten in campaign.
Added `alwaysVisible` field to CampaignNode for opt-in visibility of locked nodes (e.g. boss teasers).

https://claude.ai/code/session_01DAni5UN5tUmw2D5LWGREcH