### PR TITLE
Build and link tcg-format package locally in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,16 @@ jobs:
 
       - run: npm ci
 
+      - name: Build and link @wynillo/tcg-format
+        run: |
+          git clone https://github.com/Wynillo/Echoes-of-Sanguo-TCG.git /tmp/tcg-format
+          cd /tmp/tcg-format
+          npm ci
+          npm run build
+          npm link
+          cd ${{ github.workspace }}
+          npm link @wynillo/tcg-format
+
       - run: npm test
 
       - run: npm run build

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@wynillo:registry=https://npm.pkg.github.com

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@capacitor/android": "^8.3.0",
     "@capacitor/cli": "^8.3.0",
     "@capacitor/core": "^8.3.0",
-    "@wynillo/tcg-format": "^1.0.0",
     "gsap": "^3.14.2",
     "i18next": "^25.10.10",
     "jszip": "^3.10.1",


### PR DESCRIPTION
## Summary
This PR updates the release workflow to build and link the `@wynillo/tcg-format` package locally during CI, removing the dependency on the GitHub Package Registry.

## Key Changes
- **Workflow**: Added a build step in `.github/workflows/release.yml` that clones the tcg-format repository, installs dependencies, builds the package, and links it locally before running tests
- **Dependencies**: Removed `@wynillo/tcg-format` from `package.json` dependencies since it's now built and linked at runtime
- **Registry config**: Removed `.npmrc` file that configured the GitHub Package Registry for the `@wynillo` scope

## Implementation Details
The new workflow step:
1. Clones the Echoes-of-Sanguo-TCG repository to a temporary directory
2. Installs and builds the tcg-format package
3. Uses `npm link` to make it available globally
4. Links the package in the current workspace

This approach ensures the tcg-format package is always built from the latest source during CI rather than relying on a published version in the GitHub Package Registry.

https://claude.ai/code/session_01TGdYEsTtJvbzBFqGVCVms3