### PR TITLE
fix(e2e): use getByRole for new game button to avoid strict mode viol…

### DIFF
--- a/tests-e2e/game.spec.ts
+++ b/tests-e2e/game.spec.ts
@@ -40,7 +40,7 @@ test.describe('Title Screen', () => {
 
   test('new game button is present', async ({ page }) => {
     await passPressStart(page);
-    await expect(page.locator('#title-screen button.btn-menu')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'New Game' })).toBeVisible();
   });
 
   test('options button is present', async ({ page }) => {


### PR DESCRIPTION
…ation

btn-menu matches all menu buttons; use getByRole with name instead, consistent with the options button test.

https://claude.ai/code/session_01Nshgeq2PBpgKCqcwWSrzfM