### PR TITLE
docs: update documentation to reflect @wynillo/tcg-format extraction

### DIFF
--- a/.claude/agents/tcg-expert.md
+++ b/.claude/agents/tcg-expert.md
@@ -31,16 +31,12 @@ serialization grammar by heart.
 
 | File | Purpose |
 |------|---------|
-| `js/tcg-format/types.ts` | All TCG type definitions and interfaces |
-| `js/tcg-format/enums.ts` | Bidirectional enum converters (int <-> internal) |
-| `js/tcg-format/effect-serializer.ts` | Effect string codec (serialize/deserialize) |
-| `js/tcg-format/card-validator.ts` | Card-level validation rules |
-| `js/tcg-format/tcg-validator.ts` | Full archive validation |
-| `js/tcg-format/def-validator.ts` | Card definition (name/desc) validation |
-| `js/tcg-format/opp-desc-validator.ts` | Opponent description validation |
-| `js/tcg-format/tcg-loader.ts` | Load .tcg ZIP -> game data |
-| `js/tcg-format/tcg-builder.ts` | Export internal data -> TCG format |
-| `js/tcg-format/generate-base-tcg.ts` | CLI script for `npm run generate:tcg` |
+| `@wynillo/tcg-format` (external) | TCG types, loader, validators, packer (zero game imports) |
+| `js/tcg-bridge.ts` | Bridge: connects package output → game stores (CARD_DB, etc.) |
+| `js/tcg-builder.ts` | Converts CardData → TcgCard for packing |
+| `js/enums.ts` | Bidirectional enum converters (int ↔ game enums) |
+| `js/effect-serializer.ts` | Effect string codec (serialize/deserialize) |
+| `js/generate-base-tcg.ts` | Thin CLI wrapper → `@wynillo/tcg-format` packTcgArchive() |
 
 ## TCG Source Location
 
@@ -663,4 +659,4 @@ When asked to work with TCG data:
 4. **Use the next available ID** — check the highest existing ID and increment
 5. **Follow existing patterns** — look at nearby cards/opponents for style reference
 6. **Run validation** after changes: `npm run generate:tcg` checks format validity
-7. **Reference implementation files** when unsure — read `js/tcg-format/` source code for definitive rules
+7. **Reference implementation files** when unsure — the format library lives in the `@wynillo/tcg-format` package ([Wynillo/Echoes-of-Sanguo-TCG](https://github.com/Wynillo/Echoes-of-Sanguo-TCG)); game-side glue is in `js/tcg-bridge.ts`, `js/enums.ts`, and `js/effect-serializer.ts`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ npm run test:watch     # Vitest in watch mode
 npm run test:coverage  # Coverage report (v8)
 npm run test:e2e       # Playwright E2E tests (launches dev server)
 npm run generate:tcg   # Validate public/base.tcg-src/ folder and pack into public/base.tcg
+npm run generate:engine-dts # Generate eos-engine.d.ts for modders
 npm run build:android  # Build + Capacitor sync for Android
 npm run cap:sync       # Sync Capacitor changes
 npm run cap:open       # Open Android Studio
@@ -22,7 +23,7 @@ npm run cap:open       # Open Android Studio
 Three-layer design with strict separation:
 
 1. **Engine Layer** (pure TypeScript, no React) — `js/engine.ts`, `js/effect-registry.ts`, `js/ai-behaviors.ts`, `js/ai-orchestrator.ts`, `js/field.ts`, `js/rules.ts`
-2. **Data Layer** — `js/types.ts`, `js/cards.ts`, `js/progression.ts`, `js/campaign.ts`, `js/campaign-types.ts`, `js/campaign-store.ts`, `js/shop-data.ts`, `js/tcg-format/`
+2. **Data Layer** — `js/types.ts`, `js/cards.ts`, `js/progression.ts`, `js/campaign.ts`, `js/campaign-types.ts`, `js/campaign-store.ts`, `js/shop-data.ts`, `@wynillo/tcg-format` (external package), `js/tcg-bridge.ts`, `js/enums.ts`
 3. **UI Layer** (React) — `js/react/` with Context-based state management
 
 The engine communicates with the UI through the `UICallbacks` interface (render, log, prompt, showResult, playAttackAnimation, etc.). The engine never imports React.
@@ -50,18 +51,12 @@ js/
 ├── mod-api.ts             # window.EchoesOfSanguoMod API for community mods
 ├── i18n.ts                # i18next setup (de + en)
 ├── debug-logger.ts        # Debug utility
-├── tcg-format/            # ZIP-based card format (.tcg) — pack, load, validate
-│   ├── index.ts           # Export barrel
-│   ├── types.ts           # TCG format types
-│   ├── enums.ts           # TCG format enums
-│   ├── tcg-loader.ts      # Load .tcg ZIP → CARD_DB, FUSION_RECIPES, etc.
-│   ├── tcg-builder.ts     # Pack base.tcg-src/ → base.tcg (ZIP)
-│   ├── tcg-validator.ts   # Format validation
-│   ├── card-validator.ts  # Card-level validation
-│   ├── def-validator.ts   # Definition validator
-│   ├── opp-desc-validator.ts # Opponent description validator
-│   ├── effect-serializer.ts  # Effect string codec
-│   └── generate-base-tcg.ts  # CLI script for npm run generate:tcg
+├── tcg-bridge.ts          # Bridge: @wynillo/tcg-format → game stores (CARD_DB, etc.)
+├── tcg-builder.ts         # Converts CardData → TcgCard for packing
+├── enums.ts               # Bidirectional enum converters (int ↔ game enums)
+├── effect-serializer.ts   # Effect string codec (serialize/deserialize)
+├── generate-base-tcg.ts   # Thin CLI wrapper → @wynillo/tcg-format packTcgArchive()
+├── trigger-bus.ts         # Event emitter for extensible trigger hooks
 └── react/
     ├── App.tsx             # Root component, screen router
     ├── index.tsx           # React entry point
@@ -102,7 +97,7 @@ public/
 │   └── sfx/               # attack, button, card-play, coin, damage, destroy, draw, fusion, etc.
 └── title-bg.png
 android/                   # Capacitor Android project
-docs/                      # Documentation (tcg-format.md)
+docs/                      # Documentation (tcg-format.md, plan-outsource-tcg-package.md)
 ```
 
 ## Key Conventions
@@ -116,6 +111,7 @@ docs/                      # Documentation (tcg-format.md)
 ### Imports
 - ES modules throughout; use `.js` extension in import paths (TypeScript with bundler resolution)
 - Example: `import { CardType, Attribute } from './types.js';`
+- External package: `import { loadTcgFile } from '@wynillo/tcg-format';`
 
 ### State Management
 - React Context API only (no Redux/Zustand)
@@ -181,10 +177,21 @@ the distributed archive in sync — changes to one must be reflected in the othe
 - Auto-starts dev server on port 5173
 - Run: `npm run test:e2e`
 
+## External Package: @wynillo/tcg-format
+
+The TCG format library has been extracted to a separate repository: [Wynillo/Echoes-of-Sanguo-TCG](https://github.com/Wynillo/Echoes-of-Sanguo-TCG). It handles loading, validation, and packing of `.tcg` archives with zero game imports.
+
+- **Not in `package.json`** — linked dynamically via `git clone` + `npm link` in CI/CD workflows
+- **Local dev**: Clone the TCG repo, `npm ci && npm run build && npm link`, then `npm link @wynillo/tcg-format` in this repo
+- **Bridge layer**: `js/tcg-bridge.ts` connects the package's pure data output to game stores (`CARD_DB`, `FUSION_RECIPES`, etc.)
+- **Effect strings are opaque** in the package — parsed only by `js/effect-serializer.ts` in this repo
+
 ## CI/CD
 
 GitHub Actions (`.github/workflows/`):
-- `deploy.yml` — Triggers on push to `main`: `npm ci` → `npm test` → `npm run build` → deploy to GitHub Pages (Node.js 20)
+- `deploy.yml` — Triggers on push to `main`: `npm ci` → link `@wynillo/tcg-format` → `npm test` → `npm run generate:tcg` → E2E tests → `npm run build` → deploy to GitHub Pages (Node.js 22)
+- `release.yml` — Triggers on version tags (`v*`): build, generate `eos-engine.d.ts`, create GitHub Release
+- `deploy-hetzner.yml` — Hetzner deployment workflow
 - `summary.yml` — AI issue summarization workflow
 
 ## Tech Stack

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ The campaign spans **7 chapters** with **39 duels**, story nodes, and gauntlet e
 | **Capacitor 8** | Android app bridge |
 | **Vitest 4** | Unit and integration tests (jsdom) |
 | **Playwright 1.58** | End-to-end tests |
+| **@wynillo/tcg-format** | Card format library (external package) |
 
 **No backend** — all data is stored client-side via `localStorage`.
 
@@ -181,18 +182,12 @@ ECHOES-OF-SANGUO/
 │   ├── i18n.ts                 – i18next setup
 │   ├── mod-api.ts              – Modding API (window.EchoesOfSanguoMod)
 │   ├── debug-logger.ts         – Debug utility
-│   ├── tcg-format/             – Custom card format (.tcg = ZIP archive with JSON)
-│   │   ├── index.ts            – Export barrel
-│   │   ├── types.ts            – TCG format types
-│   │   ├── enums.ts            – TCG format enums
-│   │   ├── tcg-builder.ts      – Packs base.tcg-src/ → base.tcg (ZIP)
-│   │   ├── tcg-loader.ts       – Loads .tcg ZIP → CARD_DB, FUSION_RECIPES, etc.
-│   │   ├── tcg-validator.ts    – Validation logic for TCG archives
-│   │   ├── card-validator.ts   – Card-level validation
-│   │   ├── def-validator.ts    – Definition validator
-│   │   ├── opp-desc-validator.ts – Opponent description validator
-│   │   ├── effect-serializer.ts – Effect string codec
-│   │   └── generate-base-tcg.ts – CLI: validate & pack base.tcg-src/
+│   ├── tcg-bridge.ts           – Bridge: @wynillo/tcg-format → game stores
+│   ├── tcg-builder.ts          – Converts CardData → TcgCard for packing
+│   ├── enums.ts                – Bidirectional enum converters (int ↔ game enums)
+│   ├── effect-serializer.ts    – Effect string codec (serialize/deserialize)
+│   ├── generate-base-tcg.ts    – CLI wrapper → @wynillo/tcg-format packTcgArchive()
+│   ├── trigger-bus.ts          – Event emitter for extensible trigger hooks
 │   └── react/
 │       ├── App.tsx             – Root component (provider tree + screen router)
 │       ├── index.tsx           – React entry point
@@ -229,7 +224,7 @@ ECHOES-OF-SANGUO/
 │   └── en.json                 – English translations
 ├── tests/                      – Unit/integration tests (Vitest, 18 test files)
 ├── tests-e2e/                  – End-to-end tests (Playwright)
-├── docs/                       – Documentation (tcg-format.md)
+├── docs/                       – Documentation (tcg-format.md, plan-outsource-tcg-package.md)
 └── android/                    – Capacitor Android project
 ```
 
@@ -237,15 +232,16 @@ ECHOES-OF-SANGUO/
 
 ## Card Format (.tcg)
 
-`base.tcg` is a **ZIP archive** (renamed to `.tcg`) containing JSON files and card artwork. It is loaded on startup:
+`base.tcg` is a **ZIP archive** (renamed to `.tcg`) containing JSON files and card artwork. It is loaded on startup.
 
-- **tcg-builder.ts** — packs `public/base.tcg-src/` → `public/base.tcg` (ZIP)
-- **tcg-loader.ts** — unpacks the ZIP and populates CARD_DB, FUSION_RECIPES, etc.
-- **tcg-validator.ts** — checks completeness and consistency of the archive
-- **card-validator.ts** — validates individual card definitions
-- **def-validator.ts** — validates metadata definitions
-- **opp-desc-validator.ts** — validates opponent descriptions
-- **effect-serializer.ts** — parses and serializes effect strings
+The core TCG format library has been extracted to the [`@wynillo/tcg-format`](https://github.com/Wynillo/Echoes-of-Sanguo-TCG) package. It handles loading, validation, and packing of `.tcg` archives with zero game-engine dependencies.
+
+**In this repo** (game-specific glue):
+- **tcg-bridge.ts** — connects `@wynillo/tcg-format` output to game stores (CARD_DB, FUSION_RECIPES, etc.)
+- **tcg-builder.ts** — converts `CardData` → `TcgCard` for packing
+- **effect-serializer.ts** — parses and serializes effect strings (the package treats effects as opaque)
+- **enums.ts** — bidirectional converters between TCG integer IDs and game enums
+- **generate-base-tcg.ts** — thin CLI wrapper calling the package's `packTcgArchive()`
 
 Generate via `npm run generate:tcg` — validates `public/base.tcg-src/` and repacks it.
 
@@ -291,6 +287,7 @@ npm install              # Install dependencies
 npm run dev              # Start dev server (http://localhost:5173)
 npm run build            # Production build → dist/
 npm run generate:tcg     # Generate base.tcg from card source data
+npm run generate:engine-dts  # Generate eos-engine.d.ts for modders
 
 npm test                 # Run tests once
 npm run test:watch       # Run tests in watch mode
@@ -300,4 +297,9 @@ npm run test:e2e         # End-to-end tests (Playwright)
 npm run build:android    # Build + Capacitor sync for Android
 npm run cap:sync         # Sync Capacitor changes
 npm run cap:open         # Open Android Studio
+
+# Local development with @wynillo/tcg-format:
+git clone https://github.com/Wynillo/Echoes-of-Sanguo-TCG.git /tmp/tcg-format
+cd /tmp/tcg-format && npm ci && npm run build && npm link
+cd <this-repo> && npm link @wynillo/tcg-format
 ```

--- a/docs/tcg-format.md
+++ b/docs/tcg-format.md
@@ -1,5 +1,7 @@
 # Echoes of Sanguo — `.tcg` File Format
 
+> **Implementation**: The format library is maintained in the [`@wynillo/tcg-format`](https://github.com/Wynillo/Echoes-of-Sanguo-TCG) package. It handles loading, validation, and packing of `.tcg` archives independently of the game engine.
+
 A `.tcg` file is a **ZIP archive** renamed to `.tcg`. It contains all data needed to run a card set: card definitions, images, localizations, opponents, shop configuration, and an optional campaign graph.
 
 ---
@@ -715,10 +717,12 @@ Everything else is optional and loaded when present.
 
 ## Validation
 
-The engine validates the archive on load and reports errors and warnings to the browser console. Fatal errors (e.g. missing `cards.json`, cards without descriptions) prevent the archive from loading. Warnings (e.g. missing images, unknown fields) are logged but do not block loading.
+Validation logic lives in the [`@wynillo/tcg-format`](https://github.com/Wynillo/Echoes-of-Sanguo-TCG) package. The engine validates the archive on load and reports errors and warnings to the browser console. Fatal errors (e.g. missing `cards.json`, cards without descriptions) prevent the archive from loading. Warnings (e.g. missing images, unknown fields) are logged but do not block loading.
 
 To validate locally before shipping, run:
 
 ```bash
 npm run generate:tcg    # rebuilds public/base.tcg and prints any warnings
 ```
+
+This command calls the package's `packTcgArchive()` function via a thin wrapper (`js/generate-base-tcg.ts`).


### PR DESCRIPTION
Replace stale js/tcg-format/ references with the new architecture:
external @wynillo/tcg-format package, tcg-bridge.ts, and CI/CD npm link workflow.

https://claude.ai/code/session_018wRxvUEAoZm7Cf9w3vH2eY