### PR TITLE
ci(release): add automated GitHub Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm test
+
+      - run: npm run build
+
+      - name: Generate changelog
+        run: |
+          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+
+          if [ -z "$PREV_TAG" ]; then
+            COMMITS=$(git log --pretty=format:"%s")
+          else
+            COMMITS=$(git log --pretty=format:"%s" "${PREV_TAG}..HEAD")
+          fi
+
+          FEATURES=$(echo "$COMMITS" | grep -E "^feat(\(.+\))?: " | sed 's/^feat[^:]*: /- /' || true)
+          FIXES=$(echo "$COMMITS"    | grep -E "^fix(\(.+\))?: "  | sed 's/^fix[^:]*: /- /'  || true)
+          CHORES=$(echo "$COMMITS"   | grep -E "^chore(\(.+\))?: "| sed 's/^chore[^:]*: /- /' || true)
+
+          {
+            if [ -n "$FEATURES" ]; then
+              printf "## Features\n%s\n\n" "$FEATURES"
+            fi
+            if [ -n "$FIXES" ]; then
+              printf "## Bug Fixes\n%s\n\n" "$FIXES"
+            fi
+            if [ -n "$CHORES" ]; then
+              printf "## Chores\n%s\n\n" "$CHORES"
+            fi
+            if [ -z "$FEATURES" ] && [ -z "$FIXES" ] && [ -z "$CHORES" ]; then
+              printf "No notable changes.\n"
+            fi
+          } > release_notes.md
+
+      - name: Determine pre-release status
+        id: prerelease
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          if [ "$MAJOR" = "0" ]; then
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          body_path: release_notes.md
+          prerelease: ${{ steps.prerelease.outputs.is_prerelease }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "build:android": "vite build && cap sync android",
     "cap:sync": "cap sync",
     "cap:open": "cap open android",
-    "generate:tcg": "vite-node js/tcg-format/generate-base-tcg.ts"
+    "generate:tcg": "vite-node js/tcg-format/generate-base-tcg.ts",
+    "release:patch": "npm version patch && git push && git push --tags",
+    "release:minor": "npm version minor && git push && git push --tags",
+    "release:major": "npm version major && git push && git push --tags"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Changes

- Add GitHub Actions workflow for automated releases triggered on version tags
- Workflow runs tests and builds before creating a GitHub Release
- Automatically generates changelog from conventional commits (feat, fix, chore)
- Detects pre-release status based on semver major version (0.x.x marked as pre-release)
- Add npm scripts for releasing patch, minor, and major versions

## Workflow Details

- Triggers on push to version tags (v*)
- Runs on ubuntu-latest with Node 20
- Generates structured release notes from git history
- Uses softprops/action-gh-release for creating GitHub releases