### PR TITLE
fix(ai): stop AI from freezing when player has face-down cards

### DIFF
--- a/js/ai-behaviors.ts
+++ b/js/ai-behaviors.ts
@@ -31,6 +31,8 @@ export const AI_SCORE = {
   BUFF_KILL_THRESHOLD:    1000,
   /** Bonus for surviving when AI is low LP */
   LOW_LP_SURVIVAL:        300,
+  /** Estimated DEF for face-down monsters (AI can't see real stats) */
+  FACEDOWN_DEF_ESTIMATE:  1200,
 } as const;
 
 export const AI_LP_THRESHOLD = {
@@ -39,6 +41,23 @@ export const AI_LP_THRESHOLD = {
   /** LP below which AI activates defensive spells */
   DEFENSIVE: 5000,
 } as const;
+
+// ── Face-Down Stat Helpers (AI cannot see hidden stats) ─
+
+/** Returns estimated combat value for face-down cards, real value otherwise. */
+export function aiCombatValue(fc: FieldCard): number {
+  return fc.faceDown ? AI_SCORE.FACEDOWN_DEF_ESTIMATE : fc.combatValue();
+}
+
+/** Returns 0 for face-down cards (they can't attack), real ATK otherwise. */
+export function aiEffectiveATK(fc: FieldCard): number {
+  return fc.faceDown ? 0 : fc.effectiveATK();
+}
+
+/** Returns estimated DEF for face-down cards, real DEF otherwise. */
+export function aiEffectiveDEF(fc: FieldCard): number {
+  return fc.faceDown ? AI_SCORE.FACEDOWN_DEF_ESTIMATE : fc.effectiveDEF();
+}
 
 // ── Behavior Profiles ───────────────────────────────────────
 
@@ -220,9 +239,9 @@ export interface BoardContext {
 export function pickSmartSummonCandidate(hand: CardData[], ctx: BoardContext): number {
   const playerMonsters = ctx.playerField.filter((fc): fc is FieldCard => fc !== null);
   const playerMaxATK = playerMonsters.reduce((max, fc) =>
-    Math.max(max, fc.position === 'atk' ? fc.effectiveATK() : 0), 0);
+    Math.max(max, fc.position === 'atk' ? aiEffectiveATK(fc) : 0), 0);
   const playerMaxThreat = playerMonsters.reduce((max, fc) =>
-    Math.max(max, fc.effectiveATK()), 0);
+    Math.max(max, aiEffectiveATK(fc)), 0);
 
   let bestIdx = -1;
   let bestScore = -Infinity;
@@ -240,7 +259,7 @@ export function pickSmartSummonCandidate(hand: CardData[], ctx: BoardContext): n
 
     // Can this monster beat any player monster? Big bonus
     for (const pfc of playerMonsters) {
-      const pVal = pfc.combatValue();
+      const pVal = aiCombatValue(pfc);
       if (atk > pVal) score += 300; // can destroy a target
     }
 
@@ -298,7 +317,7 @@ export function findLethal(
     if (!fc) continue;
     defenders.push({
       zone: z,
-      val: fc.combatValue(),
+      val: aiCombatValue(fc),
       inAtk: fc.position === 'atk',
       cantBeAttacked: fc.cantBeAttacked,
     });
@@ -451,7 +470,7 @@ export function planAttacks(
   for (const a of attackers) {
     if (usedAttackers.has(a.zone)) continue;
     for (const d of defenders) {
-      const dVal = d.fc.combatValue();
+      const dVal = aiCombatValue(d.fc);
       const aAtk = a.fc.effectiveATK();
       let score = 0;
 
@@ -463,7 +482,7 @@ export function planAttacks(
         // Prioritize destroying effect monsters (they're dangerous)
         if (d.fc.card.effect) score += 500;
         // Prioritize destroying high-ATK threats
-        score += d.fc.effectiveATK() * 0.5;
+        score += aiEffectiveATK(d.fc) * 0.5;
         // Prefer efficient attacks (don't waste a 3000ATK monster on a 100DEF target)
         score -= (aAtk - dVal) * 0.1;
         // Indestructible monsters can't be destroyed
@@ -506,6 +525,16 @@ export function planAttacks(
     usedDefenders.add(opt.dZone);
   }
 
+  // Remaining attackers go direct if all defenders are covered by the plan
+  const allDefendersCovered = defenders.every(d => usedDefenders.has(d.zone));
+  if (allDefendersCovered) {
+    for (const a of attackers) {
+      if (usedAttackers.has(a.zone)) continue;
+      plans.push({ attackerZone: a.zone, targetZone: -1 });
+      usedAttackers.add(a.zone);
+    }
+  }
+
   // Aggressive: remaining unused attackers attack weakest remaining defender
   if (strategy === 'aggressive') {
     for (const a of attackers) {
@@ -514,7 +543,7 @@ export function planAttacks(
       let weakest: { zone: number; val: number } | null = null;
       for (const d of defenders) {
         if (usedDefenders.has(d.zone)) continue;
-        const dVal = d.fc.combatValue();
+        const dVal = aiCombatValue(d.fc);
         if (!weakest || dVal < weakest.val) weakest = { zone: d.zone, val: dVal };
       }
       if (weakest) {

--- a/js/ai-orchestrator.ts
+++ b/js/ai-orchestrator.ts
@@ -25,6 +25,9 @@ import {
   pickDebuffTarget,
   pickBestGraveyardMonster,
   pickSpellBuffTarget,
+  aiCombatValue,
+  aiEffectiveATK,
+  aiEffectiveDEF,
   type AttackPlan,
 } from './ai-behaviors.js';
 
@@ -153,7 +156,7 @@ async function aiMainPhase(engine: GameEngine): Promise<void> {
       } else {
         const plrMaxATK = plr.field.monsters
           .filter(Boolean)
-          .reduce((max, fc) => Math.max(max, fc!.effectiveATK()), 0);
+          .reduce((max, fc) => Math.max(max, aiEffectiveATK(fc!)), 0);
         const playerHasMonsters = plr.field.monsters.some(Boolean);
         const summonPos = decideSummonPosition(cardATK, cardDEF, plrMaxATK, playerHasMonsters, bh.positionStrategy);
         EchoesOfSanguo.log('SUMMON', `Summoning ${card.name} (ATK:${cardATK}/DEF:${cardDEF}) to zone ${zone} as ${summonPos.toUpperCase()}`);
@@ -432,7 +435,7 @@ export function aiBattlePickTarget(atk: FieldCard, plrMonsters: Array<FieldCard 
     for (let dz = 0; dz < GAME_RULES.fieldZones; dz++) {
       const def = plrMonsters[dz];
       if (!def || def.cantBeAttacked) continue;
-      const defVal = def.combatValue();
+      const defVal = aiCombatValue(def);
       if (atk.effectiveATK() > defVal) {
         // Prefer destroying effect monsters and high-ATK threats
         let score = defVal;
@@ -446,7 +449,7 @@ export function aiBattlePickTarget(atk: FieldCard, plrMonsters: Array<FieldCard 
     for (let dz = 0; dz < GAME_RULES.fieldZones; dz++) {
       const def = plrMonsters[dz];
       if (!def || def.cantBeAttacked) continue;
-      const defVal = def.combatValue();
+      const defVal = aiCombatValue(def);
       if (defVal < weakVal) { weakVal = defVal; weakest = dz; }
     }
     return weakest;
@@ -457,7 +460,7 @@ export function aiBattlePickTarget(atk: FieldCard, plrMonsters: Array<FieldCard 
   for (let dz = 0; dz < GAME_RULES.fieldZones; dz++) {
     const def = plrMonsters[dz];
     if (!def || def.cantBeAttacked) continue;
-    const defVal = def.combatValue();
+    const defVal = aiCombatValue(def);
     if (atk.effectiveATK() > defVal) {
       let score = defVal;
       // Prioritize effect monsters — they're dangerous
@@ -478,7 +481,7 @@ export function aiBattlePickTarget(atk: FieldCard, plrMonsters: Array<FieldCard 
   for (let dz = 0; dz < GAME_RULES.fieldZones; dz++) {
     const def = plrMonsters[dz];
     if (!def || def.cantBeAttacked || def.position !== 'def') continue;
-    const defVal = def.effectiveDEF();
+    const defVal = aiEffectiveDEF(def);
     if (atk.effectiveATK() >= defVal) {
       let score = 1000 - defVal; // prefer weaker DEF (easier kill)
       // Face-down monsters are worth revealing
@@ -499,7 +502,7 @@ function _findSmartFusionChain(
   // Calculate player's strongest monster to know what we need to beat
   const plrMaxATK = plrMonsters
     .filter((fc): fc is FieldCard => fc !== null)
-    .reduce((max, fc) => Math.max(max, fc.effectiveATK()), 0);
+    .reduce((max, fc) => Math.max(max, aiEffectiveATK(fc)), 0);
 
   let bestChain: number[] | null = null;
   let bestScore = -Infinity;

--- a/tests/ai-behaviors.test.js
+++ b/tests/ai-behaviors.test.js
@@ -671,6 +671,38 @@ describe('planAttacks', () => {
     expect(plans.length).toBe(1);
     expect(plans[0].targetZone).toBe(-1); // direct attack for lethal
   });
+
+  it('remaining attackers go direct after all defenders are assigned (face-down bug)', () => {
+    // Bug scenario: AI has 4x 2200 ATK monsters, player has 1 face-down 800 DEF monster.
+    // AI should destroy the face-down card AND direct attack with the remaining 3 monsters.
+    const ai0 = mockFieldCard({ card: { ...mockFieldCard().card, atk: 2200 } });
+    const ai1 = mockFieldCard({ card: { ...mockFieldCard().card, atk: 2200 } });
+    const ai2 = mockFieldCard({ card: { ...mockFieldCard().card, atk: 2200 } });
+    const ai3 = mockFieldCard({ card: { ...mockFieldCard().card, atk: 2200 } });
+    const faceDownDef = mockFieldCard({
+      card: { ...mockFieldCard().card, atk: 800, def: 800 },
+      position: 'def',
+      faceDown: true,
+    });
+
+    const plans = planAttacks(
+      [ai0, ai1, ai2, ai3, null],
+      [faceDownDef, null, null, null, null],
+      8000,
+      smartBehavior,
+    );
+
+    // One attack should target the face-down defender (zone 0)
+    const targetedAttacks = plans.filter(p => p.targetZone === 0);
+    expect(targetedAttacks.length).toBe(1);
+
+    // The remaining 3 attackers should go direct (targetZone -1)
+    const directAttacks = plans.filter(p => p.targetZone === -1);
+    expect(directAttacks.length).toBe(3);
+
+    // Total: 4 attacks planned
+    expect(plans.length).toBe(4);
+  });
 });
 
 // ── pickEquipTarget ─────────────────────────────────────


### PR DESCRIPTION
Two bugs fixed:
1. planAttacks() never scheduled remaining attackers for direct attacks
   after all defenders were assigned — only the "no defenders" path
   triggered direct attacks. Now unused attackers go direct when all
   defenders are covered by the plan.
2. AI read real stats of face-down cards via combatValue()/effectiveATK(),
   giving it perfect information about hidden cards. Added aiCombatValue,
   aiEffectiveATK, aiEffectiveDEF helpers that return estimates (1200 DEF,
   0 ATK) for face-down cards across all AI decision functions.

https://claude.ai/code/session_01RHM31jvQchgUUjKphVDCQz