### PR TITLE
fix(ui): restore carousel pagination, fix pack sizing and visibility

### DIFF
--- a/js/react/screens/ShopScreen.module.css
+++ b/js/react/screens/ShopScreen.module.css
@@ -56,7 +56,7 @@
 
 .backBtn { font-size: 0.85rem; }
 
-/* -- Tabs -- */
+/* ── Tabs ── */
 
 .tabs {
   display: flex;
@@ -91,39 +91,89 @@
   border-color: #c8a84b;
 }
 
-/* -- Pack Grid -- */
+/* ── Carousel ── */
 
-.packGrid {
+.carousel {
   position: relative;
   z-index: 1;
   width: 100%;
   max-width: 900px;
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 10px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
   flex: 1;
   min-height: 0;
-  align-content: start;
 }
 
-@media (min-width: 480px) {
-  .packGrid {
-    grid-template-columns: repeat(3, 1fr);
-    gap: 12px;
-  }
+.carouselTrack {
+  display: grid;
+  grid-template-columns: repeat(var(--items-per-page, 3), 1fr);
+  gap: 8px;
+  flex: 1;
+  min-height: 0;
+  align-items: start;
 }
 
-@media (min-width: 720px) {
-  .packGrid {
-    grid-template-columns: repeat(4, 1fr);
-    gap: 14px;
-  }
+.arrowBtn {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  background: #111828;
+  border: 2px solid #334;
+  border-radius: 0;
+  color: #c8a84b;
+  font-size: 1.3rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s, color 0.15s;
+  z-index: 2;
 }
 
-/* -- Pack Tile (Booster Pack Style) -- */
+.arrowBtn:hover:not(:disabled) {
+  background: #1a2840;
+  color: #f0d080;
+}
+
+.arrowBtn:disabled {
+  opacity: 0.25;
+  cursor: not-allowed;
+}
+
+/* ── Dots ── */
+
+.dots {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  margin-top: 12px;
+  position: relative;
+  z-index: 1;
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: 1px solid #556;
+  background: #334;
+  cursor: pointer;
+  padding: 0;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+.dot:hover { border-color: #c8a84b; }
+
+.dotActive {
+  background: #c8a84b;
+  border-color: #c8a84b;
+}
+
+/* ── Pack Tile (Booster Pack Style) ── */
 
 .packTile {
-  aspect-ratio: 2 / 3;
+  aspect-ratio: 3 / 4;
   background: linear-gradient(
     170deg,
     color-mix(in srgb, var(--pack-color, #4060c0) 18%, #111828) 0%,
@@ -160,24 +210,19 @@
   box-shadow: 0 0 12px color-mix(in srgb, var(--pack-color, #4060c0) 30%, transparent);
 }
 
-.packDisabled {
-  opacity: 0.45;
-  pointer-events: none;
-}
-
-/* -- Info (?) Button -- */
+/* ── Info (?) Button ── */
 
 .infoBtn {
   position: absolute;
   top: 4px;
   right: 4px;
-  width: 22px;
-  height: 22px;
+  width: 20px;
+  height: 20px;
   border-radius: 50%;
   border: 1.5px solid color-mix(in srgb, var(--pack-color, #4060c0) 60%, #667);
-  background: rgba(0, 0, 0, 0.5);
+  background: rgba(0, 0, 0, 0.55);
   color: #c0d0e0;
-  font-size: 0.65rem;
+  font-size: 0.6rem;
   font-weight: bold;
   cursor: pointer;
   display: flex;
@@ -187,7 +232,6 @@
   transition: background 0.15s, color 0.15s;
   padding: 0;
   line-height: 1;
-  pointer-events: auto;
 }
 
 .infoBtn:hover {
@@ -195,7 +239,7 @@
   color: #fff;
 }
 
-/* -- Pack Content Area -- */
+/* ── Pack Content Area ── */
 
 .packTop {
   flex: 1;
@@ -209,13 +253,13 @@
 }
 
 .packIcon {
-  font-size: clamp(1.8rem, 5vw, 2.8rem);
+  font-size: clamp(1.6rem, 5vw, 2.6rem);
   position: relative;
   filter: drop-shadow(0 2px 4px rgba(0,0,0,0.5));
 }
 
 .packName {
-  font-size: clamp(0.55rem, 1.8vw, 0.8rem);
+  font-size: clamp(0.5rem, 1.6vw, 0.8rem);
   font-weight: bold;
   color: #c0d0e0;
   position: relative;
@@ -224,30 +268,30 @@
 }
 
 .packCardCount {
-  font-size: clamp(0.45rem, 1.4vw, 0.65rem);
+  font-size: clamp(0.4rem, 1.2vw, 0.6rem);
   color: #606880;
   position: relative;
 }
 
 .packDesc {
-  font-size: clamp(0.45rem, 1.4vw, 0.65rem);
+  font-size: clamp(0.4rem, 1.2vw, 0.6rem);
   color: #606880;
   position: relative;
 }
 
-/* -- Pack Bottom Area -- */
+/* ── Pack Bottom Area ── */
 
 .packBottom {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
+  gap: 3px;
   width: 100%;
   position: relative;
 }
 
 .packPrice {
-  font-size: clamp(0.65rem, 1.8vw, 0.85rem);
+  font-size: clamp(0.55rem, 1.6vw, 0.8rem);
   color: #c8a84b;
   font-weight: bold;
   font-family: var(--font-stats);
@@ -265,7 +309,7 @@
   color: #c0d0e0;
   border-radius: 0;
   padding: 2px 4px;
-  font-size: clamp(0.5rem, 1.4vw, 0.7rem);
+  font-size: clamp(0.45rem, 1.2vw, 0.65rem);
   cursor: pointer;
 }
 
@@ -274,9 +318,9 @@
   border: 2px solid;
   border-color: #30a060 #0a2c18 #0a2c18 #30a060;
   color: var(--pack-color, #90b0e0);
-  padding: 4px 8px;
+  padding: 3px 6px;
   border-radius: 0;
-  font-size: clamp(0.55rem, 1.6vw, 0.75rem);
+  font-size: clamp(0.5rem, 1.4vw, 0.72rem);
   cursor: pointer;
   position: relative;
   width: 100%;
@@ -289,13 +333,7 @@
 
 .buyBtn:disabled { opacity: 0.4; cursor: not-allowed; }
 
-.packLocked {
-  font-size: clamp(0.5rem, 1.4vw, 0.7rem);
-  color: #e06040;
-  position: relative;
-}
-
-/* -- Info Modal Overlay -- */
+/* ── Info Modal Overlay ── */
 
 .infoOverlay {
   position: fixed;
@@ -434,7 +472,7 @@
   background: #1a2840;
 }
 
-/* -- Legacy compat (kept for potential reuse) -- */
+/* ── Legacy compat ── */
 
 .sectionTitle {
   font-size: clamp(1rem, 2.5vw, 1.4rem);

--- a/js/react/screens/ShopScreen.tsx
+++ b/js/react/screens/ShopScreen.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useRef, useCallback, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useScreen }      from '../contexts/ScreenContext.js';
 import { useProgression } from '../contexts/ProgressionContext.js';
@@ -24,20 +24,16 @@ function totalCards(slots: PackSlotDef[]): number {
 /**
  * Compute rarity distribution summary from pack slots.
  * `guaranteed` = number of fixed slots for that rarity.
- * `chancePct` = combined probability (0-100) of getting that rarity
- *               from all distribution-based bonus slots.
+ * `chancePct` = probability (0-100) of getting that rarity from a bonus slot.
  */
 function computeDistribution(slots: PackSlotDef[]): { rarity: number; guaranteed: number; chancePct: number }[] {
   const map = new Map<number, { guaranteed: number; chancePct: number }>();
 
   for (const slot of slots) {
     if (slot.distribution) {
-      // Each distribution slot picks one rarity per card.
-      // Show per-card probability (all distribution slots share the same distribution).
       for (const [rarityStr, prob] of Object.entries(slot.distribution)) {
         const r = Number(rarityStr);
         const entry = map.get(r) ?? { guaranteed: 0, chancePct: 0 };
-        // prob is per-card; show it as percentage
         entry.chancePct = Math.round(prob * 100);
         map.set(r, entry);
       }
@@ -66,6 +62,17 @@ function countByRarity(cards: CardData[]): { rarity: number; count: number }[] {
     .sort((a, b) => a.rarity - b.rarity);
 }
 
+function useItemsPerPage() {
+  const [ipp, setIpp] = useState(() => window.matchMedia('(min-width: 700px)').matches ? 4 : 3);
+  useEffect(() => {
+    const mq = window.matchMedia('(min-width: 700px)');
+    const handler = (e: MediaQueryListEvent) => setIpp(e.matches ? 4 : 3);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+  return ipp;
+}
+
 export default function ShopScreen() {
   const { navigateTo } = useScreen();
   const { coins, refresh } = useProgression();
@@ -75,10 +82,39 @@ export default function ShopScreen() {
 
   const hasPackages = SHOP_DATA.packages.length > 0;
   const [activeTab, setActiveTab] = useState<Tab>('standard');
+  const [page, setPage] = useState(0);
+  const itemsPerPage = useItemsPerPage();
   const [infoTarget, setInfoTarget] = useState<{ pack: PackDef; type: 'pack' } | { pack: PackageDef; type: 'package' } | null>(null);
 
+  // Touch swipe tracking
+  const touchStartX = useRef(0);
+  const touchStartY = useRef(0);
+
   const packs = Object.values(PACK_TYPES);
-  const packages = SHOP_DATA.packages;
+  const unlockedPackages = SHOP_DATA.packages.filter(pkg => isPackageUnlocked(pkg));
+  const items = activeTab === 'standard' ? packs : unlockedPackages;
+  const totalPages = Math.ceil(items.length / itemsPerPage);
+
+  // Reset page when switching tabs or when items per page changes
+  useEffect(() => { setPage(0); }, [activeTab, itemsPerPage]);
+
+  const goPage = useCallback((p: number) => {
+    setPage(Math.max(0, Math.min(p, totalPages - 1)));
+  }, [totalPages]);
+
+  const onTouchStart = useCallback((e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0].clientX;
+    touchStartY.current = e.touches[0].clientY;
+  }, []);
+
+  const onTouchEnd = useCallback((e: React.TouchEvent) => {
+    const dx = e.changedTouches[0].clientX - touchStartX.current;
+    const dy = e.changedTouches[0].clientY - touchStartY.current;
+    if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > 50) {
+      if (dx < 0) goPage(page + 1);
+      else goPage(page - 1);
+    }
+  }, [goPage, page]);
 
   function buyPackage(packageId: string) {
     const pkg = SHOP_DATA.packages.find(p => p.id === packageId);
@@ -107,6 +143,10 @@ export default function ShopScreen() {
   function showInfo(pack: PackDef | PackageDef, type: 'pack' | 'package') {
     setInfoTarget({ pack: pack as any, type });
   }
+
+  // Slice items for current page
+  const startIdx = page * itemsPerPage;
+  const visibleItems = items.slice(startIdx, startIdx + itemsPerPage);
 
   return (
     <div className={styles.screen}>
@@ -137,39 +177,76 @@ export default function ShopScreen() {
         </div>
       )}
 
-      {/* Pack Grid */}
-      <div className={styles.packGrid}>
-        {activeTab === 'standard'
-          ? packs.map(pt => {
-              const packDef = SHOP_DATA.packs.find(p => p.id === pt.id)!;
-              const affordable = coins >= pt.price;
-              return (
-                <PackTile
-                  key={pt.id}
-                  pt={pt}
-                  packDef={packDef}
-                  affordable={affordable}
-                  onBuy={buy}
-                  onInfo={() => showInfo(packDef, 'pack')}
-                />
-              );
-            })
-          : packages.map(pkg => {
-              const unlocked = isPackageUnlocked(pkg);
-              const affordable = coins >= pkg.price;
-              return (
-                <PackageTile
-                  key={pkg.id}
-                  pkg={pkg}
-                  unlocked={unlocked}
-                  affordable={affordable}
-                  onBuy={buyPackage}
-                  onInfo={() => showInfo(pkg, 'package')}
-                />
-              );
-            })
-        }
+      {/* Carousel */}
+      <div className={styles.carousel} onTouchStart={onTouchStart} onTouchEnd={onTouchEnd}>
+        {/* Arrow left */}
+        {totalPages > 1 && (
+          <button
+            className={`${styles.arrowBtn} ${styles.arrowLeft}`}
+            disabled={page === 0}
+            onClick={() => goPage(page - 1)}
+            aria-label="Previous"
+          >‹</button>
+        )}
+
+        <div
+          className={styles.carouselTrack}
+          style={{ '--items-per-page': itemsPerPage } as React.CSSProperties}
+        >
+          {activeTab === 'standard'
+            ? (visibleItems as PackTypeInfo[]).map(pt => {
+                const packDef = SHOP_DATA.packs.find(p => p.id === pt.id)!;
+                const affordable = coins >= pt.price;
+                return (
+                  <PackTile
+                    key={pt.id}
+                    pt={pt}
+                    packDef={packDef}
+                    affordable={affordable}
+                    onBuy={buy}
+                    onInfo={() => showInfo(packDef, 'pack')}
+                  />
+                );
+              })
+            : (visibleItems as PackageDef[]).map(pkg => {
+                const affordable = coins >= pkg.price;
+                return (
+                  <PackageTile
+                    key={pkg.id}
+                    pkg={pkg}
+                    affordable={affordable}
+                    onBuy={buyPackage}
+                    onInfo={() => showInfo(pkg, 'package')}
+                  />
+                );
+              })
+          }
+        </div>
+
+        {/* Arrow right */}
+        {totalPages > 1 && (
+          <button
+            className={`${styles.arrowBtn} ${styles.arrowRight}`}
+            disabled={page >= totalPages - 1}
+            onClick={() => goPage(page + 1)}
+            aria-label="Next"
+          >›</button>
+        )}
       </div>
+
+      {/* Dots */}
+      {totalPages > 1 && (
+        <div className={styles.dots}>
+          {Array.from({ length: totalPages }, (_, i) => (
+            <button
+              key={i}
+              className={`${styles.dot}${i === page ? ` ${styles.dotActive}` : ''}`}
+              onClick={() => goPage(i)}
+              aria-label={`Page ${i + 1}`}
+            />
+          ))}
+        </div>
+      )}
 
       {/* Info Modal */}
       {infoTarget && (
@@ -209,7 +286,7 @@ function PackTile({ pt, packDef, affordable, onBuy, onInfo }: PackTileProps) {
 
   return (
     <div
-      className={`${styles.packTile}${affordable ? '' : ` ${styles.packDisabled}`}`}
+      className={styles.packTile}
       style={{ '--pack-color': pt.color } as React.CSSProperties}
     >
       <button className={styles.infoBtn} onClick={(e) => { e.stopPropagation(); onInfo(); }} aria-label="Pack info">?</button>
@@ -241,19 +318,17 @@ function PackTile({ pt, packDef, affordable, onBuy, onInfo }: PackTileProps) {
 
 interface PackageTileProps {
   pkg: PackageDef;
-  unlocked: boolean;
   affordable: boolean;
   onBuy: (packageId: string) => void;
   onInfo: () => void;
 }
 
-function PackageTile({ pkg, unlocked, affordable, onBuy, onInfo }: PackageTileProps) {
+function PackageTile({ pkg, affordable, onBuy, onInfo }: PackageTileProps) {
   const { t } = useTranslation();
-  const canBuy = unlocked && affordable;
 
   return (
     <div
-      className={`${styles.packTile}${canBuy ? '' : ` ${styles.packDisabled}`}`}
+      className={styles.packTile}
       style={{ '--pack-color': pkg.color } as React.CSSProperties}
     >
       <button className={styles.infoBtn} onClick={(e) => { e.stopPropagation(); onInfo(); }} aria-label="Pack info">?</button>
@@ -266,10 +341,7 @@ function PackageTile({ pkg, unlocked, affordable, onBuy, onInfo }: PackageTilePr
 
       <div className={styles.packBottom}>
         <div className={styles.packPrice}>◈ {pkg.price.toLocaleString()}</div>
-        {!unlocked && (
-          <div className={styles.packLocked}>{t('shop.locked')}</div>
-        )}
-        <button className={styles.buyBtn} disabled={!canBuy} onClick={() => onBuy(pkg.id)}>
+        <button className={styles.buyBtn} disabled={!affordable} onClick={() => onBuy(pkg.id)}>
           {t('shop.buy_btn')}
         </button>
       </div>


### PR DESCRIPTION
- Restore carousel with swipe, arrows, and dots (3 items/page mobile, 4 desktop)
- Use CSS grid within carousel track for uniform pack layout
- Change aspect ratio from 2:3 to 3:4 for better proportions
- Hide locked packages instead of showing them dimmed
- Only disable buy button when coins insufficient (packs always full opacity)

https://claude.ai/code/session_019itNms213uqSmbqb43sWCo