### PR TITLE
feat(ui): redesign booster pack shop with grid layout and info modal

### DIFF
--- a/js/react/screens/ShopScreen.module.css
+++ b/js/react/screens/ShopScreen.module.css
@@ -6,7 +6,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 20px 16px 40px;
+  padding: 12px 12px 24px;
   overflow-y: auto;
 }
 
@@ -26,15 +26,15 @@
   justify-content: space-between;
   width: 100%;
   max-width: 900px;
-  margin-bottom: 16px;
+  margin-bottom: 10px;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: 8px;
   position: relative;
   z-index: 1;
 }
 
 .shopTitle {
-  font-size: clamp(1.3rem, 3vw, 2rem);
+  font-size: clamp(1.1rem, 3vw, 1.6rem);
   letter-spacing: 3px;
   color: #c8a84b;
   text-shadow: 2px 2px 0 #000;
@@ -56,14 +56,14 @@
 
 .backBtn { font-size: 0.85rem; }
 
-/* ── Tabs ── */
+/* -- Tabs -- */
 
 .tabs {
   display: flex;
   gap: 0;
   max-width: 900px;
   width: 100%;
-  margin-bottom: 18px;
+  margin-bottom: 12px;
   position: relative;
   z-index: 1;
 }
@@ -91,127 +91,172 @@
   border-color: #c8a84b;
 }
 
-/* ── Carousel ── */
+/* -- Pack Grid -- */
 
-.carousel {
+.packGrid {
   position: relative;
   z-index: 1;
   width: 100%;
   max-width: 900px;
-  display: flex;
-  align-items: center;
-  gap: 8px;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 10px;
   flex: 1;
   min-height: 0;
+  align-content: start;
 }
 
-.carouselTrack {
-  display: flex;
-  gap: 14px;
-  flex: 1;
-  justify-content: center;
-  min-height: 0;
+@media (min-width: 480px) {
+  .packGrid {
+    grid-template-columns: repeat(3, 1fr);
+    gap: 12px;
+  }
 }
 
-.arrowBtn {
-  flex-shrink: 0;
-  width: 36px;
-  height: 36px;
-  background: #111828;
-  border: 2px solid #334;
-  border-radius: 0;
-  color: #c8a84b;
-  font-size: 1.4rem;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: background 0.15s, color 0.15s;
-  z-index: 2;
+@media (min-width: 720px) {
+  .packGrid {
+    grid-template-columns: repeat(4, 1fr);
+    gap: 14px;
+  }
 }
 
-.arrowBtn:hover:not(:disabled) {
-  background: #1a2840;
-  color: #f0d080;
-}
-
-.arrowBtn:disabled {
-  opacity: 0.25;
-  cursor: not-allowed;
-}
-
-/* ── Dots ── */
-
-.dots {
-  display: flex;
-  gap: 8px;
-  justify-content: center;
-  margin-top: 14px;
-  position: relative;
-  z-index: 1;
-}
-
-.dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  border: 1px solid #556;
-  background: #334;
-  cursor: pointer;
-  padding: 0;
-  transition: background 0.2s, border-color 0.2s;
-}
-
-.dot:hover { border-color: #c8a84b; }
-
-.dotActive {
-  background: #c8a84b;
-  border-color: #c8a84b;
-}
-
-/* ── Pack Tile ── */
+/* -- Pack Tile (Booster Pack Style) -- */
 
 .packTile {
-  background: #111828;
-  border: 2px solid #334;
-  border-radius: 0;
-  padding: 16px 12px;
+  aspect-ratio: 2 / 3;
+  background: linear-gradient(
+    170deg,
+    color-mix(in srgb, var(--pack-color, #4060c0) 18%, #111828) 0%,
+    #0c1220 50%,
+    color-mix(in srgb, var(--pack-color, #4060c0) 12%, #0a0e1a) 100%
+  );
+  border: 2px solid color-mix(in srgb, var(--pack-color, #4060c0) 40%, #334);
+  border-radius: 4px;
+  padding: 8px 6px;
   text-align: center;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 8px;
+  justify-content: space-between;
   position: relative;
   overflow: hidden;
-  width: 100%;
-  max-width: 280px;
+  transition: border-color 0.2s, box-shadow 0.2s;
 }
 
 .packTile::before {
   content: '';
   position: absolute;
   inset: 0;
-  background: var(--pack-color, #4060c0);
-  opacity: 0.06;
+  background: radial-gradient(
+    ellipse at 50% 20%,
+    color-mix(in srgb, var(--pack-color, #4060c0) 20%, transparent) 0%,
+    transparent 70%
+  );
+  pointer-events: none;
 }
-
-.packTile:hover::before { opacity: 0.12; }
 
 .packTile:hover {
   border-color: var(--pack-color, #4060c0);
+  box-shadow: 0 0 12px color-mix(in srgb, var(--pack-color, #4060c0) 30%, transparent);
 }
 
 .packDisabled {
-  opacity: 0.5;
-  cursor: not-allowed;
+  opacity: 0.45;
+  pointer-events: none;
 }
 
-.packIcon { font-size: 2.5rem; position: relative; }
-.packName { font-size: 0.9rem; font-weight: bold; color: #c0d0e0; position: relative; }
-.packDesc { font-size: 0.72rem; color: #606880; position: relative; }
-.packPrice { font-size: 1rem; color: #c8a84b; font-weight: bold; position: relative; font-family: var(--font-stats); }
+/* -- Info (?) Button -- */
 
-.raceSelectWrap { width: 100%; position: relative; }
+.infoBtn {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 1.5px solid color-mix(in srgb, var(--pack-color, #4060c0) 60%, #667);
+  background: rgba(0, 0, 0, 0.5);
+  color: #c0d0e0;
+  font-size: 0.65rem;
+  font-weight: bold;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 3;
+  transition: background 0.15s, color 0.15s;
+  padding: 0;
+  line-height: 1;
+  pointer-events: auto;
+}
+
+.infoBtn:hover {
+  background: var(--pack-color, #4060c0);
+  color: #fff;
+}
+
+/* -- Pack Content Area -- */
+
+.packTop {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  position: relative;
+  min-height: 0;
+}
+
+.packIcon {
+  font-size: clamp(1.8rem, 5vw, 2.8rem);
+  position: relative;
+  filter: drop-shadow(0 2px 4px rgba(0,0,0,0.5));
+}
+
+.packName {
+  font-size: clamp(0.55rem, 1.8vw, 0.8rem);
+  font-weight: bold;
+  color: #c0d0e0;
+  position: relative;
+  line-height: 1.2;
+  text-shadow: 1px 1px 0 #000;
+}
+
+.packCardCount {
+  font-size: clamp(0.45rem, 1.4vw, 0.65rem);
+  color: #606880;
+  position: relative;
+}
+
+.packDesc {
+  font-size: clamp(0.45rem, 1.4vw, 0.65rem);
+  color: #606880;
+  position: relative;
+}
+
+/* -- Pack Bottom Area -- */
+
+.packBottom {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  position: relative;
+}
+
+.packPrice {
+  font-size: clamp(0.65rem, 1.8vw, 0.85rem);
+  color: #c8a84b;
+  font-weight: bold;
+  font-family: var(--font-stats);
+}
+
+.raceSelectWrap {
+  width: 100%;
+  position: relative;
+}
 
 .raceSelect {
   width: 100%;
@@ -219,8 +264,8 @@
   border: 1px solid #334;
   color: #c0d0e0;
   border-radius: 0;
-  padding: 4px 6px;
-  font-size: 0.8rem;
+  padding: 2px 4px;
+  font-size: clamp(0.5rem, 1.4vw, 0.7rem);
   cursor: pointer;
 }
 
@@ -229,9 +274,9 @@
   border: 2px solid;
   border-color: #30a060 #0a2c18 #0a2c18 #30a060;
   color: var(--pack-color, #90b0e0);
-  padding: 7px 16px;
+  padding: 4px 8px;
   border-radius: 0;
-  font-size: 0.85rem;
+  font-size: clamp(0.55rem, 1.6vw, 0.75rem);
   cursor: pointer;
   position: relative;
   width: 100%;
@@ -245,12 +290,151 @@
 .buyBtn:disabled { opacity: 0.4; cursor: not-allowed; }
 
 .packLocked {
-  font-size: 0.75rem;
+  font-size: clamp(0.5rem, 1.4vw, 0.7rem);
   color: #e06040;
   position: relative;
 }
 
-/* ── Section title (kept for potential fallback) ── */
+/* -- Info Modal Overlay -- */
+
+.infoOverlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.75);
+  z-index: 300;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+}
+
+.infoModal {
+  background: #111828;
+  border: 2px solid #c8a84b;
+  border-radius: 4px;
+  max-width: 420px;
+  width: 100%;
+  max-height: 80vh;
+  overflow-y: auto;
+  padding: 16px;
+  position: relative;
+}
+
+.infoModalHeader {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 12px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid #334;
+}
+
+.infoModalIcon {
+  font-size: 1.8rem;
+}
+
+.infoModalTitle {
+  font-size: 0.95rem;
+  font-weight: bold;
+  color: #c0d0e0;
+  margin: 0;
+}
+
+.infoModalDesc {
+  font-size: 0.7rem;
+  color: #606880;
+  margin-top: 2px;
+}
+
+.infoSection {
+  margin-bottom: 14px;
+}
+
+.infoSectionTitle {
+  font-size: 0.72rem;
+  color: #c8a84b;
+  letter-spacing: 1px;
+  margin-bottom: 6px;
+  text-transform: uppercase;
+}
+
+.rarityRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 0;
+  border-bottom: 1px solid #1a2030;
+  font-size: 0.72rem;
+}
+
+.rarityLabel {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: #c0d0e0;
+}
+
+.rarityDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.rarityInfo {
+  color: #8090a0;
+  font-family: var(--font-stats);
+  text-align: right;
+}
+
+.poolSection {
+  margin-top: 8px;
+}
+
+.poolRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 3px 0;
+  font-size: 0.68rem;
+}
+
+.poolLabel {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: #8090a0;
+}
+
+.poolCount {
+  color: #c0d0e0;
+  font-family: var(--font-stats);
+}
+
+.raceNote {
+  font-size: 0.65rem;
+  color: #a06020;
+  font-style: italic;
+  margin-top: 6px;
+}
+
+.infoCloseBtn {
+  width: 100%;
+  background: #0d1830;
+  border: 2px solid;
+  border-color: #c8a84b #504020 #504020 #c8a84b;
+  color: #c8a84b;
+  padding: 8px;
+  font-size: 0.8rem;
+  cursor: pointer;
+  margin-top: 8px;
+}
+
+.infoCloseBtn:hover {
+  background: #1a2840;
+}
+
+/* -- Legacy compat (kept for potential reuse) -- */
 
 .sectionTitle {
   font-size: clamp(1rem, 2.5vw, 1.4rem);

--- a/js/react/screens/ShopScreen.tsx
+++ b/js/react/screens/ShopScreen.tsx
@@ -1,30 +1,69 @@
-import { useState, useRef, useCallback, useEffect } from 'react';
+import { useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useScreen }      from '../contexts/ScreenContext.js';
 import { useProgression } from '../contexts/ProgressionContext.js';
 import { useCampaign }    from '../contexts/CampaignContext.js';
 import { Progression }    from '../../progression.js';
-import { getAllRaces, getRaceByKey } from '../../type-metadata.js';
-import { PACK_TYPES, openPack, openPackage, isPackageUnlocked } from '../utils/pack-logic.js';
+import { getAllRaces, getRaceByKey, getRarityById } from '../../type-metadata.js';
+import { PACK_TYPES, openPack, openPackage, isPackageUnlocked, buildCardPool } from '../utils/pack-logic.js';
 import type { PackTypeInfo } from '../utils/pack-logic.js';
 import { SHOP_DATA } from '../../shop-data.js';
-import type { PackageDef } from '../../shop-data.js';
+import type { PackDef, PackageDef, PackSlotDef } from '../../shop-data.js';
 import { Audio }               from '../../audio.js';
-import { Race } from '../../types.js';
+import { Rarity, Race } from '../../types.js';
 import type { CardData } from '../../types.js';
 import styles from './ShopScreen.module.css';
 
 type Tab = 'standard' | 'packages';
 
-function useItemsPerPage() {
-  const [ipp, setIpp] = useState(() => window.matchMedia('(min-width: 700px)').matches ? 2 : 1);
-  useEffect(() => {
-    const mq = window.matchMedia('(min-width: 700px)');
-    const handler = (e: MediaQueryListEvent) => setIpp(e.matches ? 2 : 1);
-    mq.addEventListener('change', handler);
-    return () => mq.removeEventListener('change', handler);
-  }, []);
-  return ipp;
+/** Compute total card count from slots. */
+function totalCards(slots: PackSlotDef[]): number {
+  return slots.reduce((sum, s) => sum + s.count, 0);
+}
+
+/**
+ * Compute rarity distribution summary from pack slots.
+ * `guaranteed` = number of fixed slots for that rarity.
+ * `chancePct` = combined probability (0-100) of getting that rarity
+ *               from all distribution-based bonus slots.
+ */
+function computeDistribution(slots: PackSlotDef[]): { rarity: number; guaranteed: number; chancePct: number }[] {
+  const map = new Map<number, { guaranteed: number; chancePct: number }>();
+
+  for (const slot of slots) {
+    if (slot.distribution) {
+      // Each distribution slot picks one rarity per card.
+      // Show per-card probability (all distribution slots share the same distribution).
+      for (const [rarityStr, prob] of Object.entries(slot.distribution)) {
+        const r = Number(rarityStr);
+        const entry = map.get(r) ?? { guaranteed: 0, chancePct: 0 };
+        // prob is per-card; show it as percentage
+        entry.chancePct = Math.round(prob * 100);
+        map.set(r, entry);
+      }
+    } else {
+      const r = slot.rarity ?? Rarity.Common;
+      const entry = map.get(r) ?? { guaranteed: 0, chancePct: 0 };
+      entry.guaranteed += slot.count;
+      map.set(r, entry);
+    }
+  }
+
+  return Array.from(map.entries())
+    .map(([rarity, data]) => ({ rarity, ...data }))
+    .sort((a, b) => a.rarity - b.rarity);
+}
+
+/** Group cards by rarity and count. */
+function countByRarity(cards: CardData[]): { rarity: number; count: number }[] {
+  const map = new Map<number, number>();
+  for (const c of cards) {
+    const r = c.rarity ?? Rarity.Common;
+    map.set(r, (map.get(r) ?? 0) + 1);
+  }
+  return Array.from(map.entries())
+    .map(([rarity, count]) => ({ rarity, count }))
+    .sort((a, b) => a.rarity - b.rarity);
 }
 
 export default function ShopScreen() {
@@ -36,39 +75,10 @@ export default function ShopScreen() {
 
   const hasPackages = SHOP_DATA.packages.length > 0;
   const [activeTab, setActiveTab] = useState<Tab>('standard');
-  const [page, setPage] = useState(0);
-  const itemsPerPage = useItemsPerPage();
-
-  // Touch swipe tracking
-  const touchStartX = useRef(0);
-  const touchStartY = useRef(0);
+  const [infoTarget, setInfoTarget] = useState<{ pack: PackDef; type: 'pack' } | { pack: PackageDef; type: 'package' } | null>(null);
 
   const packs = Object.values(PACK_TYPES);
   const packages = SHOP_DATA.packages;
-  const items = activeTab === 'standard' ? packs : packages;
-  const totalPages = Math.ceil(items.length / itemsPerPage);
-
-  // Reset page when switching tabs or when items per page changes
-  useEffect(() => { setPage(0); }, [activeTab, itemsPerPage]);
-
-  const goPage = useCallback((p: number) => {
-    setPage(Math.max(0, Math.min(p, totalPages - 1)));
-  }, [totalPages]);
-
-  const onTouchStart = useCallback((e: React.TouchEvent) => {
-    touchStartX.current = e.touches[0].clientX;
-    touchStartY.current = e.touches[0].clientY;
-  }, []);
-
-  const onTouchEnd = useCallback((e: React.TouchEvent) => {
-    const dx = e.changedTouches[0].clientX - touchStartX.current;
-    const dy = e.changedTouches[0].clientY - touchStartY.current;
-    // Only trigger swipe if horizontal movement > vertical and > 50px threshold
-    if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > 50) {
-      if (dx < 0) goPage(page + 1);
-      else goPage(page - 1);
-    }
-  }, [goPage, page]);
 
   function buyPackage(packageId: string) {
     const pkg = SHOP_DATA.packages.find(p => p.id === packageId);
@@ -94,9 +104,9 @@ export default function ShopScreen() {
     navigateTo('pack-opening', { cards, preOpen });
   }
 
-  // Slice items for current page
-  const startIdx = page * itemsPerPage;
-  const visibleItems = items.slice(startIdx, startIdx + itemsPerPage);
+  function showInfo(pack: PackDef | PackageDef, type: 'pack' | 'package') {
+    setInfoTarget({ pack: pack as any, type });
+  }
 
   return (
     <div className={styles.screen}>
@@ -127,97 +137,63 @@ export default function ShopScreen() {
         </div>
       )}
 
-      {/* Carousel */}
-      <div className={styles.carousel} onTouchStart={onTouchStart} onTouchEnd={onTouchEnd}>
-        {/* Arrow left */}
-        {totalPages > 1 && (
-          <button
-            className={`${styles.arrowBtn} ${styles.arrowLeft}`}
-            disabled={page === 0}
-            onClick={() => goPage(page - 1)}
-            aria-label="Previous"
-          >‹</button>
-        )}
-
-        <div className={styles.carouselTrack}>
-          {activeTab === 'standard'
-            ? (visibleItems as PackTypeInfo[]).map(pt => {
-                const affordable = coins >= pt.price;
-                return <PackTile key={pt.id} pt={pt} affordable={affordable} onBuy={buy} />;
-              })
-            : (visibleItems as PackageDef[]).map(pkg => {
-                const unlocked = isPackageUnlocked(pkg);
-                const affordable = coins >= pkg.price;
-                return <PackageTile key={pkg.id} pkg={pkg} unlocked={unlocked} affordable={affordable} onBuy={buyPackage} />;
-              })
-          }
-        </div>
-
-        {/* Arrow right */}
-        {totalPages > 1 && (
-          <button
-            className={`${styles.arrowBtn} ${styles.arrowRight}`}
-            disabled={page >= totalPages - 1}
-            onClick={() => goPage(page + 1)}
-            aria-label="Next"
-          >›</button>
-        )}
+      {/* Pack Grid */}
+      <div className={styles.packGrid}>
+        {activeTab === 'standard'
+          ? packs.map(pt => {
+              const packDef = SHOP_DATA.packs.find(p => p.id === pt.id)!;
+              const affordable = coins >= pt.price;
+              return (
+                <PackTile
+                  key={pt.id}
+                  pt={pt}
+                  packDef={packDef}
+                  affordable={affordable}
+                  onBuy={buy}
+                  onInfo={() => showInfo(packDef, 'pack')}
+                />
+              );
+            })
+          : packages.map(pkg => {
+              const unlocked = isPackageUnlocked(pkg);
+              const affordable = coins >= pkg.price;
+              return (
+                <PackageTile
+                  key={pkg.id}
+                  pkg={pkg}
+                  unlocked={unlocked}
+                  affordable={affordable}
+                  onBuy={buyPackage}
+                  onInfo={() => showInfo(pkg, 'package')}
+                />
+              );
+            })
+        }
       </div>
 
-      {/* Dots */}
-      {totalPages > 1 && (
-        <div className={styles.dots}>
-          {Array.from({ length: totalPages }, (_, i) => (
-            <button
-              key={i}
-              className={`${styles.dot}${i === page ? ` ${styles.dotActive}` : ''}`}
-              onClick={() => goPage(i)}
-              aria-label={`Page ${i + 1}`}
-            />
-          ))}
-        </div>
+      {/* Info Modal */}
+      {infoTarget && (
+        <PackInfoModal
+          pack={infoTarget.pack}
+          type={infoTarget.type}
+          onClose={() => setInfoTarget(null)}
+        />
       )}
     </div>
   );
 }
+
+// ── Pack Tile ──────────────────────────────────────────────
 
 interface PackTileProps {
   pt: PackTypeInfo;
+  packDef: PackDef;
   affordable: boolean;
   onBuy: (packType: string, race: string | null) => void;
+  onInfo: () => void;
 }
 
-interface PackageTileProps {
-  pkg: PackageDef;
-  unlocked: boolean;
-  affordable: boolean;
-  onBuy: (packageId: string) => void;
-}
-
-function PackageTile({ pkg, unlocked, affordable, onBuy }: PackageTileProps) {
-  const { t } = useTranslation();
-  const canBuy = unlocked && affordable;
-
-  return (
-    <div
-      className={`${styles.packTile}${canBuy ? '' : ` ${styles.packDisabled}`}`}
-      style={{ '--pack-color': pkg.color } as React.CSSProperties}
-    >
-      <div className={styles.packIcon}>{pkg.icon}</div>
-      <div className={styles.packName}>{pkg.name}</div>
-      <div className={styles.packDesc}>{pkg.desc}</div>
-      <div className={styles.packPrice}>◈ {pkg.price.toLocaleString()}</div>
-      {!unlocked && (
-        <div className={styles.packLocked}>{t('shop.locked')}</div>
-      )}
-      <button className={styles.buyBtn} disabled={!canBuy} onClick={() => onBuy(pkg.id)}>
-        {t('shop.buy_btn')}
-      </button>
-    </div>
-  );
-}
-
-function PackTile({ pt, affordable, onBuy }: PackTileProps) {
+function PackTile({ pt, packDef, affordable, onBuy, onInfo }: PackTileProps) {
   const { t } = useTranslation();
   const starterRace = Progression.getStarterRace() || '';
   const raceKeys = getAllRaces().map(r => r.key);
@@ -236,20 +212,154 @@ function PackTile({ pt, affordable, onBuy }: PackTileProps) {
       className={`${styles.packTile}${affordable ? '' : ` ${styles.packDisabled}`}`}
       style={{ '--pack-color': pt.color } as React.CSSProperties}
     >
-      <div className={styles.packIcon}>{pt.icon}</div>
-      <div className={styles.packName}>{t(`pack.${pt.id}_name`)}</div>
-      <div className={styles.packDesc}>{t(`pack.${pt.id}_desc`)}</div>
-      <div className={styles.packPrice}>◈ {pt.price.toLocaleString()}</div>
-      {pt.id === 'race' && (
-        <div className={styles.raceSelectWrap}>
-          <select id={`shop-race-select-${pt.id}`} className={styles.raceSelect} defaultValue={starterRace}>
-            {raceKeys.map(k => (
-              <option key={k} value={k}>{getRaceByKey(k)?.icon ?? ''} {t(`cards.race_${k}`)}</option>
-            ))}
-          </select>
+      <button className={styles.infoBtn} onClick={(e) => { e.stopPropagation(); onInfo(); }} aria-label="Pack info">?</button>
+
+      <div className={styles.packTop}>
+        <div className={styles.packIcon}>{pt.icon}</div>
+        <div className={styles.packName}>{t(`pack.${pt.id}_name`)}</div>
+        <div className={styles.packCardCount}>{t('shop.cards_count', { count: totalCards(packDef.slots) })}</div>
+      </div>
+
+      <div className={styles.packBottom}>
+        <div className={styles.packPrice}>◈ {pt.price.toLocaleString()}</div>
+        {pt.id === 'race' && (
+          <div className={styles.raceSelectWrap}>
+            <select id={`shop-race-select-${pt.id}`} className={styles.raceSelect} defaultValue={starterRace}>
+              {raceKeys.map(k => (
+                <option key={k} value={k}>{getRaceByKey(k)?.icon ?? ''} {t(`cards.race_${k}`)}</option>
+              ))}
+            </select>
+          </div>
+        )}
+        <button className={styles.buyBtn} disabled={!affordable} onClick={handleBuy}>{t('shop.buy_btn')}</button>
+      </div>
+    </div>
+  );
+}
+
+// ── Package Tile ───────────────────────────────────────────
+
+interface PackageTileProps {
+  pkg: PackageDef;
+  unlocked: boolean;
+  affordable: boolean;
+  onBuy: (packageId: string) => void;
+  onInfo: () => void;
+}
+
+function PackageTile({ pkg, unlocked, affordable, onBuy, onInfo }: PackageTileProps) {
+  const { t } = useTranslation();
+  const canBuy = unlocked && affordable;
+
+  return (
+    <div
+      className={`${styles.packTile}${canBuy ? '' : ` ${styles.packDisabled}`}`}
+      style={{ '--pack-color': pkg.color } as React.CSSProperties}
+    >
+      <button className={styles.infoBtn} onClick={(e) => { e.stopPropagation(); onInfo(); }} aria-label="Pack info">?</button>
+
+      <div className={styles.packTop}>
+        <div className={styles.packIcon}>{pkg.icon}</div>
+        <div className={styles.packName}>{pkg.name}</div>
+        <div className={styles.packCardCount}>{t('shop.cards_count', { count: totalCards(pkg.slots) })}</div>
+      </div>
+
+      <div className={styles.packBottom}>
+        <div className={styles.packPrice}>◈ {pkg.price.toLocaleString()}</div>
+        {!unlocked && (
+          <div className={styles.packLocked}>{t('shop.locked')}</div>
+        )}
+        <button className={styles.buyBtn} disabled={!canBuy} onClick={() => onBuy(pkg.id)}>
+          {t('shop.buy_btn')}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── Pack Info Modal ────────────────────────────────────────
+
+interface PackInfoModalProps {
+  pack: PackDef | PackageDef;
+  type: 'pack' | 'package';
+  onClose: () => void;
+}
+
+function PackInfoModal({ pack, type, onClose }: PackInfoModalProps) {
+  const { t } = useTranslation();
+
+  const distribution = useMemo(() => computeDistribution(pack.slots), [pack]);
+
+  const pool = useMemo(() => {
+    const cardPool = 'cardPool' in pack ? pack.cardPool : undefined;
+    return buildCardPool(cardPool);
+  }, [pack]);
+
+  const poolByRarity = useMemo(() => countByRarity(pool), [pool]);
+
+  const isRacePack = type === 'pack' && (pack as PackDef).filter === 'byRace';
+  const total = totalCards(pack.slots);
+  const displayName = type === 'pack' ? t(`pack.${pack.id}_name`) : pack.name;
+  const displayDesc = type === 'pack' ? t(`pack.${pack.id}_desc`) : pack.desc;
+
+  return (
+    <div className={styles.infoOverlay} onClick={onClose}>
+      <div className={styles.infoModal} onClick={(e) => e.stopPropagation()}>
+        {/* Header */}
+        <div className={styles.infoModalHeader}>
+          <span className={styles.infoModalIcon}>{pack.icon}</span>
+          <div>
+            <div className={styles.infoModalTitle}>{displayName}</div>
+            <div className={styles.infoModalDesc}>{displayDesc}</div>
+          </div>
         </div>
-      )}
-      <button className={styles.buyBtn} disabled={!affordable} onClick={handleBuy}>{t('shop.buy_btn')}</button>
+
+        {/* Distribution */}
+        <div className={styles.infoSection}>
+          <div className={styles.infoSectionTitle}>{t('shop.info_per_pack', { count: total })}</div>
+          {distribution.map(({ rarity, guaranteed, chancePct }) => {
+            const meta = getRarityById(rarity);
+            const name = meta?.value ?? `Rarity ${rarity}`;
+            const color = meta?.color ?? '#aaa';
+            const parts: string[] = [];
+            if (guaranteed > 0) parts.push(t('shop.info_guaranteed', { count: guaranteed }));
+            if (chancePct > 0) parts.push(t('shop.info_chance', { percent: chancePct }));
+            return (
+              <div key={rarity} className={styles.rarityRow}>
+                <span className={styles.rarityLabel}>
+                  <span className={styles.rarityDot} style={{ background: color }} />
+                  {name}
+                </span>
+                <span className={styles.rarityInfo}>{parts.join(' + ')}</span>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Card Pool */}
+        <div className={styles.infoSection}>
+          <div className={styles.infoSectionTitle}>{t('shop.info_cards_in_pool', { count: pool.length })}</div>
+          <div className={styles.poolSection}>
+            {poolByRarity.map(({ rarity, count }) => {
+              const meta = getRarityById(rarity);
+              const name = meta?.value ?? `Rarity ${rarity}`;
+              const color = meta?.color ?? '#aaa';
+              return (
+                <div key={rarity} className={styles.poolRow}>
+                  <span className={styles.poolLabel}>
+                    <span className={styles.rarityDot} style={{ background: color }} />
+                    {name}
+                  </span>
+                  <span className={styles.poolCount}>{count}</span>
+                </div>
+              );
+            })}
+          </div>
+          {isRacePack && <div className={styles.raceNote}>{t('shop.info_race_note')}</div>}
+        </div>
+
+        <button className={styles.infoCloseBtn} onClick={onClose}>{t('shop.info_close')}</button>
+      </div>
     </div>
   );
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -85,7 +85,15 @@
     "packages_title": "◈ Kartenpakete",
     "tab_standard": "Standardpacks",
     "tab_packages": "Kartenpakete",
-    "locked": "🔒 Gesperrt"
+    "locked": "🔒 Gesperrt",
+    "info_title": "Pack-Inhalt",
+    "info_cards_in_pool": "{{count}} Karten im Pool",
+    "info_guaranteed": "{{count}} garantiert",
+    "info_chance": "{{percent}}% Chance",
+    "info_per_pack": "{{count}} Karten pro Pack",
+    "info_race_note": "Gefiltert nach gewählter Rasse",
+    "info_close": "Schließen",
+    "cards_count": "{{count}} Karten"
   },
   "pack": {
     "race_name": "Rassen-Pack",

--- a/locales/en.json
+++ b/locales/en.json
@@ -85,7 +85,15 @@
     "packages_title": "◈ Card Packages",
     "tab_standard": "Standard Packs",
     "tab_packages": "Card Packages",
-    "locked": "🔒 Locked"
+    "locked": "🔒 Locked",
+    "info_title": "Pack Contents",
+    "info_cards_in_pool": "{{count}} cards in pool",
+    "info_guaranteed": "{{count}} guaranteed",
+    "info_chance": "{{percent}}% chance",
+    "info_per_pack": "{{count}} cards per pack",
+    "info_race_note": "Filtered by chosen race",
+    "info_close": "Close",
+    "cards_count": "{{count}} Cards"
   },
   "pack": {
     "race_name": "Race Pack",


### PR DESCRIPTION
Replace carousel with responsive CSS grid (2-4 columns) showing all packs
at once. Restyle pack tiles with 2:3 aspect ratio to look like real TCG
booster packs. Add (?) info button on each pack showing rarity distribution
and card pool breakdown.

https://claude.ai/code/session_019itNms213uqSmbqb43sWCo