### PR TITLE
Refactor Shop screen to carousel layout with tab navigation

### DIFF
--- a/css/progression.css
+++ b/css/progression.css
@@ -13,6 +13,7 @@
   margin: 10px 0;
   border-radius: 0;
   box-shadow: none;
+  font-family: var(--font-stats);
 }
 
 .result-coins::before {

--- a/js/react/contexts/ScreenContext.tsx
+++ b/js/react/contexts/ScreenContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useRef, useEffect } from 'react';
+import { createContext, useContext, useState, useRef, useEffect, useCallback } from 'react';
 import { gsap } from 'gsap';
 import { Audio } from '../../audio.js';
 
@@ -22,9 +22,10 @@ interface ScreenCtx {
   screenData: Record<string, unknown> | null;
   setScreen: (s: Screen) => void;
   navigateTo: (s: Screen, data?: Record<string, unknown>) => void;
+  navigateBack: () => void;
 }
 
-const ScreenContext = createContext<ScreenCtx>({ screen: 'press-start', screenData: null, setScreen: () => {}, navigateTo: () => {} });
+const ScreenContext = createContext<ScreenCtx>({ screen: 'press-start', screenData: null, setScreen: () => {}, navigateTo: () => {}, navigateBack: () => {} });
 
 const SCREEN_MUSIC: Partial<Record<Screen, string>> = {
   'press-start':  'music_title',
@@ -41,16 +42,33 @@ const SCREEN_MUSIC: Partial<Record<Screen, string>> = {
   // duel-result music is set explicitly by GameContext before navigating
 };
 
+/** Fallback back-navigation map when history stack is empty */
+const BACK_MAP: Partial<Record<Screen, Screen>> = {
+  shop:           'save-point',
+  collection:     'save-point',
+  deckbuilder:    'save-point',
+  opponent:       'save-point',
+  campaign:       'save-point',
+  'pack-opening': 'shop',
+  'save-point':   'title',
+};
+
+/** Screens where back navigation should be blocked */
+const NO_BACK: Set<Screen> = new Set(['press-start', 'title', 'game', 'starter']);
+
 export function ScreenProvider({ children }: { children: React.ReactNode }) {
   const [screen, setScreen] = useState<Screen>('press-start');
   const [screenData, setScreenData] = useState<Record<string, unknown> | null>(null);
-  // Track the active transition tween to kill it on rapid re-navigation
   const transitionRef = useRef<gsap.core.Tween | null>(null);
+  const historyRef = useRef<Screen[]>([]);
+  // Flag to suppress pushState during popstate-driven navigation
+  const isPopNavRef = useRef(false);
+  const screenRef = useRef<Screen>(screen);
+  screenRef.current = screen;
 
-  function navigateTo(s: Screen, data?: Record<string, unknown>) {
+  function doTransition(s: Screen, data?: Record<string, unknown>) {
     const overlay = document.getElementById('screen-transition-overlay');
     if (!overlay) { setScreenData(data ?? null); setScreen(s); playScreenMusic(s); return; }
-    // Kill any in-flight transition to prevent stacking
     if (transitionRef.current) { transitionRef.current.kill(); gsap.set(overlay, { opacity: 0 }); }
     transitionRef.current = gsap.to(overlay, {
       opacity: 1, duration: 0.18, ease: 'none',
@@ -63,17 +81,60 @@ export function ScreenProvider({ children }: { children: React.ReactNode }) {
     });
   }
 
+  function navigateTo(s: Screen, data?: Record<string, unknown>) {
+    // Push current screen onto history stack
+    historyRef.current.push(screenRef.current);
+    if (!isPopNavRef.current) {
+      try { window.history.pushState({ screen: s }, ''); } catch { /* ignored */ }
+    }
+    doTransition(s, data);
+  }
+
+  const navigateBack = useCallback(() => {
+    if (NO_BACK.has(screenRef.current)) return;
+    const prev = historyRef.current.pop() ?? BACK_MAP[screenRef.current];
+    if (!prev) return;
+    if (!isPopNavRef.current) {
+      try { window.history.back(); } catch { /* ignored */ }
+      // The actual navigation will happen via the popstate handler
+      // But we set a flag so the popstate handler knows to use this prev
+    }
+    doTransition(prev);
+  }, []);
+
   function playScreenMusic(s: Screen) {
     const track = SCREEN_MUSIC[s];
     if (track) Audio.playMusic(track);
   }
 
-  // Start music for the initial screen once audio context is ready
+  // Initial music + history state
   useEffect(() => {
     playScreenMusic(screen);
+    try { window.history.replaceState({ screen }, ''); } catch { /* ignored */ }
   }, []);
 
-  return <ScreenContext.Provider value={{ screen, screenData, setScreen, navigateTo }}>{children}</ScreenContext.Provider>;
+  // Listen for browser/mobile back button
+  useEffect(() => {
+    function handlePopstate() {
+      if (NO_BACK.has(screenRef.current)) {
+        // Re-push to prevent leaving the app
+        try { window.history.pushState({ screen: screenRef.current }, ''); } catch { /* ignored */ }
+        return;
+      }
+      const prev = historyRef.current.pop() ?? BACK_MAP[screenRef.current];
+      if (!prev) {
+        try { window.history.pushState({ screen: screenRef.current }, ''); } catch { /* ignored */ }
+        return;
+      }
+      isPopNavRef.current = true;
+      doTransition(prev);
+      isPopNavRef.current = false;
+    }
+    window.addEventListener('popstate', handlePopstate);
+    return () => window.removeEventListener('popstate', handlePopstate);
+  }, []);
+
+  return <ScreenContext.Provider value={{ screen, screenData, setScreen, navigateTo, navigateBack }}>{children}</ScreenContext.Provider>;
 }
 
 export function useScreen() { return useContext(ScreenContext); }

--- a/js/react/screens/SavePointScreen.module.css
+++ b/js/react/screens/SavePointScreen.module.css
@@ -33,7 +33,7 @@
   font-size: 0.875rem; color: var(--gold-light); letter-spacing: 1px;
 }
 
-.coinsValue { font-weight: bold; font-size: 1rem; }
+.coinsValue { font-weight: bold; font-size: 1rem; font-family: var(--font-stats); }
 
 .backupWarning {
   font-size: 0.75rem; letter-spacing: 1px;

--- a/js/react/screens/ShopScreen.module.css
+++ b/js/react/screens/ShopScreen.module.css
@@ -26,7 +26,7 @@
   justify-content: space-between;
   width: 100%;
   max-width: 900px;
-  margin-bottom: 24px;
+  margin-bottom: 16px;
   flex-wrap: wrap;
   gap: 10px;
   position: relative;
@@ -47,23 +47,129 @@
   gap: 6px;
   color: #c8a84b;
   font-size: 1rem;
+  font-family: var(--font-stats);
+}
+
+.coinsValue {
+  font-weight: bold;
 }
 
 .backBtn { font-size: 0.85rem; }
 
-.grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 14px;
+/* ── Tabs ── */
+
+.tabs {
+  display: flex;
+  gap: 0;
   max-width: 900px;
   width: 100%;
+  margin-bottom: 18px;
   position: relative;
   z-index: 1;
 }
 
-@media (min-width: 700px) {
-  .grid { grid-template-columns: repeat(4, 1fr); }
+.tabBtn {
+  flex: 1;
+  background: #111828;
+  color: var(--text-dim);
+  padding: 8px 14px;
+  border: 2px solid #334;
+  border-radius: 0;
+  font-size: 0.85rem;
+  cursor: pointer;
+  letter-spacing: 1px;
+  transition: color 0.15s, background 0.15s;
 }
+
+.tabBtn:first-child { border-right: none; }
+
+.tabBtn:hover { color: var(--gold); }
+
+.tabBtn.activeTab {
+  background: #1a2840;
+  color: #c8a84b;
+  border-color: #c8a84b;
+}
+
+/* ── Carousel ── */
+
+.carousel {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  max-width: 900px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  min-height: 0;
+}
+
+.carouselTrack {
+  display: flex;
+  gap: 14px;
+  flex: 1;
+  justify-content: center;
+  min-height: 0;
+}
+
+.arrowBtn {
+  flex-shrink: 0;
+  width: 36px;
+  height: 36px;
+  background: #111828;
+  border: 2px solid #334;
+  border-radius: 0;
+  color: #c8a84b;
+  font-size: 1.4rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s, color 0.15s;
+  z-index: 2;
+}
+
+.arrowBtn:hover:not(:disabled) {
+  background: #1a2840;
+  color: #f0d080;
+}
+
+.arrowBtn:disabled {
+  opacity: 0.25;
+  cursor: not-allowed;
+}
+
+/* ── Dots ── */
+
+.dots {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  margin-top: 14px;
+  position: relative;
+  z-index: 1;
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: 1px solid #556;
+  background: #334;
+  cursor: pointer;
+  padding: 0;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+.dot:hover { border-color: #c8a84b; }
+
+.dotActive {
+  background: #c8a84b;
+  border-color: #c8a84b;
+}
+
+/* ── Pack Tile ── */
 
 .packTile {
   background: #111828;
@@ -77,6 +183,8 @@
   gap: 8px;
   position: relative;
   overflow: hidden;
+  width: 100%;
+  max-width: 280px;
 }
 
 .packTile::before {
@@ -101,7 +209,7 @@
 .packIcon { font-size: 2.5rem; position: relative; }
 .packName { font-size: 0.9rem; font-weight: bold; color: #c0d0e0; position: relative; }
 .packDesc { font-size: 0.72rem; color: #606880; position: relative; }
-.packPrice { font-size: 1rem; color: #c8a84b; font-weight: bold; position: relative; }
+.packPrice { font-size: 1rem; color: #c8a84b; font-weight: bold; position: relative; font-family: var(--font-stats); }
 
 .raceSelectWrap { width: 100%; position: relative; }
 
@@ -136,7 +244,13 @@
 
 .buyBtn:disabled { opacity: 0.4; cursor: not-allowed; }
 
-.msg { color: #e06040; font-size: 0.9rem; margin-top: 10px; min-height: 1.2em; }
+.packLocked {
+  font-size: 0.75rem;
+  color: #e06040;
+  position: relative;
+}
+
+/* ── Section title (kept for potential fallback) ── */
 
 .sectionTitle {
   font-size: clamp(1rem, 2.5vw, 1.4rem);
@@ -148,8 +262,4 @@
   width: 100%;
 }
 
-.packLocked {
-  font-size: 0.75rem;
-  color: #e06040;
-  position: relative;
-}
+.msg { color: #e06040; font-size: 0.9rem; margin-top: 10px; min-height: 1.2em; }

--- a/js/react/screens/ShopScreen.tsx
+++ b/js/react/screens/ShopScreen.tsx
@@ -1,3 +1,4 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useScreen }      from '../contexts/ScreenContext.js';
 import { useProgression } from '../contexts/ProgressionContext.js';
@@ -13,11 +14,61 @@ import { Race } from '../../types.js';
 import type { CardData } from '../../types.js';
 import styles from './ShopScreen.module.css';
 
+type Tab = 'standard' | 'packages';
+
+function useItemsPerPage() {
+  const [ipp, setIpp] = useState(() => window.matchMedia('(min-width: 700px)').matches ? 2 : 1);
+  useEffect(() => {
+    const mq = window.matchMedia('(min-width: 700px)');
+    const handler = (e: MediaQueryListEvent) => setIpp(e.matches ? 2 : 1);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+  return ipp;
+}
+
 export default function ShopScreen() {
   const { navigateTo } = useScreen();
   const { coins, refresh } = useProgression();
   const { progress } = useCampaign();
   const bgUrl = SHOP_DATA.backgrounds[progress.currentChapter] ?? SHOP_DATA.backgrounds['ch1'] ?? '';
+  const { t } = useTranslation();
+
+  const hasPackages = SHOP_DATA.packages.length > 0;
+  const [activeTab, setActiveTab] = useState<Tab>('standard');
+  const [page, setPage] = useState(0);
+  const itemsPerPage = useItemsPerPage();
+
+  // Touch swipe tracking
+  const touchStartX = useRef(0);
+  const touchStartY = useRef(0);
+
+  const packs = Object.values(PACK_TYPES);
+  const packages = SHOP_DATA.packages;
+  const items = activeTab === 'standard' ? packs : packages;
+  const totalPages = Math.ceil(items.length / itemsPerPage);
+
+  // Reset page when switching tabs or when items per page changes
+  useEffect(() => { setPage(0); }, [activeTab, itemsPerPage]);
+
+  const goPage = useCallback((p: number) => {
+    setPage(Math.max(0, Math.min(p, totalPages - 1)));
+  }, [totalPages]);
+
+  const onTouchStart = useCallback((e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0].clientX;
+    touchStartY.current = e.touches[0].clientY;
+  }, []);
+
+  const onTouchEnd = useCallback((e: React.TouchEvent) => {
+    const dx = e.changedTouches[0].clientX - touchStartX.current;
+    const dy = e.changedTouches[0].clientY - touchStartY.current;
+    // Only trigger swipe if horizontal movement > vertical and > 50px threshold
+    if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > 50) {
+      if (dx < 0) goPage(page + 1);
+      else goPage(page - 1);
+    }
+  }, [goPage, page]);
 
   function buyPackage(packageId: string) {
     const pkg = SHOP_DATA.packages.find(p => p.id === packageId);
@@ -43,43 +94,88 @@ export default function ShopScreen() {
     navigateTo('pack-opening', { cards, preOpen });
   }
 
-  const { t } = useTranslation();
+  // Slice items for current page
+  const startIdx = page * itemsPerPage;
+  const visibleItems = items.slice(startIdx, startIdx + itemsPerPage);
 
   return (
     <div className={styles.screen}>
       <div className={styles.shopBg} style={{ backgroundImage: `url(${bgUrl})` }} />
+
+      {/* Header */}
       <div className={styles.header}>
         <h2 className={styles.shopTitle}>{t('shop.title')}</h2>
         <div className={styles.coinsBar}>
           <span className="coins-icon">◈</span>
-          <span id="shop-coin-display">{coins.toLocaleString()}</span>
+          <span className={styles.coinsValue}>{coins.toLocaleString()}</span>
           <span className="coins-label">{t('common.coins')}</span>
         </div>
         <button className={`btn-secondary ${styles.backBtn}`} onClick={() => navigateTo('save-point')}>{t('shop.back')}</button>
       </div>
 
-      <div className={styles.grid}>
-        {Object.values(PACK_TYPES).map(pt => {
-          const affordable = coins >= pt.price;
-          return (
-            <PackTile key={pt.id} pt={pt} affordable={affordable} onBuy={buy} />
-          );
-        })}
+      {/* Tabs */}
+      {hasPackages && (
+        <div className={styles.tabs}>
+          <button
+            className={`${styles.tabBtn}${activeTab === 'standard' ? ` ${styles.activeTab}` : ''}`}
+            onClick={() => setActiveTab('standard')}
+          >{t('shop.tab_standard')}</button>
+          <button
+            className={`${styles.tabBtn}${activeTab === 'packages' ? ` ${styles.activeTab}` : ''}`}
+            onClick={() => setActiveTab('packages')}
+          >{t('shop.tab_packages')}</button>
+        </div>
+      )}
+
+      {/* Carousel */}
+      <div className={styles.carousel} onTouchStart={onTouchStart} onTouchEnd={onTouchEnd}>
+        {/* Arrow left */}
+        {totalPages > 1 && (
+          <button
+            className={`${styles.arrowBtn} ${styles.arrowLeft}`}
+            disabled={page === 0}
+            onClick={() => goPage(page - 1)}
+            aria-label="Previous"
+          >‹</button>
+        )}
+
+        <div className={styles.carouselTrack}>
+          {activeTab === 'standard'
+            ? (visibleItems as PackTypeInfo[]).map(pt => {
+                const affordable = coins >= pt.price;
+                return <PackTile key={pt.id} pt={pt} affordable={affordable} onBuy={buy} />;
+              })
+            : (visibleItems as PackageDef[]).map(pkg => {
+                const unlocked = isPackageUnlocked(pkg);
+                const affordable = coins >= pkg.price;
+                return <PackageTile key={pkg.id} pkg={pkg} unlocked={unlocked} affordable={affordable} onBuy={buyPackage} />;
+              })
+          }
+        </div>
+
+        {/* Arrow right */}
+        {totalPages > 1 && (
+          <button
+            className={`${styles.arrowBtn} ${styles.arrowRight}`}
+            disabled={page >= totalPages - 1}
+            onClick={() => goPage(page + 1)}
+            aria-label="Next"
+          >›</button>
+        )}
       </div>
 
-      {SHOP_DATA.packages.length > 0 && (
-        <>
-          <h3 className={styles.sectionTitle}>{t('shop.packages_title')}</h3>
-          <div className={styles.grid}>
-            {SHOP_DATA.packages.map(pkg => {
-              const unlocked = isPackageUnlocked(pkg);
-              const affordable = coins >= pkg.price;
-              return (
-                <PackageTile key={pkg.id} pkg={pkg} unlocked={unlocked} affordable={affordable} onBuy={buyPackage} />
-              );
-            })}
-          </div>
-        </>
+      {/* Dots */}
+      {totalPages > 1 && (
+        <div className={styles.dots}>
+          {Array.from({ length: totalPages }, (_, i) => (
+            <button
+              key={i}
+              className={`${styles.dot}${i === page ? ` ${styles.dotActive}` : ''}`}
+              onClick={() => goPage(i)}
+              aria-label={`Page ${i + 1}`}
+            />
+          ))}
+        </div>
       )}
     </div>
   );

--- a/js/react/utils/pack-logic.ts
+++ b/js/react/utils/pack-logic.ts
@@ -171,10 +171,8 @@ export function openPack(packType: string, race: Race | null = null): CardData[]
   const packDef = SHOP_DATA.packs.find(p => p.id === packType);
   if (!packDef) return [];
 
-  const starterRace = Progression.getStarterRace();
   const targetRace: Race | null =
-    packDef.filter === 'byRace' && packType === 'race'    ? race
-    : packDef.filter === 'byRace' && packType === 'starter' ? (starterRace != null ? Number(starterRace) as Race : race)
+    packDef.filter === 'byRace' ? race
     : null;
 
   const rarities = _expandSlots(packDef);

--- a/js/shop-data.ts
+++ b/js/shop-data.ts
@@ -94,17 +94,6 @@ export const SHOP_DATA: ShopData = {
   packages: [],
   packs: [
     {
-      id: 'starter',
-      name: 'Starter Pack',
-      desc: '9 cards \u00b7 One race \u00b7 C/U-heavy',
-      price: 200,
-      icon: '\u2726',
-      color: '#4080a0',
-      slots: STANDARD_SLOTS,
-      filter: 'byRace',
-      cardPool: { include: { maxAtk: 1500 } },
-    },
-    {
       id: 'race',
       name: 'Race Pack',
       desc: '9 cards \u00b7 Chosen race \u00b7 Standard',

--- a/locales/de.json
+++ b/locales/de.json
@@ -82,11 +82,11 @@
     "back": "← Zurück",
     "buy_btn": "Pack kaufen",
     "packages_title": "◈ Kartenpakete",
+    "tab_standard": "Standardpacks",
+    "tab_packages": "Kartenpakete",
     "locked": "🔒 Gesperrt"
   },
   "pack": {
-    "starter_name": "Starterpack",
-    "starter_desc": "9 Karten · Eine Rasse · C/U-lastig",
     "race_name": "Rassen-Pack",
     "race_desc": "9 Karten · Gewählte Rasse · Standard",
     "aether_name": "Jade-Pack",

--- a/locales/en.json
+++ b/locales/en.json
@@ -82,11 +82,11 @@
     "back": "← Back",
     "buy_btn": "Buy Pack",
     "packages_title": "◈ Card Packages",
+    "tab_standard": "Standard Packs",
+    "tab_packages": "Card Packages",
     "locked": "🔒 Locked"
   },
   "pack": {
-    "starter_name": "Starter Pack",
-    "starter_desc": "9 Cards · One Race · C/U-heavy",
     "race_name": "Race Pack",
     "race_desc": "9 Cards · Chosen Race · Standard",
     "aether_name": "Jade Pack",

--- a/public/base.tcg-src/shop.json
+++ b/public/base.tcg-src/shop.json
@@ -1,41 +1,6 @@
 {
   "packs": [
     {
-      "id": "starter",
-      "name": "Starter Pack",
-      "desc": "9 cards · One race · C/U-heavy",
-      "price": 200,
-      "icon": "✦",
-      "color": "#4080a0",
-      "slots": [
-        {
-          "count": 5,
-          "rarity": 1
-        },
-        {
-          "count": 2,
-          "rarity": 2
-        },
-        {
-          "count": 1,
-          "rarity": 4
-        },
-        {
-          "count": 1,
-          "pool": "guaranteed_rare_plus",
-          "distribution": {
-            "4": 0.75,
-            "6": 0.2,
-            "8": 0.05
-          }
-        }
-      ],
-      "filter": "byRace",
-      "cardPool": {
-        "include": { "maxAtk": 1500 }
-      }
-    },
-    {
       "id": "aether",
       "name": "Jade Pack",
       "desc": "9 cards · All races · Standard",

--- a/tests/pack-logic.test.js
+++ b/tests/pack-logic.test.js
@@ -26,7 +26,7 @@ function openMany(packType, count, race = null) {
 describe('PACK_TYPES', () => {
   it('contains the expected pack type keys', () => {
     expect(Object.keys(PACK_TYPES)).toEqual(
-      expect.arrayContaining(['starter', 'race', 'aether', 'rarity'])
+      expect.arrayContaining(['race', 'aether', 'rarity'])
     );
   });
 
@@ -44,8 +44,7 @@ describe('PACK_TYPES', () => {
     }
   });
 
-  it('pack prices are ordered: starter < aether < race < rarity', () => {
-    expect(PACK_TYPES.starter.price).toBeLessThan(PACK_TYPES.aether.price);
+  it('pack prices are ordered: aether < race < rarity', () => {
     expect(PACK_TYPES.aether.price).toBeLessThan(PACK_TYPES.race.price);
     expect(PACK_TYPES.race.price).toBeLessThan(PACK_TYPES.rarity.price);
   });
@@ -119,23 +118,6 @@ describe('openPack race filtering', () => {
     }
   });
 
-  it('starter pack uses the saved starter race from Progression', () => {
-    // Set a starter race in localStorage
-    Progression.markStarterChosen(String(Race.Dragon));
-    const cards = openMany('starter', 20);
-    for (const card of cards) {
-      if (card.race !== undefined) {
-        expect(card.race).toBe(Race.Dragon);
-      }
-    }
-  });
-
-  it('starter pack with no saved race and no explicit race returns all-race cards', () => {
-    // No starter race set, no race argument → targetRace is null
-    const cards = openPack('starter');
-    // Should still return 9 cards — no crash
-    expect(cards).toHaveLength(9);
-  });
 
   it('aether pack ignores race parameter and returns cards from any race', () => {
     const cards = openMany('aether', 20);
@@ -287,15 +269,6 @@ describe('openPack edge cases', () => {
     expect(unique.size).toBeGreaterThan(1);
   });
 
-  it('starter pack falls back to race argument when no saved starter race', () => {
-    // No starter race in localStorage; pass race explicitly
-    const cards = openMany('starter', 20, Race.Warrior);
-    for (const card of cards) {
-      if (card.race !== undefined) {
-        expect(card.race).toBe(Race.Warrior);
-      }
-    }
-  });
 });
 
 // ── _pickCard fallback behavior (tested indirectly) ───────


### PR DESCRIPTION
## Summary
Transforms the Shop screen from a static grid layout to a responsive carousel with tab-based navigation between standard packs and card packages. Adds touch swipe support and improves navigation history tracking across the app.

## Key Changes

### Shop Screen UI Refactor
- **Carousel Layout**: Replaced fixed grid with a paginated carousel supporting 1-2 items per page based on viewport width (responsive via `useItemsPerPage` hook)
- **Tab Navigation**: Added tabs to switch between "Standard Packs" and "Card Packages" when packages exist
- **Navigation Controls**: 
  - Arrow buttons (‹ ›) to navigate between pages
  - Dot indicators for page selection
  - Touch swipe detection (horizontal swipe > 50px threshold)
- **Removed Starter Pack**: Deleted the starter pack from shop data and all related logic

### Navigation System Enhancement
- **History Stack**: Implemented proper back-navigation with `historyRef` to track screen history
- **Browser Back Button**: Added `popstate` event listener to handle device/browser back button
- **Fallback Map**: Created `BACK_MAP` for default back navigation when history is empty
- **No-Back Screens**: Defined screens where back navigation is blocked (press-start, title, game, starter)
- **New `navigateBack` Function**: Exported from ScreenContext for programmatic back navigation

### Styling Updates
- **Carousel Styles**: Added `.carousel`, `.carouselTrack`, `.arrowBtn`, `.dots`, `.dot` classes
- **Tab Styles**: Added `.tabs`, `.tabBtn`, `.activeTab` classes with hover/active states
- **Typography**: Applied `var(--font-stats)` font family to coin displays and prices for consistency
- **Layout Adjustments**: Reduced header margin-bottom (24px → 16px), added pack tile max-width constraints

### Localization
- Added new translation keys: `shop.tab_standard` and `shop.tab_packages`
- Removed starter pack localization strings from en.json and de.json

### Test Updates
- Updated pack-logic tests to remove starter pack references
- Adjusted price ordering test (removed starter pack comparison)
- Removed starter pack-specific test cases

## Implementation Details
- `useItemsPerPage()` hook uses `window.matchMedia` to detect viewport changes and adjust items per page dynamically
- Touch swipe logic distinguishes between horizontal and vertical movement to avoid conflicts with vertical scrolling
- Page state resets when switching tabs or when items per page changes
- Arrow buttons are disabled at carousel boundaries
- History navigation gracefully falls back to `BACK_MAP` if history stack is empty

https://claude.ai/code/session_01KqyBsec1KBeAz7674ef9o9