### PR TITLE
Reorder CI workflow steps: generate TCG before E2E tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,11 +37,11 @@ jobs:
           cd ${{ github.workspace }}
           npm link @wynillo/tcg-format
       - run: npm test
+      - run: npm run generate:tcg
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
       - name: Run E2E tests
         run: npm run test:e2e
-      - run: npm run generate:tcg
       - run: npm run build
       - uses: actions/configure-pages@v4
       - name: Delete stale github-pages artifacts


### PR DESCRIPTION
## Summary
Reordered the deployment workflow steps to generate TCG data before running E2E tests, rather than after.

## Changes
- Moved `npm run generate:tcg` step to execute immediately after unit tests and before Playwright browser installation
- This ensures TCG data is generated and available during E2E test execution

## Rationale
This change improves the logical flow of the CI pipeline by ensuring that generated TCG data is available when E2E tests run, rather than being generated after tests complete. This may be necessary if the E2E tests depend on the generated TCG data.

https://claude.ai/code/session_01W6RVrqDdiB5aZF4XUrq1V9