### PR TITLE
feat(ui): add booster pack opening animation with card reveal sequence

### DIFF
--- a/css/animations.css
+++ b/css/animations.css
@@ -257,6 +257,60 @@
 .vfx-damage:nth-child(5)  { --vfx-fire-ox:  40px; --vfx-fire-oy: -80px; }
 .vfx-damage:nth-child(6)  { --vfx-fire-ox: -50px; --vfx-fire-oy:  30px; }
 
+/* ── Pack Opening ────────────────────────────────────────── */
+
+/* Holographic shimmer sweep across booster pack */
+@keyframes packShimmer {
+  0%   { background-position: -200% 0; }
+  100% { background-position: 200% 0; }
+}
+
+/* White flash burst when pack tears open */
+@keyframes packFlash {
+  0%   { opacity: 0; }
+  20%  { opacity: 1; }
+  100% { opacity: 0; }
+}
+
+/* Golden sparkle particles radiate outward (for SR/UR cards) */
+@keyframes sparkleParticle {
+  0% {
+    transform: translate(-50%, -50%) rotate(var(--sparkle-angle)) translateY(0) scale(0.3);
+    opacity: 0;
+  }
+  15% {
+    opacity: 1;
+  }
+  50% {
+    transform: translate(-50%, -50%) rotate(var(--sparkle-angle)) translateY(-50px) scale(1);
+    opacity: 0.9;
+  }
+  100% {
+    transform: translate(-50%, -50%) rotate(var(--sparkle-angle)) translateY(-90px) scale(0.2);
+    opacity: 0;
+  }
+}
+
+/* Golden burst flash behind rare card on reveal */
+@keyframes sparkleBurst {
+  0%   { transform: translate(-50%, -50%) scale(0.1); opacity: 1; }
+  40%  { transform: translate(-50%, -50%) scale(1.5);  opacity: 0.8; }
+  100% { transform: translate(-50%, -50%) scale(2.5);  opacity: 0; }
+}
+
+/* Shimmer glow pulse on rare card border */
+@keyframes rareBorderGlow {
+  0%, 100% { box-shadow: 0 0 8px var(--rarity-color, #c8a84b), 0 0 16px transparent; }
+  50%      { box-shadow: 0 0 12px var(--rarity-color, #c8a84b), 0 0 28px var(--rarity-color, #c8a84b); }
+}
+
+/* Pack wobble before tear */
+@keyframes packWobble {
+  0%, 100% { transform: rotate(0deg); }
+  25%  { transform: rotate(-3deg); }
+  75%  { transform: rotate(3deg); }
+}
+
 /* ── Reduced Motion ─────────────────────────────────────── */
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {

--- a/js/react/screens/PackOpeningScreen.module.css
+++ b/js/react/screens/PackOpeningScreen.module.css
@@ -1,3 +1,4 @@
+/* ── Shared screen base ──────────────────────────────────── */
 .screen {
   position: fixed;
   inset: 0;
@@ -6,8 +7,242 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  user-select: none;
+}
+
+/* ── Phase 1: Pack Tear-Open ─────────────────────────────── */
+.packPhase {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.packWrapper {
+  position: relative;
+  width: 140px;
+  height: 200px;
+  border-radius: 8px;
+  background: linear-gradient(135deg, #1a1040 0%, #2a1860 30%, #3a2080 50%, #2a1860 70%, #1a1040 100%);
+  border: 2px solid #c8a84b;
+  box-shadow: 0 0 20px rgba(200, 168, 75, 0.3), 0 4px 20px rgba(0, 0, 0, 0.6);
+  overflow: hidden;
+}
+
+.packFoil {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    105deg,
+    transparent 20%,
+    rgba(255, 220, 100, 0.15) 30%,
+    rgba(200, 160, 255, 0.2) 40%,
+    rgba(100, 220, 255, 0.15) 50%,
+    transparent 60%
+  );
+  background-size: 200% 100%;
+  animation: packShimmer 1.8s linear infinite;
+  pointer-events: none;
+}
+
+.packLabel {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 16px;
+}
+
+.packIcon {
+  font-size: 2.4rem;
+  margin-bottom: 8px;
+  filter: drop-shadow(0 0 4px rgba(200, 168, 75, 0.6));
+}
+
+.packName {
+  font-size: 0.7rem;
+  color: #c8a84b;
+  text-shadow: 1px 1px 0 #000;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+/* Pack halves for tear animation */
+.packHalfLeft,
+.packHalfRight {
+  position: absolute;
+  top: 0;
+  width: 50%;
+  height: 100%;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.packHalfLeft {
+  left: 0;
+  clip-path: polygon(0 0, 100% 0, 85% 50%, 100% 100%, 0 100%);
+}
+
+.packHalfRight {
+  right: 0;
+  clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%, 15% 50%);
+}
+
+.packHalfInner {
+  position: absolute;
+  top: 0;
+  width: 140px;
+  height: 200px;
+  border-radius: 8px;
+  background: linear-gradient(135deg, #1a1040 0%, #2a1860 30%, #3a2080 50%, #2a1860 70%, #1a1040 100%);
+  border: 2px solid #c8a84b;
+}
+
+.packHalfLeft .packHalfInner { left: 0; }
+.packHalfRight .packHalfInner { right: 0; }
+
+/* White flash overlay */
+.flash {
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(ellipse at center, rgba(255, 240, 200, 0.9), rgba(255, 255, 255, 0.6));
+  pointer-events: none;
+  z-index: 210;
+  animation: packFlash 0.5s ease-out forwards;
+}
+
+/* ── Phase 2: Card Reveal ────────────────────────────────── */
+.revealPhase {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.revealStage {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  width: 100%;
+}
+
+.revealCard {
+  position: absolute;
+  width: 160px;
+  min-height: 200px;
+  border-radius: 0;
+  padding: 10px;
+  font-size: 0.8rem;
+  overflow: hidden;
+  border: 3px solid var(--rarity-color, #aaa);
+  background: #111828;
+  box-shadow: 0 0 12px rgba(0, 0, 0, 0.8);
+  opacity: 0;
+  will-change: transform, opacity;
+}
+
+@media (min-width: 480px) {
+  .revealCard { width: 180px; min-height: 230px; }
+}
+
+.revealCard.sparkle {
+  animation: rareBorderGlow 0.8s ease-in-out 2;
+}
+
+/* Sparkle particle for SR/UR */
+.sparkle-particle {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  left: 50%;
+  top: 50%;
+  clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
+  background: linear-gradient(135deg, #ffd700 0%, #fff8dc 50%, #ffd700 100%);
+  box-shadow: 0 0 6px rgba(255, 215, 0, 0.8);
+  pointer-events: none;
+  will-change: transform, opacity;
+  animation: sparkleParticle 0.8s ease-out forwards;
+}
+
+/* Sparkle burst behind card */
+.sparkle-burst {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 180px;
+  height: 180px;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 215, 0, 0.5) 0%, rgba(255, 215, 0, 0.1) 40%, transparent 70%);
+  pointer-events: none;
+  animation: sparkleBurst 0.7s ease-out forwards;
+  z-index: -1;
+}
+
+/* Rarity bar on reveal card */
+.revealRarityBar {
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 3px;
+}
+
+/* Counter e.g. "3 / 9" */
+.revealCounter {
+  position: absolute;
+  bottom: 24px;
+  font-size: 0.7rem;
+  color: #607090;
+  letter-spacing: 2px;
+}
+
+/* Mini strip of already-revealed cards at bottom */
+.miniStrip {
+  display: flex;
+  gap: 6px;
+  padding: 8px 12px;
+  justify-content: center;
+  flex-wrap: wrap;
+  max-width: 100%;
+  min-height: 48px;
+}
+
+.miniCard {
+  width: 32px;
+  height: 44px;
+  border-radius: 0;
+  border: 1px solid var(--rarity-color, #aaa);
+  background: #111828;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.35rem;
+  color: #6080a0;
+  overflow: hidden;
+  opacity: 0.7;
+  transition: opacity 0.2s;
+}
+
+/* ── Phase 3: Summary Grid ───────────────────────────────── */
+.summaryPhase {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   padding: 20px 16px 40px;
   overflow-y: auto;
+  width: 100%;
+  height: 100%;
 }
 
 .header { text-align: center; margin-bottom: 20px; }
@@ -66,6 +301,7 @@
   border-radius: 0;
   letter-spacing: 1px;
   z-index: 1;
+  text-shadow: none;
 }
 
 .cardInner :global(.card-header) {
@@ -81,9 +317,33 @@
 .cardInner :global(.card-desc) { color: #8090a8; font-size: 0.65rem; line-height: 1.3; max-height: 3.9em; overflow: hidden; }
 .cardInner :global(.card-footer) { display: flex; justify-content: space-between; margin-top: 4px; color: #90b0d0; font-size: 0.7rem; }
 
+/* Same styles for reveal card inner text */
+.revealCard :global(.card-header) {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 4px;
+  margin-bottom: 4px;
+}
+
+.revealCard :global(.card-name) { font-weight: bold; color: #d0e0ff; font-size: 0.9rem; }
+.revealCard :global(.card-level) { color: #c8a84b; font-size: 0.7rem; }
+.revealCard :global(.card-type-line) { color: #6080a0; font-size: 0.7rem; margin-bottom: 3px; }
+.revealCard :global(.card-desc) { color: #8090a8; font-size: 0.7rem; line-height: 1.3; max-height: 3.9em; overflow: hidden; }
+.revealCard :global(.card-footer) { display: flex; justify-content: space-between; margin-top: 4px; color: #90b0d0; font-size: 0.75rem; }
+
 .buttons {
   display: flex;
   gap: 12px;
   flex-wrap: wrap;
   justify-content: center;
+}
+
+/* Skip hint at bottom of screen */
+.skipHint {
+  position: absolute;
+  bottom: 16px;
+  font-size: 0.6rem;
+  color: #405060;
+  letter-spacing: 1px;
+  animation: titlePulse 2s ease-in-out infinite;
 }

--- a/js/react/screens/PackOpeningScreen.tsx
+++ b/js/react/screens/PackOpeningScreen.tsx
@@ -1,79 +1,378 @@
 import { useTranslation } from 'react-i18next';
-import { useEffect }   from 'react';
+import { useEffect, useMemo, useRef, useState, useCallback } from 'react';
+import { gsap } from 'gsap';
 import { useScreen }   from '../contexts/ScreenContext.js';
 import { getRarityById } from '../../type-metadata.js';
 import { cardTypeCss, ATTR_CSS } from '../components/Card.js';
 import { Audio }        from '../../audio.js';
-import { CardType } from '../../types.js';
+import { CardType, Rarity } from '../../types.js';
 import type { CardData }          from '../../types.js';
 import type { CollectionEntry }   from '../../types.js';
 import styles from './PackOpeningScreen.module.css';
+
+type Phase = 'pack' | 'reveal' | 'summary';
+
+/* ── Timing constants ──────────────────────────────────── */
+const HOLD_BY_RARITY: Record<number, number> = {
+  [Rarity.Common]:    0.5,
+  [Rarity.Uncommon]:  0.5,
+  [Rarity.Rare]:      0.8,
+  [Rarity.SuperRare]: 1.0,
+  [Rarity.UltraRare]: 1.2,
+};
+
+const SPARKLE_RARITIES = new Set([Rarity.SuperRare, Rarity.UltraRare]);
+const SPARKLE_COUNT = 12;
+
+/* ── Helpers ───────────────────────────────────────────── */
+
+function getTypeLabel(card: CardData, t: (k: string) => string) {
+  if (card.type === CardType.Monster && card.effect) return t('pack_opening.type_effect');
+  if (card.type === CardType.Monster) return t('pack_opening.type_normal');
+  if (card.type === CardType.Fusion) return t('pack_opening.type_fusion');
+  if (card.type === CardType.Spell)  return t('pack_opening.type_spell');
+  return t('pack_opening.type_trap');
+}
+
+function spawnSparkles(container: HTMLElement) {
+  for (let i = 0; i < SPARKLE_COUNT; i++) {
+    const el = document.createElement('div');
+    el.className = styles['sparkle-particle'];
+    el.style.setProperty('--sparkle-angle', `${(i / SPARKLE_COUNT) * 360}deg`);
+    el.style.animationDelay = `${Math.random() * 0.15}s`;
+    container.appendChild(el);
+    el.addEventListener('animationend', () => el.remove(), { once: true });
+    setTimeout(() => { if (el.parentNode) el.remove(); }, 1200);
+  }
+  // burst
+  const burst = document.createElement('div');
+  burst.className = styles['sparkle-burst'];
+  container.appendChild(burst);
+  burst.addEventListener('animationend', () => burst.remove(), { once: true });
+  setTimeout(() => { if (burst.parentNode) burst.remove(); }, 1000);
+}
+
+/* ── Component ─────────────────────────────────────────── */
 
 export default function PackOpeningScreen() {
   const { navigateTo, screenData } = useScreen();
   const { t } = useTranslation();
 
-  useEffect(() => { Audio.playSfx('sfx_pack_open'); }, []);
-
   const { cards: _cards, preOpen: _preOpen } = (screenData as { cards: CardData[]; preOpen: CollectionEntry[] } | null) ?? { cards: [], preOpen: [] };
+  const ownedBefore = useMemo(() => new Set(_preOpen.filter(e => e.count > 0).map(e => e.id)), [_preOpen]);
 
-  const ownedBefore = new Set(_preOpen.filter(e => e.count > 0).map(e => e.id));
+  // Sort cards by rarity ascending (Common first → UltraRare last)
+  const sortedCards = useMemo(() =>
+    [..._cards].sort((a, b) => (a.rarity ?? 1) - (b.rarity ?? 1)),
+    [_cards],
+  );
 
-  function getTypeLabel(card: CardData) {
-    if (card.type === CardType.Monster && card.effect) return t('pack_opening.type_effect');
-    if (card.type === CardType.Monster) return t('pack_opening.type_normal');
-    if (card.type === CardType.Fusion) return t('pack_opening.type_fusion');
-    if (card.type === CardType.Spell)  return t('pack_opening.type_spell');
-    return t('pack_opening.type_trap');
+  const [phase, setPhase] = useState<Phase>('pack');
+  const [revealIndex, setRevealIndex] = useState(-1);
+  const [showFlash, setShowFlash] = useState(false);
+  const skipRef = useRef(false);
+  const tlRef = useRef<gsap.core.Timeline | null>(null);
+  const packRef = useRef<HTMLDivElement>(null);
+  const leftRef = useRef<HTMLDivElement>(null);
+  const rightRef = useRef<HTMLDivElement>(null);
+  const revealCardRef = useRef<HTMLDivElement>(null);
+
+  /* ── Reduced motion: skip everything ─── */
+  useEffect(() => {
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      skipRef.current = true;
+      setPhase('summary');
+    }
+  }, []);
+
+  /* ── Skip handler ─── */
+  const handleSkip = useCallback(() => {
+    if (phase === 'summary') return;
+    skipRef.current = true;
+    tlRef.current?.kill();
+    setPhase('summary');
+  }, [phase]);
+
+  /* ── Phase 1: Pack tear-open animation ─── */
+  useEffect(() => {
+    if (phase !== 'pack') return;
+    if (skipRef.current) { setPhase('summary'); return; }
+
+    const pack = packRef.current;
+    const left = leftRef.current;
+    const right = rightRef.current;
+    if (!pack || !left || !right) return;
+
+    Audio.playSfx('sfx_pack_open');
+
+    const tl = gsap.timeline({
+      onComplete: () => {
+        if (!skipRef.current) setPhase('reveal');
+      },
+    });
+    tlRef.current = tl;
+
+    // Wobble the pack
+    tl.to(pack, { rotation: -3, duration: 0.12, ease: 'steps(3)' })
+      .to(pack, { rotation: 3, duration: 0.12, ease: 'steps(3)' })
+      .to(pack, { rotation: -2, duration: 0.1, ease: 'steps(2)' })
+      .to(pack, { rotation: 0, duration: 0.08, ease: 'steps(2)' });
+
+    // Hide original, show halves
+    tl.call(() => {
+      gsap.set(pack, { visibility: 'hidden' });
+      gsap.set([left, right], { visibility: 'visible' });
+    });
+
+    // Tear apart
+    tl.to(left, {
+      x: -80, rotation: -12, opacity: 0,
+      duration: 0.4, ease: 'steps(6)',
+    }, '+=0')
+      .to(right, {
+        x: 80, rotation: 12, opacity: 0,
+        duration: 0.4, ease: 'steps(6)',
+      }, '<');
+
+    // Flash
+    tl.call(() => setShowFlash(true), undefined, '-=0.15');
+    tl.to({}, { duration: 0.5 }); // wait for flash to fade
+
+    return () => { tl.kill(); };
+  }, [phase]);
+
+  /* ── Phase 2: Card reveal sequence ─── */
+  useEffect(() => {
+    if (phase !== 'reveal') return;
+    if (skipRef.current) { setPhase('summary'); return; }
+    if (sortedCards.length === 0) { setPhase('summary'); return; }
+
+    let cancelled = false;
+    let currentTl: gsap.core.Timeline | null = null;
+
+    async function revealSequence() {
+      for (let i = 0; i < sortedCards.length; i++) {
+        if (cancelled || skipRef.current) break;
+
+        // Update index to render the card
+        setRevealIndex(i);
+
+        // Wait a tick for React to render
+        await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
+        if (cancelled || skipRef.current) break;
+
+        const cardEl = revealCardRef.current;
+        if (!cardEl) continue;
+
+        const card = sortedCards[i];
+        const rarity = card.rarity ?? Rarity.Common;
+        const holdTime = HOLD_BY_RARITY[rarity] ?? 0.5;
+        const isSparkly = SPARKLE_RARITIES.has(rarity);
+
+        Audio.playSfx('sfx_pack_reveal');
+
+        // Animate card: slide from top to center
+        const tl = gsap.timeline();
+        currentTl = tl;
+        tlRef.current = tl;
+
+        gsap.set(cardEl, { y: '-120vh', opacity: 0, scale: 0.85 });
+
+        tl.to(cardEl, {
+          y: 0, opacity: 1, scale: 1,
+          duration: 0.45, ease: 'steps(8)',
+        });
+
+        // Sparkle effect for SR/UR
+        if (isSparkly) {
+          tl.call(() => {
+            if (cardEl) {
+              spawnSparkles(cardEl);
+              cardEl.classList.add(styles.sparkle);
+            }
+          });
+        }
+
+        // Hold
+        tl.to({}, { duration: holdTime });
+
+        // Shrink & move down to mini strip area
+        tl.to(cardEl, {
+          scale: 0.3, opacity: 0, y: '30vh',
+          duration: 0.3, ease: 'steps(5)',
+        });
+
+        // Wait for timeline to complete
+        await new Promise<void>(resolve => {
+          tl.eventCallback('onComplete', resolve);
+        });
+
+        if (cancelled || skipRef.current) break;
+      }
+
+      if (!cancelled && !skipRef.current) {
+        setPhase('summary');
+      }
+    }
+
+    revealSequence();
+
+    return () => {
+      cancelled = true;
+      currentTl?.kill();
+    };
+  }, [phase, sortedCards]);
+
+  /* ── Render ─── */
+
+  // Phase 1: Pack
+  if (phase === 'pack') {
+    return (
+      <div className={styles.screen} onClick={handleSkip}>
+        {showFlash && <div className={styles.flash} />}
+        <div className={styles.packPhase}>
+          <div ref={packRef} className={styles.packWrapper}>
+            <div className={styles.packFoil} />
+            <div className={styles.packLabel}>
+              <div className={styles.packIcon}>🀄</div>
+              <div className={styles.packName}>{t('pack_opening.title')}</div>
+            </div>
+          </div>
+
+          {/* Tear halves (hidden until tear moment) */}
+          <div ref={leftRef} className={styles.packHalfLeft} style={{ visibility: 'hidden', position: 'absolute' }}>
+            <div className={styles.packHalfInner}>
+              <div className={styles.packFoil} />
+            </div>
+          </div>
+          <div ref={rightRef} className={styles.packHalfRight} style={{ visibility: 'hidden', position: 'absolute' }}>
+            <div className={styles.packHalfInner}>
+              <div className={styles.packFoil} />
+            </div>
+          </div>
+
+          <div className={styles.skipHint}>{t('pack_opening.skip_hint')}</div>
+        </div>
+      </div>
+    );
   }
 
-  return (
-    <div className={styles.screen}>
-      <div className={styles.header}>
-        <h2 className={styles.title}>{t('pack_opening.title')}</h2>
-      </div>
+  // Phase 2: Reveal
+  if (phase === 'reveal') {
+    const currentCard = revealIndex >= 0 ? sortedCards[revealIndex] : null;
+    const rarColor = currentCard ? (getRarityById((currentCard as any).rarity)?.color ?? '#aaa') : '#aaa';
 
-      <div className={styles.grid}>
-        {_cards.map((card, i) => {
-          const isNew    = !ownedBefore.has(card.id);
-          const rarColor = getRarityById((card as any).rarity)?.color ?? '#aaa';
-          return (
-            <div
-              key={i}
-              className={styles.cardWrapper}
-              style={{ animationDelay: `${i * 0.08}s` }}
-            >
+    return (
+      <div className={styles.screen} onClick={handleSkip}>
+        <div className={styles.revealPhase}>
+          <div className={styles.revealStage}>
+            {currentCard && (
               <div
-                className={`${styles.cardInner} card ${cardTypeCss(card)}-card attr-${card.attribute ? ATTR_CSS[card.attribute] || 'spell' : 'spell'}`}
+                ref={revealCardRef}
+                className={`${styles.revealCard} card ${cardTypeCss(currentCard)}-card attr-${currentCard.attribute ? ATTR_CSS[currentCard.attribute] || 'spell' : 'spell'}`}
                 style={{ '--rarity-color': rarColor } as React.CSSProperties}
               >
-                {isNew && <div className={styles.newBadge}>{t('pack_opening.new_badge')}</div>}
-                <div className={styles.rarityBar} style={{ background: rarColor }}></div>
+                <div className={styles.revealRarityBar} style={{ background: rarColor }} />
+                {!ownedBefore.has(currentCard.id) && (
+                  <div className={styles.newBadge}>{t('pack_opening.new_badge')}</div>
+                )}
                 <div className="card-header">
-                  <span className="card-name">{card.name}</span>
+                  <span className="card-name">{currentCard.name}</span>
                   <span className="card-level">
-                    {card.level ? '★'.repeat(Math.min(card.level, 5)) : ''}
+                    {currentCard.level ? '★'.repeat(Math.min(currentCard.level, 5)) : ''}
                   </span>
                 </div>
                 <div className="card-body">
-                  <div className="card-type-line">{getTypeLabel(card)}</div>
-                  <div className="card-desc">{card.description || ''}</div>
+                  <div className="card-type-line">{getTypeLabel(currentCard, t)}</div>
+                  <div className="card-desc">{currentCard.description || ''}</div>
                 </div>
-                {card.atk !== undefined && (
+                {currentCard.atk !== undefined && (
                   <div className="card-footer">
-                    <span>ATK {card.atk}</span>
-                    <span>DEF {card.def}</span>
+                    <span>ATK {currentCard.atk}</span>
+                    <span>DEF {currentCard.def}</span>
                   </div>
                 )}
               </div>
-            </div>
-          );
-        })}
-      </div>
+            )}
+          </div>
 
-      <div className={styles.buttons}>
-        <button className="btn-secondary" onClick={() => navigateTo('shop')}>{t('pack_opening.back_shop')}</button>
-        <button className="btn-primary"   onClick={() => navigateTo('save-point')}>{t('pack_opening.home')}</button>
+          {/* Counter */}
+          <div className={styles.revealCounter}>
+            {revealIndex + 1} / {sortedCards.length}
+          </div>
+
+          {/* Mini strip of already-revealed cards */}
+          <div className={styles.miniStrip}>
+            {sortedCards.slice(0, revealIndex).map((card, i) => {
+              const rc = getRarityById((card as any).rarity)?.color ?? '#aaa';
+              return (
+                <div
+                  key={i}
+                  className={styles.miniCard}
+                  style={{ '--rarity-color': rc, borderColor: rc } as React.CSSProperties}
+                >
+                  <span>{card.name?.charAt(0) ?? '?'}</span>
+                </div>
+              );
+            })}
+          </div>
+
+          <div className={styles.skipHint}>{t('pack_opening.skip_hint')}</div>
+        </div>
+      </div>
+    );
+  }
+
+  // Phase 3: Summary
+  return (
+    <div className={styles.screen}>
+      <div className={styles.summaryPhase}>
+        <div className={styles.header}>
+          <h2 className={styles.title}>{t('pack_opening.title')}</h2>
+        </div>
+
+        <div className={styles.grid}>
+          {sortedCards.map((card, i) => {
+            const isNew = !ownedBefore.has(card.id);
+            const rarColor = getRarityById((card as any).rarity)?.color ?? '#aaa';
+            return (
+              <div
+                key={i}
+                className={styles.cardWrapper}
+                style={{ animationDelay: `${i * 0.08}s` }}
+              >
+                <div
+                  className={`${styles.cardInner} card ${cardTypeCss(card)}-card attr-${card.attribute ? ATTR_CSS[card.attribute] || 'spell' : 'spell'}`}
+                  style={{ '--rarity-color': rarColor } as React.CSSProperties}
+                >
+                  {isNew && <div className={styles.newBadge}>{t('pack_opening.new_badge')}</div>}
+                  <div className={styles.rarityBar} style={{ background: rarColor }} />
+                  <div className="card-header">
+                    <span className="card-name">{card.name}</span>
+                    <span className="card-level">
+                      {card.level ? '★'.repeat(Math.min(card.level, 5)) : ''}
+                    </span>
+                  </div>
+                  <div className="card-body">
+                    <div className="card-type-line">{getTypeLabel(card, t)}</div>
+                    <div className="card-desc">{card.description || ''}</div>
+                  </div>
+                  {card.atk !== undefined && (
+                    <div className="card-footer">
+                      <span>ATK {card.atk}</span>
+                      <span>DEF {card.def}</span>
+                    </div>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className={styles.buttons}>
+          <button className="btn-secondary" onClick={() => navigateTo('shop')}>{t('pack_opening.back_shop')}</button>
+          <button className="btn-primary" onClick={() => navigateTo('save-point')}>{t('pack_opening.home')}</button>
+        </div>
       </div>
     </div>
   );

--- a/locales/de.json
+++ b/locales/de.json
@@ -113,7 +113,8 @@
     "type_fusion": "Fusion",
     "type_spell": "Zauber",
     "type_trap": "Falle",
-    "type_equipment": "Ausrüstung"
+    "type_equipment": "Ausrüstung",
+    "skip_hint": "Tippen zum Überspringen"
   },
   "collection": {
     "title": "📚 MEINE SAMMLUNG",

--- a/locales/en.json
+++ b/locales/en.json
@@ -113,7 +113,8 @@
     "type_fusion": "Fusion",
     "type_spell": "Spell",
     "type_trap": "Trap",
-    "type_equipment": "Equipment"
+    "type_equipment": "Equipment",
+    "skip_hint": "Tap to skip"
   },
   "collection": {
     "title": "📚 MY COLLECTION",


### PR DESCRIPTION
Three-phase animation: foiled pack tear-open with holographic shimmer,
one-by-one card reveals sorted by rarity (common→legendary) with golden
sparkle effects on SuperRare/UltraRare cards, and a summary grid with
NEW badges for cards not previously in collection. Skippable via tap.

https://claude.ai/code/session_013Zd6eLPyB6YVJZ62pPTrQs