### PR TITLE
fix(ui): introduce btn-menu class for consistent menu button sizing

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -87,7 +87,7 @@ button { cursor: pointer; border: none; font-family: inherit; transition: none; 
   background: #1a6040;
   color: var(--gold-light); padding: 12px 28px;
   border: 2px solid; border-color: #30a060 #0a2c18 #0a2c18 #30a060; border-radius: 0;
-  font-size: 12px; letter-spacing: 1px;
+  font-size: 0.75rem; letter-spacing: 1px;
 }
 .btn-primary:hover { background: #1e6848; box-shadow: none; }
 .btn-secondary {
@@ -96,6 +96,12 @@ button { cursor: pointer; border: none; font-family: inherit; transition: none; 
   border-radius: 0; font-size: 0.9375rem;
 }
 .btn-secondary:hover { background: #1c6440; border-color: var(--gold); color: var(--gold); box-shadow: none; }
+.btn-menu {
+  background: #185838; color: var(--gold-light);
+  padding: 12px 28px; border: 2px solid; border-color: #2a9858 #0a2c18 #0a2c18 #2a9858;
+  border-radius: 0; font-size: 0.9375rem;
+}
+.btn-menu:hover { background: #1c6440; border-color: var(--gold); color: var(--gold); box-shadow: none; }
 .btn-cancel {
   background: #3c1414; color: #ff8888;
   padding: 8px 20px; border: 2px solid; border-color: #602020 #200808 #200808 #602020;

--- a/js/react/screens/SavePointScreen.module.css
+++ b/js/react/screens/SavePointScreen.module.css
@@ -47,7 +47,6 @@
   align-items: center; gap: 10px;
 }
 
-.menu :global(.btn-primary),
-.menu :global(.btn-secondary) {
+.menu :global(.btn-menu) {
   width: 260px; text-align: center;
 }

--- a/js/react/screens/SavePointScreen.tsx
+++ b/js/react/screens/SavePointScreen.tsx
@@ -55,14 +55,14 @@ export default function SavePointScreen() {
           <p className={styles.backupWarning}>{t('save.backup_warning')}</p>
         )}
         <div className={styles.menu}>
-          <button className="btn-secondary" onClick={() => navigateTo('campaign')}>{t('save.btn_story')}</button>
-          <button className="btn-secondary" onClick={() => navigateTo('opponent')}>{t('save.btn_duel')}</button>
-          <button className="btn-secondary" onClick={() => navigateTo('shop')}>{t('save.btn_shop')}</button>
-          <button className="btn-secondary" onClick={() => navigateTo('collection')}>{t('save.btn_collection')}</button>
-          <button className="btn-secondary" onClick={() => navigateTo('deckbuilder')}>{t('save.btn_deckbuilder')}</button>
-          <button className="btn-secondary" onClick={() => openModal({ type: 'card-list' })}>{t('save.btn_cardlist')}</button>
-          <button className="btn-secondary" onClick={handleToMainMenu}>{t('save.btn_mainmenu')}</button>
-          <button className="btn-primary" onClick={handleSave}>
+          <button className="btn-menu" onClick={() => navigateTo('campaign')}>{t('save.btn_story')}</button>
+          <button className="btn-menu" onClick={() => navigateTo('opponent')}>{t('save.btn_duel')}</button>
+          <button className="btn-menu" onClick={() => navigateTo('shop')}>{t('save.btn_shop')}</button>
+          <button className="btn-menu" onClick={() => navigateTo('collection')}>{t('save.btn_collection')}</button>
+          <button className="btn-menu" onClick={() => navigateTo('deckbuilder')}>{t('save.btn_deckbuilder')}</button>
+          <button className="btn-menu" onClick={() => openModal({ type: 'card-list' })}>{t('save.btn_cardlist')}</button>
+          <button className="btn-menu" onClick={handleToMainMenu}>{t('save.btn_mainmenu')}</button>
+          <button className="btn-menu" onClick={handleSave}>
             {savedMsg ? t('save.btn_saved') : t('save.btn_save')}
           </button>
         </div>

--- a/js/react/screens/TitleScreen.module.css
+++ b/js/react/screens/TitleScreen.module.css
@@ -43,19 +43,11 @@
   backdrop-filter: blur(2px);
 }
 
-.menu :global(.btn-primary) {
-  width: 220px; text-align: center;
-  background: rgba(20, 100, 50, 0.55);
-  border-color: rgba(40, 160, 80, 0.7) rgba(8, 40, 20, 0.7) rgba(8, 40, 20, 0.7) rgba(40, 160, 80, 0.7);
-}
-.menu :global(.btn-primary):hover {
-  background: rgba(25, 115, 60, 0.7);
-}
-.menu :global(.btn-secondary) {
+.menu :global(.btn-menu) {
   width: 220px; text-align: center;
   background: rgba(18, 85, 45, 0.55);
   border-color: rgba(35, 145, 70, 0.7) rgba(8, 40, 20, 0.7) rgba(8, 40, 20, 0.7) rgba(35, 145, 70, 0.7);
 }
-.menu :global(.btn-secondary):hover {
+.menu :global(.btn-menu):hover {
   background: rgba(22, 100, 55, 0.7);
 }

--- a/js/react/screens/TitleScreen.tsx
+++ b/js/react/screens/TitleScreen.tsx
@@ -37,12 +37,12 @@ export default function TitleScreen() {
       </div>
       <div className={styles.content}>
         <div className={styles.menu}>
-          <button className="btn-primary" onClick={handleNewGame}>{t('title.new_game')}</button>
+          <button className="btn-menu" onClick={handleNewGame}>{t('title.new_game')}</button>
           {hasSave && (
-            <button className="btn-secondary" onClick={handleLoadGame}>{t('title.load_game')}</button>
+            <button className="btn-menu" onClick={handleLoadGame}>{t('title.load_game')}</button>
           )}
-<button className="btn-secondary" onClick={() => openModal({ type: 'main-options' })}>{t('title.options')}</button>
-          <button className="btn-secondary" onClick={() => window.close()}>{t('title.quit')}</button>
+<button className="btn-menu" onClick={() => openModal({ type: 'main-options' })}>{t('title.options')}</button>
+          <button className="btn-menu" onClick={() => window.close()}>{t('title.quit')}</button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Replace mixed btn-primary/btn-secondary usage in TitleScreen and
SavePointScreen menus with a dedicated btn-menu class. Also convert
btn-primary font-size from absolute 12px to 0.75rem.

https://claude.ai/code/session_01FKC1vG6j38Bjjmsvoa8KaS