### PR TITLE
feat(ui): show fusion hints in card detail modal

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -802,6 +802,9 @@ button { cursor: pointer; border: none; font-family: inherit; transition: none; 
 .detail-info h2 { color: var(--gold-light); font-size: 1.125rem; margin-bottom: 6px; text-align: left; }
 .detail-type  { font-size: 0.75rem; color: var(--text-dim); margin-bottom: 8px; }
 .detail-desc  { font-size: 0.75rem; color: var(--text); line-height: 1.5; margin-bottom: 8px; }
+.detail-fusion-hints { font-size: 0.75rem; margin-bottom: 8px; }
+.fusion-hint-label { color: var(--gold-light); font-weight: bold; display: block; margin-bottom: 4px; }
+.fusion-hint-row { color: #cc88ff; margin-left: 8px; line-height: 1.6; }
 .detail-stats { font-size: 0.875rem; font-weight: bold; color: var(--gold); font-family: var(--font-stats); }
 
 /* ── Card description keyword highlights ──────────────────── */

--- a/js/cards.ts
+++ b/js/cards.ts
@@ -2,10 +2,10 @@
 // ECHOES OF SANGUO - Kartendatenbank
 // Runtime data store — populated at startup by loading base.tcg
 // ============================================================
-import type { CardData, FusionRecipe, FusionFormula, OpponentConfig } from './types.js';
+import type { CardData, FusionRecipe, FusionFormula, FusionComboType, OpponentConfig } from './types.js';
 import { CardType, Rarity, isMonsterType } from './types.js';
 import {
-  getRaceByKey, getAttrByKey, getRarityById,
+  getRaceByKey, getAttrByKey, getRarityById, getRaceById, getAttrById,
   TYPE_META,
 } from './type-metadata.js';
 
@@ -214,4 +214,68 @@ export function resolveFusionChain(cardIds: string[]): FusionChainResult {
   }
 
   return { finalCardId: currentId, steps, consumedIds };
+}
+
+// ── Fusion Hints (reverse lookup for card detail) ───────
+
+export interface FusionHint {
+  type: 'formula' | 'recipe';
+  comboType?: FusionComboType;
+  operand1Label?: string;
+  operand2Label?: string;
+  material1?: CardData;
+  material2?: CardData;
+}
+
+/** Return all fusion hints for a given card (how to obtain it). */
+export function getFusionHints(cardId: string): FusionHint[] {
+  const hints: FusionHint[] = [];
+  const seen = new Set<string>();
+
+  // Formula-based hints
+  for (const formula of FUSION_FORMULAS) {
+    if (!formula.resultPool.includes(cardId)) continue;
+
+    let label1: string | undefined;
+    let label2: string | undefined;
+
+    switch (formula.comboType) {
+      case 'race+race':
+        label1 = getRaceById(formula.operand1)?.value;
+        label2 = getRaceById(formula.operand2)?.value;
+        break;
+      case 'race+attr':
+        label1 = getRaceById(formula.operand1)?.value;
+        label2 = getAttrById(formula.operand2)?.value;
+        break;
+      case 'attr+attr':
+        label1 = getAttrById(formula.operand1)?.value;
+        label2 = getAttrById(formula.operand2)?.value;
+        break;
+    }
+
+    if (label1 && label2) {
+      const key = `${formula.comboType}:${label1}+${label2}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        hints.push({ type: 'formula', comboType: formula.comboType, operand1Label: label1, operand2Label: label2 });
+      }
+    }
+  }
+
+  // Explicit recipe hints
+  for (const recipe of FUSION_RECIPES) {
+    if (recipe.result !== cardId) continue;
+    const m1 = CARD_DB[recipe.materials[0]];
+    const m2 = CARD_DB[recipe.materials[1]];
+    if (m1 && m2) {
+      const key = `recipe:${m1.id}+${m2.id}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        hints.push({ type: 'recipe', material1: m1, material2: m2 });
+      }
+    }
+  }
+
+  return hints;
 }

--- a/js/react/modals/CardDetailModal.tsx
+++ b/js/react/modals/CardDetailModal.tsx
@@ -9,6 +9,7 @@ import type { CardData, GameState } from '../../types.js';
 import type { FieldCard } from '../../field.js';
 import type { GameEngine } from '../../engine.js';
 import { getAttrById } from '../../type-metadata.js';
+import { getFusionHints } from '../../cards.js';
 import type { ModalState } from '../contexts/ModalContext.js';
 import type { Selection } from '../contexts/SelectionContext.js';
 
@@ -22,6 +23,8 @@ export function CardDetailModal({ modal }: Props) {
   const { t } = useTranslation();
 
   const game = gameRef.current;
+
+  const fusionHints = card.type === CardType.Fusion ? getFusionHints(card.id) : [];
 
   const attrName = card.attribute ? (getAttrById(card.attribute)?.value ?? '') : '';
   const typeLabels: Record<number, string> = {
@@ -167,6 +170,18 @@ export function CardDetailModal({ modal }: Props) {
           <h2 id="detail-card-name">{card.name}</h2>
           <p className="detail-type">{[attrName, typeLabel].filter(Boolean).join(' · ')}{levelStr}</p>
           <p className="detail-desc">{card.description ? highlightCardText(card.description) : ''}</p>
+          {fusionHints.length > 0 && (
+            <div className="detail-fusion-hints">
+              <span className="fusion-hint-label">{t('card_detail.fusion_hint_label')}</span>
+              {fusionHints.map((h, i) => (
+                <div key={i} className="fusion-hint-row">
+                  {h.type === 'formula'
+                    ? t('card_detail.fusion_hint_combo', { a: h.operand1Label, b: h.operand2Label })
+                    : t('card_detail.fusion_hint_combo', { a: h.material1!.name, b: h.material2!.name })}
+                </div>
+              ))}
+            </div>
+          )}
           <p className="detail-stats">{statsText}</p>
         </div>
       </div>

--- a/locales/de.json
+++ b/locales/de.json
@@ -246,7 +246,9 @@
     "type_spell": "Zauberkarte",
     "type_trap": "Fallenkarte",
     "type_equipment": "Ausrüstung",
-    "atk_bonus": " (+Bonus)"
+    "atk_bonus": " (+Bonus)",
+    "fusion_hint_label": "Fusion:",
+    "fusion_hint_combo": "{{a}} + {{b}}"
   },
   "card_list": {
     "title": "Alle Karten — Echoes of Sanguo",

--- a/locales/en.json
+++ b/locales/en.json
@@ -246,7 +246,9 @@
     "type_spell": "Spell Card",
     "type_trap": "Trap Card",
     "type_equipment": "Equipment",
-    "atk_bonus": " (+Bonus)"
+    "atk_bonus": " (+Bonus)",
+    "fusion_hint_label": "Fusion:",
+    "fusion_hint_combo": "{{a}} + {{b}}"
   },
   "card_list": {
     "title": "All Cards — Echoes of Sanguo",


### PR DESCRIPTION
When viewing a fusion card, display the race/attribute combinations
needed to obtain it, helping players discover fusion recipes.

https://claude.ai/code/session_012UviDkm5ykkQf6fbsP6rfr