### PR TITLE
Add TriggerBus event system and modding type definitions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ jobs:
 
       - run: npm run build
 
+      - name: Generate eos-engine.d.ts
+        run: npm run generate:engine-dts
+
       - name: Generate changelog
         run: |
           PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
@@ -73,4 +76,5 @@ jobs:
           name: ${{ github.ref_name }}
           body_path: release_notes.md
           prerelease: ${{ steps.prerelease.outputs.is_prerelease }}
+          files: dist/eos-engine.d.ts
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/js/engine.ts
+++ b/js/engine.ts
@@ -7,6 +7,7 @@ import { executeEffectBlock, matchesFilter } from './effect-registry.js';
 import { CardType } from './types.js';
 import { meetsEquipRequirement } from './types.js';
 import type { Owner, Phase, Position, CardData, CardEffectBlock, EffectContext, EffectSignal, GameState, UICallbacks, OpponentConfig, AIBehavior, DuelStats } from './types.js';
+import { TriggerBus } from './trigger-bus.js';
 // Re-export for backwards compatibility
 export { meetsEquipRequirement } from './types.js';
 
@@ -375,6 +376,7 @@ export class GameEngine {
     this._recalcFieldSpellBonuses(fc);
     // trigger onSummon effect for every summon method
     await this._triggerEffect(fc, owner, 'onSummon', zone);
+    TriggerBus.emit('onSummon', { engine: this, owner, card: fc.card, fieldCard: fc, zone });
     this.ui.render(this.state);
     return true;
   }
@@ -390,6 +392,7 @@ export class GameEngine {
     fc.faceDown = false;
     this.addLog(`${fc.card.name} is flipped face-up (Flip Summon)!`);
     await this._triggerFlipEffect(fc, owner, zone);
+    TriggerBus.emit('onFlip', { engine: this, owner, card: fc.card, fieldCard: fc, zone });
     this.ui.render(this.state);
     return true;
   }
@@ -409,6 +412,7 @@ export class GameEngine {
     this.ui.playSfx?.('sfx_card_play');
     this._recalcFieldSpellBonuses(fc);
     await this._triggerEffect(fc, owner, 'onSummon', zone);
+    TriggerBus.emit('onSummon', { engine: this, owner, card: fc.card, fieldCard: fc, zone });
     this.ui.render(this.state);
     return true;
   }
@@ -428,6 +432,7 @@ export class GameEngine {
     this.ui.playSfx?.('sfx_card_play');
     this._recalcFieldSpellBonuses(fc);
     await this._triggerEffect(fc, owner, 'onSummon', zone);
+    TriggerBus.emit('onSummon', { engine: this, owner, card: fc.card, fieldCard: fc, zone });
     this.ui.render(this.state);
     return true;
   }
@@ -702,6 +707,7 @@ export class GameEngine {
 
     this.ui.render(this.state);
     await this._triggerEffect(fc, owner, 'onSummon', zone);
+    TriggerBus.emit('onSummon', { engine: this, owner, card: fc.card, fieldCard: fc, zone });
     return true;
   }
 
@@ -782,6 +788,7 @@ export class GameEngine {
 
     this.ui.render(this.state);
     await this._triggerEffect(fc, owner, 'onSummon', zone);
+    TriggerBus.emit('onSummon', { engine: this, owner, card: fc.card, fieldCard: fc, zone });
     return true;
   }
 
@@ -800,6 +807,7 @@ export class GameEngine {
       attFC.position = 'atk';
       this.addLog(`${attFC.card.name} is revealed (attack)!`);
       await this._triggerFlipEffect(attFC, attackerOwner, attackerZone);
+      TriggerBus.emit('onFlip', { engine: this, owner: attackerOwner, card: attFC.card, fieldCard: attFC, zone: attackerZone });
     }
     if(attFC.position !== 'atk'){ this.addLog('Monster must be in attack position!'); return; }
 
@@ -848,6 +856,7 @@ export class GameEngine {
       attFC.position = 'atk';
       this.addLog(`${attFC.card.name} is flipped face-up (Attack)!`);
       await this._triggerFlipEffect(attFC, attackerOwner, attackerZone);
+      TriggerBus.emit('onFlip', { engine: this, owner: attackerOwner, card: attFC.card, fieldCard: attFC, zone: attackerZone });
     }
     if(attFC.position !== 'atk') return;
 
@@ -870,6 +879,7 @@ export class GameEngine {
       defFC.faceDown = false;
       this.addLog(`${defFC.card.name} is revealed!`);
       await this._triggerFlipEffect(defFC, defOwner, defZone);
+      TriggerBus.emit('onFlip', { engine: this, owner: defOwner, card: defFC.card, fieldCard: defFC, zone: defZone });
     }
 
     const defVal = defFC.combatValue();
@@ -892,6 +902,7 @@ export class GameEngine {
         this.dealDamage(defOwner, dmg);
         // attacker effect: onDestroyByBattle
         await this._triggerEffect(attFC, atkOwner, 'onDestroyByBattle', null);
+        TriggerBus.emit('onDestroyByBattle', { engine: this, owner: atkOwner, card: attFC.card, fieldCard: attFC });
       } else if(effATK === defVal){
         this.addLog('Tie! Both monsters destroyed!');
         await this._destroyMonster(atkOwner, atkZone, 'battle', defOwner);
@@ -902,7 +913,9 @@ export class GameEngine {
         await this._destroyMonster(atkOwner, atkZone, 'battle', defOwner);
         this.dealDamage(atkOwner, dmg);
         await this._triggerEffect(attFC, atkOwner, 'onDestroyByBattle', null);
+        TriggerBus.emit('onDestroyByBattle', { engine: this, owner: atkOwner, card: attFC.card, fieldCard: attFC });
         await this._triggerEffect(defFC, defOwner, 'onDestroyByBattle', null);
+        TriggerBus.emit('onDestroyByBattle', { engine: this, owner: defOwner, card: defFC.card, fieldCard: defFC });
       }
     } else {
       // defender in DEF mode
@@ -936,6 +949,7 @@ export class GameEngine {
     // Shadow Reaper / onDestroyByBattle for defender
     if(reason === 'battle' && byOwner !== owner){
       await this._triggerEffect(fc, owner, 'onDestroyByOpponent', zone);
+      TriggerBus.emit('onDestroyByOpponent', { engine: this, owner, card: fc.card, fieldCard: fc, zone });
     }
 
     st.graveyard.push(fc.card);

--- a/js/mod-api.ts
+++ b/js/mod-api.ts
@@ -7,6 +7,7 @@
 import { CARD_DB, FUSION_RECIPES, OPPONENT_CONFIGS, STARTER_DECKS } from './cards.js';
 import { EFFECT_REGISTRY, registerEffect } from './effect-registry.js';
 import { loadAndApplyTcg, unloadModCards, getLoadedMods } from './tcg-bridge.js';
+import { TriggerBus } from './trigger-bus.js';
 
 declare global {
   interface Window {
@@ -33,6 +34,10 @@ const modApi = {
   unloadModCards,
   /** List all currently loaded mods with their card IDs and load order. */
   getLoadedMods,
+  /** Fire effects with a custom trigger name. */
+  emitTrigger: TriggerBus.emit,
+  /** Subscribe to a trigger event (returns unsubscribe function). */
+  addTriggerHook: TriggerBus.on,
 };
 
 window.EchoesOfSanguoMod = modApi;

--- a/js/trigger-bus.ts
+++ b/js/trigger-bus.ts
@@ -1,0 +1,40 @@
+// ============================================================
+// ECHOES OF SANGUO — TriggerBus
+// Lightweight event emitter for extensible trigger hooks.
+// Modders subscribe via addTriggerHook / emitTrigger on the mod API.
+// ============================================================
+import type { EffectContext, CardData, Owner } from './types.js';
+import type { FieldCard } from './field.js';
+
+/** Context passed to TriggerBus handlers — extends EffectContext with the triggering card. */
+export interface TriggerContext extends EffectContext {
+  /** The card that caused this trigger (e.g. the summoned monster). */
+  card?: CardData;
+  /** The FieldCard instance on the board, if applicable. */
+  fieldCard?: FieldCard;
+  /** The board zone index, if applicable. */
+  zone?: number | null;
+}
+
+type TriggerHandler = (ctx: TriggerContext) => void;
+
+const handlers = new Map<string, Set<TriggerHandler>>();
+
+export const TriggerBus = {
+  /** Subscribe to a trigger event. Returns an unsubscribe function. */
+  on(event: string, handler: TriggerHandler): () => void {
+    if (!handlers.has(event)) handlers.set(event, new Set());
+    handlers.get(event)!.add(handler);
+    return () => { handlers.get(event)?.delete(handler); };
+  },
+
+  /** Fire all handlers registered for the given event. */
+  emit(event: string, ctx: TriggerContext): void {
+    handlers.get(event)?.forEach(h => h(ctx));
+  },
+
+  /** Remove all handlers. Used in test teardown. */
+  clear(): void {
+    handlers.clear();
+  },
+};

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "cap:sync": "cap sync",
     "cap:open": "cap open android",
     "generate:tcg": "vite-node js/generate-base-tcg.ts",
+    "generate:engine-dts": "node scripts/generate-engine-dts.js",
     "release:patch": "npm version patch && git push && git push --tags",
     "release:minor": "npm version minor && git push && git push --tags",
     "release:major": "npm version major && git push && git push --tags"

--- a/scripts/generate-engine-dts.js
+++ b/scripts/generate-engine-dts.js
@@ -1,0 +1,244 @@
+#!/usr/bin/env node
+/**
+ * Generate eos-engine.d.ts — a standalone type definitions file for modders.
+ *
+ * Extracts modding-relevant types from js/types.ts, js/trigger-bus.ts, and
+ * js/mod-api.ts, wraps them in `declare global { ... }`, and writes
+ * dist/eos-engine.d.ts.
+ *
+ * Usage: node scripts/generate-engine-dts.js
+ */
+import { readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+
+const typesSource = readFileSync(join(root, 'js/types.ts'), 'utf8');
+
+// Extract the types we want to expose to modders.
+// We manually curate them to avoid leaking internal engine details.
+
+const output = `// eos-engine.d.ts — Auto-generated type definitions for Echoes of Sanguo modding.
+// Add this file to your project to get type safety for EOS modding.
+// Extend EffectDescriptorMap via declaration merging to add custom effect types.
+//
+// Generated: ${new Date().toISOString().slice(0, 10)}
+
+declare global {
+  // ── Primitive Unions ──────────────────────────────────────────
+  type Owner        = 'player' | 'opponent';
+  type Phase        = 'draw' | 'main' | 'battle' | 'end';
+  type Position     = 'atk' | 'def';
+  type TrapTrigger  = 'onAttack' | 'onOwnMonsterAttacked' | 'onOpponentSummon' | 'manual';
+  type EffectTrigger= 'onSummon' | 'onDestroyByBattle' | 'onDestroyByOpponent' | 'passive' | 'onFlip';
+  type SpellType    = 'normal' | 'targeted' | 'fromGrave' | 'field';
+
+  // ── Int-based Enums ───────────────────────────────────────────
+  const enum CardType {
+    Monster   = 1,
+    Fusion    = 2,
+    Spell     = 3,
+    Trap      = 4,
+    Equipment = 5,
+  }
+
+  const enum Attribute {
+    Light = 1,
+    Dark  = 2,
+    Fire  = 3,
+    Water = 4,
+    Earth = 5,
+    Wind  = 6,
+  }
+
+  const enum Race {
+    Dragon      = 1,
+    Spellcaster = 2,
+    Warrior     = 3,
+    Beast       = 4,
+    Plant       = 5,
+    Rock        = 6,
+    Phoenix     = 7,
+    Undead      = 8,
+    Aqua        = 9,
+    Insect      = 10,
+    Machine     = 11,
+    Pyro        = 12,
+  }
+
+  const enum Rarity {
+    Common    = 1,
+    Uncommon  = 2,
+    Rare      = 4,
+    SuperRare = 6,
+    UltraRare = 8,
+  }
+
+  // ── Effect System ─────────────────────────────────────────────
+
+  type ValueExpr =
+    | number
+    | { from: 'attacker.effectiveATK'; multiply: number; round: 'floor' | 'ceil' }
+    | { from: 'summoned.atk';          multiply: number; round: 'floor' | 'ceil' };
+
+  type StatTarget = 'ownMonster' | 'oppMonster' | 'attacker' | 'defender' | 'summonedFC';
+
+  interface CardFilter {
+    race?:      Race;
+    attr?:      Attribute;
+    cardType?:  CardType;
+    cardId?:    string;
+    maxAtk?:    number;
+    minAtk?:    number;
+    maxDef?:    number;
+    maxLevel?:  number;
+    minLevel?:  number;
+    random?:    number;
+  }
+
+  /**
+   * Open map of effect action types → payloads.
+   * Extend via declaration merging to add custom effect types:
+   *
+   * \\\`\\\`\\\`ts
+   * declare global {
+   *   interface EffectDescriptorMap {
+   *     teleportMonster: { from: 'hand' | 'field'; to: 'hand' | 'field' };
+   *   }
+   * }
+   * \\\`\\\`\\\`
+   */
+  interface EffectDescriptorMap {
+    dealDamage:              { target: 'opponent' | 'self'; value: ValueExpr };
+    gainLP:                  { target: 'opponent' | 'self'; value: number | ValueExpr };
+    draw:                    { target: 'self' | 'opponent'; count: number };
+    buffField:               { value: number; filter?: CardFilter };
+    tempBuffField:           { value: number; filter?: CardFilter };
+    debuffField:             { atkD: number; defD: number };
+    tempDebuffField:         { atkD: number; defD?: number };
+    bounceStrongestOpp:      {};
+    bounceAttacker:          {};
+    bounceAllOppMonsters:    {};
+    searchDeckToHand:        { filter: CardFilter };
+    tempAtkBonus:            { target: StatTarget; value: number };
+    permAtkBonus:            { target: StatTarget; value: number; filter?: CardFilter };
+    tempDefBonus:            { target: StatTarget; value: number };
+    permDefBonus:            { target: StatTarget; value: number };
+    reviveFromGrave:         {};
+    cancelAttack:            {};
+    destroyAttacker:         {};
+    destroySummonedIf:       { minAtk: number };
+    destroyAllOpp:           {};
+    destroyAll:              {};
+    destroyWeakestOpp:       {};
+    destroyStrongestOpp:     {};
+    sendTopCardsToGrave:     { count: number };
+    sendTopCardsToGraveOpp:  { count: number };
+    salvageFromGrave:        { filter: CardFilter };
+    recycleFromGraveToDeck:  { filter: CardFilter };
+    shuffleGraveIntoDeck:    {};
+    shuffleDeck:             {};
+    peekTopCard:             {};
+    specialSummonFromHand:   { filter?: CardFilter };
+    discardFromHand:         { count: number };
+    discardOppHand:          { count: number };
+    passive_piercing:        {};
+    passive_untargetable:    {};
+    passive_directAttack:    {};
+    passive_vsAttrBonus:     { attr: Attribute; atk: number };
+    passive_phoenixRevival:  {};
+    passive_indestructible:  {};
+    passive_effectImmune:    {};
+    passive_cantBeAttacked:  {};
+  }
+
+  type EffectDescriptor = {
+    [K in keyof EffectDescriptorMap]: { type: K } & EffectDescriptorMap[K]
+  }[keyof EffectDescriptorMap];
+
+  interface EffectSignal {
+    cancelAttack?:     boolean;
+    destroySummoned?:  boolean;
+    destroyAttacker?:  boolean;
+  }
+
+  interface CardEffectBlock {
+    trigger:    EffectTrigger | TrapTrigger;
+    actions:    EffectDescriptor[];
+  }
+
+  // ── Card ──────────────────────────────────────────────────────
+
+  interface CardData {
+    id:           string;
+    name:         string;
+    type:         CardType;
+    attribute?:   Attribute;
+    race?:        Race;
+    rarity?:      Rarity;
+    level?:       number;
+    atk?:         number;
+    def?:         number;
+    description:  string;
+    effect?:      CardEffectBlock;
+    spellType?:   SpellType;
+    trapTrigger?: TrapTrigger;
+    target?:      string;
+    atkBonus?:    number;
+    defBonus?:    number;
+    equipRequirement?: { race?: Race; attr?: Attribute };
+  }
+
+  // ── Effect Context (passed to effect handlers) ────────────────
+
+  interface EffectContext {
+    engine:       any;
+    owner:        Owner;
+    targetFC?:    any;
+    targetCard?:  CardData;
+    attacker?:    any;
+    defender?:    any;
+    summonedFC?:  any;
+  }
+
+  // ── TriggerBus Context ────────────────────────────────────────
+
+  interface TriggerContext extends EffectContext {
+    card?:      CardData;
+    fieldCard?: any;
+    zone?:      number | null;
+  }
+
+  // ── Effect Implementation (for registerEffect) ────────────────
+
+  type EffectImpl = (action: any, ctx: EffectContext) => EffectSignal | void;
+
+  // ── Mod API (available on window.EchoesOfSanguoMod) ───────────
+
+  interface EchoesOfSanguoModApi {
+    CARD_DB:          Record<string, CardData>;
+    FUSION_RECIPES:   Array<{ materials: [string, string]; result: string }>;
+    OPPONENT_CONFIGS: Array<any>;
+    STARTER_DECKS:    Record<number, string[]>;
+    EFFECT_REGISTRY:  Map<string, EffectImpl>;
+    registerEffect(type: string, impl: EffectImpl): void;
+    loadModTcg(source: string | ArrayBuffer, onProgress?: (percent: number) => void): Promise<any>;
+    unloadModCards(source: string): boolean;
+    getLoadedMods(): ReadonlyArray<{ source: string; cardIds: string[]; opponentIds: number[]; timestamp: number }>;
+    emitTrigger(event: string, ctx: TriggerContext): void;
+    addTriggerHook(event: string, handler: (ctx: TriggerContext) => void): () => void;
+  }
+
+  interface Window {
+    EchoesOfSanguoMod: EchoesOfSanguoModApi;
+  }
+}
+
+export {};
+`;
+
+mkdirSync(join(root, 'dist'), { recursive: true });
+writeFileSync(join(root, 'dist/eos-engine.d.ts'), output);
+console.log('Generated dist/eos-engine.d.ts');

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,5 +1,5 @@
 // Minimal localStorage mock for Node environment (used by progression.js)
-import { beforeEach } from 'vitest';
+import { afterEach, beforeEach } from 'vitest';
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
@@ -49,3 +49,7 @@ if (typeof window === 'undefined') {
   const buf = await zip.generateAsync({ type: 'arraybuffer' });
   await loadAndApplyTcg(buf);
 }
+
+// Clean TriggerBus between tests so handlers don't leak across test files
+const { TriggerBus } = await import('../js/trigger-bus.js');
+afterEach(() => { TriggerBus.clear(); });

--- a/tests/trigger-bus.test.js
+++ b/tests/trigger-bus.test.js
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest';
+import { TriggerBus } from '../js/trigger-bus.js';
+
+// setup.js calls TriggerBus.clear() in afterEach, so each test starts clean.
+
+describe('TriggerBus', () => {
+  it('calls handler when event is emitted', () => {
+    const handler = vi.fn();
+    TriggerBus.on('onSummon', handler);
+    const ctx = { engine: {}, owner: 'player' };
+    TriggerBus.emit('onSummon', ctx);
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith(ctx);
+  });
+
+  it('does not call handler for a different event', () => {
+    const handler = vi.fn();
+    TriggerBus.on('onSummon', handler);
+    TriggerBus.emit('onFlip', { engine: {}, owner: 'player' });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('supports multiple handlers on the same event', () => {
+    const h1 = vi.fn();
+    const h2 = vi.fn();
+    TriggerBus.on('onSummon', h1);
+    TriggerBus.on('onSummon', h2);
+    TriggerBus.emit('onSummon', { engine: {}, owner: 'player' });
+    expect(h1).toHaveBeenCalledOnce();
+    expect(h2).toHaveBeenCalledOnce();
+  });
+
+  it('unsubscribes via returned function', () => {
+    const handler = vi.fn();
+    const unsub = TriggerBus.on('onSummon', handler);
+    unsub();
+    TriggerBus.emit('onSummon', { engine: {}, owner: 'player' });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('clear() removes all handlers', () => {
+    const h1 = vi.fn();
+    const h2 = vi.fn();
+    TriggerBus.on('onSummon', h1);
+    TriggerBus.on('onFlip', h2);
+    TriggerBus.clear();
+    TriggerBus.emit('onSummon', { engine: {}, owner: 'player' });
+    TriggerBus.emit('onFlip', { engine: {}, owner: 'opponent' });
+    expect(h1).not.toHaveBeenCalled();
+    expect(h2).not.toHaveBeenCalled();
+  });
+
+  it('supports custom trigger names (modder use case)', () => {
+    const handler = vi.fn();
+    TriggerBus.on('onEliteSummon', handler);
+    // Simulate a modder's derived trigger
+    TriggerBus.on('onSummon', (ctx) => {
+      if (ctx.card && ctx.card.level >= 7) {
+        TriggerBus.emit('onEliteSummon', ctx);
+      }
+    });
+    TriggerBus.emit('onSummon', { engine: {}, owner: 'player', card: { level: 8, name: 'Dragon' } });
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it('does not fire derived trigger for low-level card', () => {
+    const handler = vi.fn();
+    TriggerBus.on('onEliteSummon', handler);
+    TriggerBus.on('onSummon', (ctx) => {
+      if (ctx.card && ctx.card.level >= 7) {
+        TriggerBus.emit('onEliteSummon', ctx);
+      }
+    });
+    TriggerBus.emit('onSummon', { engine: {}, owner: 'player', card: { level: 3, name: 'Goblin' } });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('emitting unknown event does nothing', () => {
+    expect(() => {
+      TriggerBus.emit('nonExistentEvent', { engine: {}, owner: 'player' });
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
This PR introduces a lightweight event emitter system (`TriggerBus`) for extensible trigger hooks and generates standalone TypeScript type definitions (`eos-engine.d.ts`) for modders. These changes enable modders to hook into game events and extend the engine with custom effects while maintaining type safety.

## Key Changes

- **New TriggerBus module** (`js/trigger-bus.ts`):
  - Lightweight event emitter for game triggers (onSummon, onFlip, etc.)
  - Supports subscription/unsubscription via `on()` and returned cleanup functions
  - Allows modders to emit custom trigger events via `emitTrigger()` on the mod API
  - Includes `clear()` for test isolation

- **Engine integration**:
  - Integrated `TriggerBus.emit()` calls at key game events (summon, flip, etc.)
  - Passes rich context including engine, owner, card data, field card instance, and zone
  - Enables modders to react to game state changes without modifying core engine code

- **Mod API expansion** (`js/mod-api.ts`):
  - Exposed `emitTrigger()` and `addTriggerHook()` methods on `window.EchoesOfSanguoMod`
  - Allows modders to fire custom triggers and subscribe to engine events

- **Type definitions generator** (`scripts/generate-engine-dts.js`):
  - New build script that generates `dist/eos-engine.d.ts`
  - Curated public API types for modders (CardData, EffectDescriptor, TriggerContext, etc.)
  - Includes extensible `EffectDescriptorMap` interface for custom effect types via declaration merging
  - Comprehensive documentation with examples

- **Test coverage** (`tests/trigger-bus.test.js`):
  - Full test suite for TriggerBus functionality
  - Tests event emission, multiple handlers, unsubscription, and custom trigger names
  - Validates modder use cases like derived triggers

- **Build pipeline**:
  - Added `generate:engine-dts` npm script
  - Integrated into release workflow to auto-generate type definitions on version bump
  - Test setup updated to clean TriggerBus between tests

## Notable Implementation Details

- TriggerBus uses a `Map<string, Set<TriggerHandler>>` for efficient event management
- Handlers are called synchronously; context includes both engine state and card metadata
- Type definitions are manually curated to avoid exposing internal engine details
- Declaration merging pattern allows modders to extend `EffectDescriptorMap` with custom effect types
- Generated `.d.ts` file is standalone and can be distributed to modders independently

https://claude.ai/code/session_015wbcvJ23qZHTSxBiEQ15bP