### PR TITLE
fix(ci): add @wynillo/tcg-format as GitHub dependency in package.json

### DIFF
--- a/.github/workflows/deploy-hetzner.yml
+++ b/.github/workflows/deploy-hetzner.yml
@@ -22,9 +22,6 @@ jobs:
       - name: Install & Build
         run: |
           npm ci
-          git clone https://github.com/Wynillo/Echoes-of-Sanguo-TCG.git /tmp/tcg-format
-          cd /tmp/tcg-format && npm ci && npm run build && npm link
-          cd ${{ github.workspace }} && npm link @wynillo/tcg-format
           npm run build
 
       - name: Deploy via SCP

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,15 +27,6 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
-      - name: Build and link @wynillo/tcg-format
-        run: |
-          git clone https://github.com/Wynillo/Echoes-of-Sanguo-TCG.git /tmp/tcg-format
-          cd /tmp/tcg-format
-          npm ci
-          npm run build
-          npm link
-          cd ${{ github.workspace }}
-          npm link @wynillo/tcg-format
       - run: npm test
       - run: npm run generate:tcg
       - name: Install Playwright browsers

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,16 +23,6 @@ jobs:
 
       - run: npm ci
 
-      - name: Build and link @wynillo/tcg-format
-        run: |
-          git clone https://github.com/Wynillo/Echoes-of-Sanguo-TCG.git /tmp/tcg-format
-          cd /tmp/tcg-format
-          npm ci
-          npm run build
-          npm link
-          cd ${{ github.workspace }}
-          npm link @wynillo/tcg-format
-
       - run: npm test
 
       - run: npm run build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,15 +181,15 @@ the distributed archive in sync — changes to one must be reflected in the othe
 
 The TCG format library has been extracted to a separate repository: [Wynillo/Echoes-of-Sanguo-TCG](https://github.com/Wynillo/Echoes-of-Sanguo-TCG). It handles loading, validation, and packing of `.tcg` archives with zero game imports.
 
-- **Not in `package.json`** — linked dynamically via `git clone` + `npm link` in CI/CD workflows
-- **Local dev**: Clone the TCG repo, `npm ci && npm run build && npm link`, then `npm link @wynillo/tcg-format` in this repo
+- **In `package.json`** as a GitHub dependency (`"github:Wynillo/Echoes-of-Sanguo-TCG"`) — installed automatically by `npm ci`
+- **Local dev**: Just run `npm install` — the package is fetched from GitHub automatically
 - **Bridge layer**: `js/tcg-bridge.ts` connects the package's pure data output to game stores (`CARD_DB`, `FUSION_RECIPES`, etc.)
 - **Effect strings are opaque** in the package — parsed only by `js/effect-serializer.ts` in this repo
 
 ## CI/CD
 
 GitHub Actions (`.github/workflows/`):
-- `deploy.yml` — Triggers on push to `main`: `npm ci` → link `@wynillo/tcg-format` → `npm test` → `npm run generate:tcg` → E2E tests → `npm run build` → deploy to GitHub Pages (Node.js 22)
+- `deploy.yml` — Triggers on push to `main`: `npm ci` → `npm test` → `npm run generate:tcg` → E2E tests → `npm run build` → deploy to GitHub Pages (Node.js 22)
 - `release.yml` — Triggers on version tags (`v*`): build, generate `eos-engine.d.ts`, create GitHub Release
 - `deploy-hetzner.yml` — Hetzner deployment workflow
 - `summary.yml` — AI issue summarization workflow

--- a/README.md
+++ b/README.md
@@ -298,8 +298,8 @@ npm run build:android    # Build + Capacitor sync for Android
 npm run cap:sync         # Sync Capacitor changes
 npm run cap:open         # Open Android Studio
 
-# Local development with @wynillo/tcg-format:
-git clone https://github.com/Wynillo/Echoes-of-Sanguo-TCG.git /tmp/tcg-format
-cd /tmp/tcg-format && npm ci && npm run build && npm link
-cd <this-repo> && npm link @wynillo/tcg-format
+# @wynillo/tcg-format is installed automatically from GitHub via npm install.
+# To develop against a local clone, use npm link:
+# cd /path/to/Echoes-of-Sanguo-TCG && npm ci && npm run build && npm link
+# cd <this-repo> && npm link @wynillo/tcg-format
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@capacitor/android": "^8.3.0",
         "@capacitor/cli": "^8.3.0",
         "@capacitor/core": "^8.3.0",
+        "@wynillo/tcg-format": "github:Wynillo/Echoes-of-Sanguo-TCG",
         "gsap": "^3.14.2",
         "i18next": "^25.10.10",
         "jszip": "^3.10.1",
@@ -1453,6 +1454,20 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@wynillo/tcg-format": {
+      "version": "1.0.0",
+      "resolved": "git+ssh://git@github.com/Wynillo/Echoes-of-Sanguo-TCG.git#9e0285647645f741927a1f35079839ea0f923d00",
+      "license": "MIT",
+      "dependencies": {
+        "jszip": "^3.10.1"
+      },
+      "bin": {
+        "tcg-format": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@xmldom/xmldom": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "jszip": "^3.10.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-i18next": "^16.6.6"
+    "react-i18next": "^16.6.6",
+    "@wynillo/tcg-format": "github:Wynillo/Echoes-of-Sanguo-TCG"
   }
 }


### PR DESCRIPTION
Replace manual git clone + npm link workflow with a proper GitHub
dependency. This eliminates boilerplate from all 3 CI workflows and
makes local development simpler (just npm install).

https://claude.ai/code/session_011mW7NXQ7P62MKVdsqyypCu