### PR TITLE
feat(ui): add opponent stats, win reason, and coin display to duel result screen

### DIFF
--- a/js/engine.ts
+++ b/js/engine.ts
@@ -88,6 +88,10 @@ export class GameEngine {
       turns: 0, monstersPlayed: 0, fusionsPerformed: 0,
       spellsActivated: 0, trapsActivated: 0, cardsDrawn: 0,
       lpRemaining: 0, opponentLpRemaining: 0, deckRemaining: 0, graveyardSize: 0,
+      opponentMonstersPlayed: 0, opponentFusionsPerformed: 0,
+      opponentSpellsActivated: 0, opponentTrapsActivated: 0,
+      opponentDeckRemaining: 0, opponentGraveyardSize: 0,
+      endReason: 'lp_zero',
     };
   }
 
@@ -290,21 +294,25 @@ export class GameEngine {
   checkWin(){
     if(this.state.player.lp <= 0){
       this.addLog('=== DEFEAT ===');
+      this._stats.endReason = 'lp_zero';
       this._endDuel('defeat');
       return true;
     }
     if(this.state.opponent.lp <= 0){
       this.addLog('=== VICTORY ===');
+      this._stats.endReason = 'lp_zero';
       this._endDuel('victory');
       return true;
     }
     if(this.state.player.deck.length === 0 && this.state.phase === 'draw'){
       this.addLog('=== DEFEAT (Deck empty) ===');
+      this._stats.endReason = 'deck_out';
       this._endDuel('defeat');
       return true;
     }
     if(this.state.opponent.deck.length === 0){
       this.addLog('=== VICTORY (Opponent deck empty) ===');
+      this._stats.endReason = 'deck_out';
       this._endDuel('victory');
       return true;
     }
@@ -318,6 +326,8 @@ export class GameEngine {
     this._stats.opponentLpRemaining = this.state.opponent.lp;
     this._stats.deckRemaining = this.state.player.deck.length;
     this._stats.graveyardSize = this.state.player.graveyard.length;
+    this._stats.opponentDeckRemaining = this.state.opponent.deck.length;
+    this._stats.opponentGraveyardSize = this.state.opponent.graveyard.length;
 
     // onDuelEnd allows progression evaluation in the UI layer
     if(typeof this.ui.onDuelEnd === 'function'){
@@ -329,6 +339,7 @@ export class GameEngine {
 
   surrender(): void {
     this.addLog('=== SURRENDER ===');
+    this._stats.endReason = 'surrender';
     this._endDuel('defeat');
   }
 
@@ -369,7 +380,7 @@ export class GameEngine {
     const fc = new FieldCard(card, position, faceDown);
     st.field.monsters[zone] = fc;
     st.normalSummonUsed = true;
-    if (owner === 'player') this._stats.monstersPlayed++;
+    if (owner === 'player') this._stats.monstersPlayed++; else this._stats.opponentMonstersPlayed++;
     const posStr = faceDown ? 'face-down DEF' : position.toUpperCase();
     this.addLog(`${ownerLabel(owner)}: ${card.name} (${posStr}).`);
     this.ui.playSfx?.('sfx_card_play');
@@ -407,7 +418,7 @@ export class GameEngine {
     const fc = new FieldCard(card, 'atk');
     fc.summonedThisTurn = false; // special summons can usually attack (or keep true for balance)
     st.field.monsters[zone] = fc;
-    if (owner === 'player') this._stats.monstersPlayed++;
+    if (owner === 'player') this._stats.monstersPlayed++; else this._stats.opponentMonstersPlayed++;
     this.addLog(`${ownerLabel(owner)}: ${card.name} Special Summon!`);
     this.ui.playSfx?.('sfx_card_play');
     this._recalcFieldSpellBonuses(fc);
@@ -427,7 +438,7 @@ export class GameEngine {
     const fc = new FieldCard(c, 'atk');
     fc.summonedThisTurn = false;
     st.field.monsters[zone] = fc;
-    if (owner === 'player') this._stats.monstersPlayed++;
+    if (owner === 'player') this._stats.monstersPlayed++; else this._stats.opponentMonstersPlayed++;
     this.addLog(`${ownerLabel(owner)}: ${c.name} summoned from graveyard!`);
     this.ui.playSfx?.('sfx_card_play');
     this._recalcFieldSpellBonuses(fc);
@@ -456,7 +467,7 @@ export class GameEngine {
     const card = st.hand[handIndex];
     if(!card || card.type !== CardType.Spell){ this.addLog('Not a spell card!'); return false; }
     st.hand.splice(handIndex, 1);
-    if (owner === 'player') this._stats.spellsActivated++;
+    if (owner === 'player') this._stats.spellsActivated++; else this._stats.opponentSpellsActivated++;
     this.addLog(`${ownerLabel(owner)}: ${card.name} activated!`);
     this.ui.playSfx?.('sfx_spell');
     if(this.ui.showActivation) await this.ui.showActivation(card, card.description);
@@ -474,7 +485,7 @@ export class GameEngine {
     const fst = st.field.spellTraps[zone];
     if(!fst || fst.card.type !== CardType.Spell) return false;
     fst.faceDown = false;
-    if (owner === 'player') this._stats.spellsActivated++;
+    if (owner === 'player') this._stats.spellsActivated++; else this._stats.opponentSpellsActivated++;
     this.addLog(`${ownerLabel(owner)}: ${fst.card.name} activated!`);
     if(this.ui.showActivation) await this.ui.showActivation(fst.card, fst.card.description);
     if(fst.card.effect) {
@@ -493,7 +504,7 @@ export class GameEngine {
     if(!fst || fst.card.type !== CardType.Trap || fst.used) return null;
     fst.used = true;
     fst.faceDown = false;
-    if (owner === 'player') this._stats.trapsActivated++;
+    if (owner === 'player') this._stats.trapsActivated++; else this._stats.opponentTrapsActivated++;
     this.addLog(`${ownerLabel(owner)}: Trap ${fst.card.name} activated!`);
     this.ui.playSfx?.('sfx_trap');
     if(this.ui.showActivation) await this.ui.showActivation(fst.card, fst.card.description);
@@ -591,7 +602,7 @@ export class GameEngine {
     }
 
     st.field.fieldSpell = new FieldSpellTrap(card, false);
-    if (owner === 'player') this._stats.spellsActivated++;
+    if (owner === 'player') this._stats.spellsActivated++; else this._stats.opponentSpellsActivated++;
     this.addLog(`${ownerLabel(owner)}: Field Spell ${card.name} activated!`);
     this.ui.playSfx?.('sfx_spell');
     if (this.ui.showActivation) await this.ui.showActivation(card, card.description);
@@ -686,7 +697,7 @@ export class GameEngine {
     const fusionCardData = CARD_DB[recipe.result];
     if (!fusionCardData) { this.addLog('Fusion result card not found!'); return false; }
 
-    if (owner === 'player') this._stats.fusionsPerformed++;
+    if (owner === 'player') this._stats.fusionsPerformed++; else this._stats.opponentFusionsPerformed++;
     this.addLog(`${ownerLabel(owner)}: FUSION! ${card1.name} + ${card2.name} = ${fusionCardData.name}!`);
     this.ui.playSfx?.('sfx_fusion');
 
@@ -746,7 +757,7 @@ export class GameEngine {
 
     // Build log message showing the chain
     const cardNames = handIndices.map(i => hand[i].name);
-    if (owner === 'player') this._stats.fusionsPerformed++;
+    if (owner === 'player') this._stats.fusionsPerformed++; else this._stats.opponentFusionsPerformed++;
     this.addLog(`${ownerLabel(owner)}: FUSION! ${cardNames.join(' + ')} = ${finalCard.name}!`);
     this.ui.playSfx?.('sfx_fusion');
 

--- a/js/react/contexts/GameContext.tsx
+++ b/js/react/contexts/GameContext.tsx
@@ -281,22 +281,25 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
       }
 
       // Standard (non-campaign) duel flow
-      let coinsEarned = 0;
       if (opponentId) {
         import('../../cards.js').then(({ OPPONENT_CONFIGS }) =>
           import('../../progression.js').then(({ Progression }) => {
             Progression.recordDuelResult(opponentId, result === 'victory');
             const cfg = OPPONENT_CONFIGS.find((o) => o.id === opponentId);
+            let coinsEarned = 0;
             if (cfg) {
               coinsEarned = result === 'victory' ? cfg.coinsWin : 0;
               Progression.addCoins(coinsEarned);
             }
             refreshRef.current();
-            openModalRef.current({ type: 'result', resultType: result, coinsEarned });
+            navigateToRef.current('duel-result', resultData(result, {
+              rewards: coinsEarned > 0 ? { coins: coinsEarned } : undefined,
+              mode: 'free',
+            }));
           })
         ).catch(e => console.error('[GameContext] Failed to apply standard duel result:', e));
       } else {
-        openModalRef.current({ type: 'result', resultType: result, coinsEarned: 0 });
+        navigateToRef.current('duel-result', resultData(result, { mode: 'free' }));
       }
     },
   }), []); // stable — uses refs internally

--- a/js/react/screens/DuelResultScreen.module.css
+++ b/js/react/screens/DuelResultScreen.module.css
@@ -74,9 +74,34 @@
   opacity: 0;
 }
 
+/* ── Win/loss reason ─────────────────────────────────────── */
+.winReason {
+  font-size: 0.5rem;
+  letter-spacing: 1px;
+  color: #c0b090;
+  text-shadow: 1px 1px 4px #000;
+  font-style: italic;
+  margin: 0;
+  opacity: 0;
+}
+
+/* ── Stats columns (player + opponent side by side) ──────── */
+.statsColumns {
+  display: flex;
+  gap: 10px;
+  width: 100%;
+}
+
+@media (max-width: 520px) {
+  .statsColumns {
+    flex-direction: column;
+  }
+}
+
 /* ── Stats panel ─────────────────────────────────────────── */
 .statsPanel {
-  width: 100%;
+  flex: 1;
+  min-width: 0;
   border: 1px solid var(--accent-dim, rgba(212,160,23,0.3));
   border-radius: 4px;
   background: rgba(0,0,0,0.4);
@@ -95,8 +120,8 @@
 
 .statsGrid {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 4px 16px;
+  grid-template-columns: 1fr;
+  gap: 4px 0;
 }
 
 .statRow {

--- a/js/react/screens/DuelResultScreen.tsx
+++ b/js/react/screens/DuelResultScreen.tsx
@@ -7,7 +7,7 @@ import type { DuelStats } from '../../types.js';
 import styles from './DuelResultScreen.module.css';
 
 const PARTICLE_COUNT = 22;
-const ANIM_LOCK_MS = 2500;
+const ANIM_LOCK_MS = 3200;
 
 interface Rewards {
   coins?: number;
@@ -22,13 +22,16 @@ export default function DuelResultScreen() {
   const victory = result === 'victory';
   const stats = screenData?.stats as DuelStats | undefined;
   const rewards = screenData?.rewards as Rewards | undefined;
+  const mode = screenData?.mode as 'campaign' | 'free' | undefined;
 
   const [locked, setLocked] = useState(true);
   const contentRef = useRef<HTMLDivElement>(null);
   const titleRef = useRef<HTMLHeadingElement>(null);
   const sepRef = useRef<HTMLDivElement>(null);
   const msgRef = useRef<HTMLParagraphElement>(null);
+  const reasonRef = useRef<HTMLParagraphElement>(null);
   const statsPanelRef = useRef<HTMLDivElement>(null);
+  const oppStatsPanelRef = useRef<HTMLDivElement>(null);
   const rewardsRef = useRef<HTMLDivElement>(null);
   const continueRef = useRef<HTMLParagraphElement>(null);
 
@@ -53,6 +56,10 @@ export default function DuelResultScreen() {
 
   function proceed() {
     if (locked) return;
+    if (mode === 'free') {
+      navigateTo('opponent');
+      return;
+    }
     if (victory) {
       const next = screenData?.nextScreen as string | undefined;
       if (next === 'dialogue') {
@@ -96,13 +103,31 @@ export default function DuelResultScreen() {
       }, 0.8);
     }
 
-    // Stats panel
+    // Win/loss reason
+    if (reasonRef.current) {
+      gsap.set(reasonRef.current, { y: 8, opacity: 0 });
+      tl.to(reasonRef.current, {
+        y: 0, opacity: 1, duration: 0.35,
+        ease: 'power2.out',
+      }, 1.0);
+    }
+
+    // Stats panel (player)
     if (statsPanelRef.current) {
       gsap.set(statsPanelRef.current, { y: 20, opacity: 0 });
       tl.to(statsPanelRef.current, {
         y: 0, opacity: 1, duration: 0.45,
         ease: 'power2.out',
-      }, 1.0);
+      }, 1.2);
+    }
+
+    // Stats panel (opponent)
+    if (oppStatsPanelRef.current) {
+      gsap.set(oppStatsPanelRef.current, { y: 20, opacity: 0 });
+      tl.to(oppStatsPanelRef.current, {
+        y: 0, opacity: 1, duration: 0.45,
+        ease: 'power2.out',
+      }, 1.4);
     }
 
     // Rewards (victory only)
@@ -114,7 +139,7 @@ export default function DuelResultScreen() {
         onStart: () => {
           if (victory && rewards?.coins) Audio.playSfx('sfx_coin');
         },
-      }, 1.5);
+      }, 1.8);
     }
 
     // Continue prompt
@@ -123,7 +148,7 @@ export default function DuelResultScreen() {
       tl.to(continueRef.current, {
         opacity: 1, duration: 0.3,
         ease: 'none',
-      }, 2.0);
+      }, 2.5);
     }
 
     // Unlock input after animation
@@ -143,6 +168,15 @@ export default function DuelResultScreen() {
 
   const hasRewards = victory && rewards && ((rewards.coins ?? 0) > 0 || (rewards.cards?.length ?? 0) > 0);
 
+  // Win/loss reason text
+  const reasonKey = stats?.endReason
+    ? victory
+      ? (stats.endReason === 'deck_out' ? 'duelResult.win_reason_deckout' : 'duelResult.win_reason_lp')
+      : (stats.endReason === 'surrender' ? 'duelResult.loss_reason_surrender'
+         : stats.endReason === 'deck_out' ? 'duelResult.loss_reason_deckout'
+         : 'duelResult.loss_reason_lp')
+    : null;
+
   const statRows = stats
     ? [
         { label: t('duelResult.stat_turns'),    value: stats.turns },
@@ -152,6 +186,16 @@ export default function DuelResultScreen() {
         { label: t('duelResult.stat_traps'),    value: stats.trapsActivated },
         { label: t('duelResult.stat_deck'),     value: stats.deckRemaining },
         { label: t('duelResult.stat_lp'),       value: stats.lpRemaining },
+      ]
+    : [];
+
+  const opponentStatRows = stats
+    ? [
+        { label: t('duelResult.opp_stat_lp'),       value: stats.opponentLpRemaining },
+        { label: t('duelResult.opp_stat_monsters'),  value: stats.opponentMonstersPlayed },
+        { label: t('duelResult.opp_stat_fusions'),   value: stats.opponentFusionsPerformed },
+        { label: t('duelResult.opp_stat_spells'),    value: stats.opponentSpellsActivated },
+        { label: t('duelResult.opp_stat_traps'),     value: stats.opponentTrapsActivated },
       ]
     : [];
 
@@ -193,17 +237,40 @@ export default function DuelResultScreen() {
           {victory ? t('duelResult.victory_message') : t('duelResult.defeat_message')}
         </p>
 
-        {/* Duel stats */}
+        {/* Win/loss reason */}
+        {reasonKey && (
+          <p ref={reasonRef} className={styles.winReason}>
+            {t(reasonKey)}
+          </p>
+        )}
+
+        {/* Stats columns: player + opponent */}
         {stats && (
-          <div ref={statsPanelRef} className={styles.statsPanel}>
-            <div className={styles.statsTitle}>{t('duelResult.stats_title')}</div>
-            <div className={styles.statsGrid}>
-              {statRows.map((row) => (
-                <div key={row.label} className={styles.statRow}>
-                  <span className={styles.statLabel}>{row.label}</span>
-                  <span className={styles.statValue}>{row.value}</span>
-                </div>
-              ))}
+          <div className={styles.statsColumns}>
+            {/* Player stats */}
+            <div ref={statsPanelRef} className={styles.statsPanel}>
+              <div className={styles.statsTitle}>{t('duelResult.player_stats_title')}</div>
+              <div className={styles.statsGrid}>
+                {statRows.map((row) => (
+                  <div key={row.label} className={styles.statRow}>
+                    <span className={styles.statLabel}>{row.label}</span>
+                    <span className={styles.statValue}>{row.value}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            {/* Opponent stats */}
+            <div ref={oppStatsPanelRef} className={styles.statsPanel}>
+              <div className={styles.statsTitle}>{t('duelResult.opponent_stats_title')}</div>
+              <div className={styles.statsGrid}>
+                {opponentStatRows.map((row) => (
+                  <div key={row.label} className={styles.statRow}>
+                    <span className={styles.statLabel}>{row.label}</span>
+                    <span className={styles.statValue}>{row.value}</span>
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
         )}

--- a/js/types.ts
+++ b/js/types.ts
@@ -330,6 +330,13 @@ export interface DuelStats {
   opponentLpRemaining: number;
   deckRemaining:    number;
   graveyardSize:    number;
+  opponentMonstersPlayed:   number;
+  opponentFusionsPerformed: number;
+  opponentSpellsActivated:  number;
+  opponentTrapsActivated:   number;
+  opponentDeckRemaining:    number;
+  opponentGraveyardSize:    number;
+  endReason: 'lp_zero' | 'deck_out' | 'surrender';
 }
 
 // ── UI callbacks ─────────────────────────────────────────────

--- a/locales/de.json
+++ b/locales/de.json
@@ -367,12 +367,24 @@
     "cards_earned": "+{{count}} Karte(n) erhalten",
     "new_unlock": "Neuer Pfad freigeschaltet!",
     "stats_title": "Duell-Zusammenfassung",
+    "player_stats_title": "Deine Statistik",
+    "opponent_stats_title": "Gegner-Statistik",
     "stat_turns": "Runden",
     "stat_monsters": "Monster beschworen",
     "stat_fusions": "Fusionen",
     "stat_spells": "Zauber eingesetzt",
     "stat_traps": "Fallen eingesetzt",
     "stat_deck": "Karten im Deck",
-    "stat_lp": "LP verbleibend"
+    "stat_lp": "LP verbleibend",
+    "opp_stat_lp": "LP verbleibend",
+    "opp_stat_monsters": "Monster beschworen",
+    "opp_stat_fusions": "Fusionen",
+    "opp_stat_spells": "Zauber eingesetzt",
+    "opp_stat_traps": "Fallen eingesetzt",
+    "win_reason_lp": "Gegners Lebenspunkte wurden auf 0 reduziert.",
+    "win_reason_deckout": "Gegners Deck hatte keine Karten mehr.",
+    "loss_reason_lp": "Deine Lebenspunkte wurden auf 0 reduziert.",
+    "loss_reason_deckout": "Dein Deck hatte keine Karten mehr.",
+    "loss_reason_surrender": "Du hast aufgegeben."
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -367,12 +367,24 @@
     "cards_earned": "+{{count}} Card(s) Obtained",
     "new_unlock": "New path unlocked!",
     "stats_title": "Duel Summary",
+    "player_stats_title": "Your Stats",
+    "opponent_stats_title": "Opponent Stats",
     "stat_turns": "Turns",
     "stat_monsters": "Monsters Summoned",
     "stat_fusions": "Fusions",
     "stat_spells": "Spells Used",
     "stat_traps": "Traps Used",
     "stat_deck": "Cards in Deck",
-    "stat_lp": "LP Remaining"
+    "stat_lp": "LP Remaining",
+    "opp_stat_lp": "LP Remaining",
+    "opp_stat_monsters": "Monsters Summoned",
+    "opp_stat_fusions": "Fusions",
+    "opp_stat_spells": "Spells Used",
+    "opp_stat_traps": "Traps Used",
+    "win_reason_lp": "Opponent's life points were reduced to 0.",
+    "win_reason_deckout": "Opponent's deck ran out of cards.",
+    "loss_reason_lp": "Your life points were reduced to 0.",
+    "loss_reason_deckout": "Your deck ran out of cards.",
+    "loss_reason_surrender": "You surrendered."
   }
 }


### PR DESCRIPTION
The victory/defeat screen now shows why the duel ended (LP reduced to 0,
deck out, surrender), opponent stats (LP, monsters, fusions, spells, traps),
and coins earned. Non-campaign duels also route to the full result screen
instead of the minimal modal.

https://claude.ai/code/session_01X74UtjS6WfNxJgtqukeCnH