### PR TITLE
Reorder functions in CampaignScreen for better code organization

### DIFF
--- a/js/react/screens/CampaignScreen.tsx
+++ b/js/react/screens/CampaignScreen.tsx
@@ -37,6 +37,22 @@ export default function CampaignScreen() {
     });
   }, [chapters, progress.completedNodes]);
 
+  function getNodeState(node: CampaignNode): 'completed' | 'available' | 'locked' {
+    if (progress.completedNodes.includes(node.id)) return 'completed';
+    if (isNodeUnlocked(node.id)) return 'available';
+    return 'locked';
+  }
+
+  // Only show nodes that are available/completed, or locked but marked alwaysVisible
+  const visibleNodes = useMemo(() => {
+    if (!activeChapter) return [];
+    return activeChapter.nodes.filter(node => {
+      const state = getNodeState(node);
+      if (state !== 'locked') return true;
+      return node.alwaysVisible === true;
+    });
+  }, [activeChapter, progress.completedNodes]);
+
   // Normalize node positions to percentages so they always fit the container width
   const PADDING_X = 12; // % horizontal padding on each side
   const PADDING_TOP = 40; // px top padding
@@ -70,22 +86,6 @@ export default function CampaignScreen() {
     const maxTop = Math.max(...Array.from(positions.values()).map(p => p.topPx));
     return { nodePositions: positions, mapHeight: maxTop + PADDING_BOTTOM };
   }, [visibleNodes]);
-
-  function getNodeState(node: CampaignNode): 'completed' | 'available' | 'locked' {
-    if (progress.completedNodes.includes(node.id)) return 'completed';
-    if (isNodeUnlocked(node.id)) return 'available';
-    return 'locked';
-  }
-
-  // Only show nodes that are available/completed, or locked but marked alwaysVisible
-  const visibleNodes = useMemo(() => {
-    if (!activeChapter) return [];
-    return activeChapter.nodes.filter(node => {
-      const state = getNodeState(node);
-      if (state !== 'locked') return true;
-      return node.alwaysVisible === true;
-    });
-  }, [activeChapter, progress.completedNodes]);
 
   function handleNodeClick(node: CampaignNode) {
     const state = getNodeState(node);


### PR DESCRIPTION
## Summary
Reorganized the code in CampaignScreen.tsx by moving the `getNodeState()` function and `visibleNodes` memoized value to appear earlier in the component, before they are used in subsequent calculations.

## Key Changes
- Moved `getNodeState()` function from line 74 to line 40 (before its usage)
- Moved `visibleNodes` useMemo hook from line 81 to line 47 (before its usage in nodePositions calculation)
- No functional changes to the logic or behavior

## Implementation Details
This is a pure refactoring that improves code readability by following a top-down flow where functions and values are defined before they are consumed. The `visibleNodes` memoized value is now defined immediately after `getNodeState()`, and both are positioned before the `nodePositions` calculation that depends on `visibleNodes`. This makes the dependency chain clearer and easier to follow.

https://claude.ai/code/session_01KrtVQ7377pidGQf8XYgNbc