### PR TITLE
fix(e2e): increase timeouts for app loading in CI

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,9 +2,13 @@ import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests-e2e',
-  timeout: 15_000,
-  retries: 0,
+  timeout: 60_000,
+  retries: process.env.CI ? 1 : 0,
   reporter: 'list',
+
+  expect: {
+    timeout: 15_000,
+  },
 
   use: {
     baseURL: 'http://localhost:5173',

--- a/tests-e2e/game.spec.ts
+++ b/tests-e2e/game.spec.ts
@@ -3,9 +3,9 @@ import { test, expect, Page } from '@playwright/test';
 // Dismiss the press-start screen by pressing a key, then wait for title screen.
 async function passPressStart(page: Page) {
   await page.goto('/');
-  await expect(page.getByText('PRESS ANY KEY')).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByText('PRESS ANY KEY')).toBeVisible();
   await page.keyboard.press('Enter');
-  await expect(page.locator('#title-screen')).toBeVisible({ timeout: 5_000 });
+  await expect(page.locator('#title-screen')).toBeVisible();
 }
 
 // ── Press Start Screen ─────────────────────────────────────
@@ -23,9 +23,9 @@ test.describe('Press Start Screen', () => {
 
   test('navigates to title screen on click', async ({ page }) => {
     await page.goto('/');
-    await expect(page.getByText('PRESS ANY KEY')).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText('PRESS ANY KEY')).toBeVisible();
     await page.locator('body').click();
-    await expect(page.locator('#title-screen')).toBeVisible({ timeout: 5_000 });
+    await expect(page.locator('#title-screen')).toBeVisible();
   });
 });
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,6 +4,9 @@ export default defineConfig({
   plugins: [react()],
   root: '.',
   base: './',
+  optimizeDeps: {
+    include: ['@wynillo/tcg-format'],
+  },
   build: {
     outDir: 'dist',
     chunkSizeWarningLimit: 600,


### PR DESCRIPTION
The app loading sequence (Vite pre-bundling @wynillo/tcg-format, fetching
and decompressing 17MB base.tcg, dynamic imports, React mount) exceeds the
default 5s expect timeout in CI. Raise global expect timeout to 15s, test
timeout to 60s, add CI retry, pre-bundle the linked package at server
startup, and remove redundant inline timeout overrides.

https://claude.ai/code/session_01XxeViVaw9zs2tqQKVDRMe9