### PR TITLE
Update title screen button selector from btn-primary to btn-menu

### DIFF
--- a/tests-e2e/game.spec.ts
+++ b/tests-e2e/game.spec.ts
@@ -40,7 +40,7 @@ test.describe('Title Screen', () => {
 
   test('new game button is present', async ({ page }) => {
     await passPressStart(page);
-    await expect(page.locator('#title-screen button.btn-primary')).toBeVisible();
+    await expect(page.locator('#title-screen button.btn-menu')).toBeVisible();
   });
 
   test('options button is present', async ({ page }) => {


### PR DESCRIPTION
## Summary
Updated the e2e test selector for the new game button on the title screen to use the correct CSS class name.

## Changes
- Changed the button selector in the title screen test from `button.btn-primary` to `button.btn-menu` to match the actual styling class applied to the new game button

## Details
This change corrects the test assertion to target the button with the appropriate menu button styling class rather than the primary button class. This ensures the test accurately reflects the current UI implementation and will properly validate the presence of the new game button on the title screen.

https://claude.ai/code/session_01Nshgeq2PBpgKCqcwWSrzfM