### PR TITLE
feat(ui): add POW/TEC battle badges with coin multipliers and S-rank card drops

### DIFF
--- a/js/battle-badges.ts
+++ b/js/battle-badges.ts
@@ -1,0 +1,219 @@
+import type { DuelStats } from './types.js';
+import { Rarity } from './types.js';
+import { CARD_DB } from './cards.js';
+
+// ── Types ────────────────────────────────────────────────────
+
+export type BadgeRank = 'S' | 'A' | 'B';
+export type BadgeCategory = 'POW' | 'TEC';
+
+export interface BadgeResult {
+  category: BadgeCategory;
+  rank: BadgeRank;
+  score: number;
+}
+
+export interface BattleBadges {
+  pow: BadgeResult;
+  tec: BadgeResult;
+  best: BadgeRank;
+  coinMultiplier: number;
+}
+
+// ── Helpers ──────────────────────────────────────────────────
+
+/** Pick the first matching range value. Ranges are [max, modifier] checked with <=. */
+function rangeScore(value: number, ranges: [number, number][]): number {
+  for (const [max, mod] of ranges) {
+    if (value <= max) return mod;
+  }
+  return ranges[ranges.length - 1][1];
+}
+
+const RANK_ORDER: Record<BadgeRank, number> = { S: 3, A: 2, B: 1 };
+
+function bestRank(a: BadgeRank, b: BadgeRank): BadgeRank {
+  return RANK_ORDER[a] >= RANK_ORDER[b] ? a : b;
+}
+
+function multiplierForRank(rank: BadgeRank): number {
+  switch (rank) {
+    case 'S': return 2.5;
+    case 'A': return 1.0;
+    case 'B': return 0.8;
+  }
+}
+
+// ── POW scoring ──────────────────────────────────────────────
+
+function scorePOW(stats: DuelStats): number {
+  let score = 50;
+
+  // Victory condition
+  score += stats.endReason === 'lp_zero' ? 2 : -20;
+
+  // Turns
+  score += rangeScore(stats.turns, [
+    [4, 12], [8, 8], [16, 0], [24, -8], [Infinity, -12],
+  ]);
+
+  // Monsters played
+  score += rangeScore(stats.monstersPlayed, [
+    [3, 4], [6, 2], [10, 0], [15, -4], [Infinity, -8],
+  ]);
+
+  // Fusions performed (fusions = power)
+  score += rangeScore(stats.fusionsPerformed, [
+    [0, -2], [2, 4], [4, 2], [Infinity, 0],
+  ]);
+
+  // LP remaining
+  score += rangeScore(stats.lpRemaining, [
+    [999, -4], [3999, 0], [6999, 2], [7999, 6], [Infinity, 8],
+  ]);
+
+  // Opponent LP remaining (lower = better for POW)
+  score += rangeScore(stats.opponentLpRemaining, [
+    [0, 2], [999, 0], [Infinity, -4],
+  ]);
+
+  // Cards drawn (fewer = faster game)
+  score += rangeScore(stats.cardsDrawn, [
+    [5, 4], [10, 2], [20, 0], [30, -4], [Infinity, -8],
+  ]);
+
+  return score;
+}
+
+function rankPOW(score: number): BadgeRank {
+  if (score >= 80) return 'S';
+  if (score >= 60) return 'A';
+  return 'B';
+}
+
+// ── TEC scoring ──────────────────────────────────────────────
+
+function scoreTEC(stats: DuelStats): number {
+  let score = 50;
+
+  // Victory condition — LP win is clean, deck out is sloppy
+  score += stats.endReason === 'lp_zero' ? 2 : -20;
+
+  // Turns (fewer = more efficient)
+  score += rangeScore(stats.turns, [
+    [4, 12], [8, 8], [16, 0], [24, -8], [Infinity, -12],
+  ]);
+
+  // Spells activated (fewer = more technical)
+  score += rangeScore(stats.spellsActivated, [
+    [0, 8], [2, 4], [4, 0], [8, -6], [Infinity, -12],
+  ]);
+
+  // Traps activated (fewer = more technical, heavy penalty)
+  score += rangeScore(stats.trapsActivated, [
+    [0, 6], [1, 0], [3, -10], [5, -18], [Infinity, -26],
+  ]);
+
+  // Fusions performed (fewer = more technical)
+  score += rangeScore(stats.fusionsPerformed, [
+    [0, 6], [2, 0], [4, -4], [8, -8], [Infinity, -12],
+  ]);
+
+  // Monsters played (fewer = more efficient)
+  score += rangeScore(stats.monstersPlayed, [
+    [3, 8], [6, 2], [10, 0], [15, -6], [Infinity, -10],
+  ]);
+
+  // LP remaining (high = clean win)
+  score += rangeScore(stats.lpRemaining, [
+    [999, -4], [3999, -2], [6999, 0], [7999, 4], [Infinity, 6],
+  ]);
+
+  // Graveyard size (fewer resources spent = more technical)
+  score += rangeScore(stats.graveyardSize, [
+    [4, 8], [8, 4], [14, 0], [20, -6], [Infinity, -10],
+  ]);
+
+  return score;
+}
+
+function rankTEC(score: number): BadgeRank {
+  // Same direction as POW: higher = better
+  if (score >= 80) return 'S';
+  if (score >= 60) return 'A';
+  return 'B';
+}
+
+// ── Public API ───────────────────────────────────────────────
+
+export function calculateBattleBadges(stats: DuelStats): BattleBadges {
+  const powScore = scorePOW(stats);
+  const tecScore = scoreTEC(stats);
+
+  const pow: BadgeResult = { category: 'POW', rank: rankPOW(powScore), score: powScore };
+  const tec: BadgeResult = { category: 'TEC', rank: rankTEC(tecScore), score: tecScore };
+  const best = bestRank(pow.rank, tec.rank);
+
+  return { pow, tec, best, coinMultiplier: multiplierForRank(best) };
+}
+
+// ── S-rank card drops ────────────────────────────────────────
+
+const DROP_WEIGHTS: [Rarity, number][] = [
+  [Rarity.Common, 0.50],
+  [Rarity.Uncommon, 0.30],
+  [Rarity.Rare, 0.149],
+  [Rarity.SuperRare, 0.05],
+  [Rarity.UltraRare, 0.001],
+];
+
+const RARITY_FALLBACK: Rarity[] = [
+  Rarity.UltraRare, Rarity.SuperRare, Rarity.Rare, Rarity.Uncommon, Rarity.Common,
+];
+
+function rollRarity(): Rarity {
+  const r = Math.random();
+  let cumulative = 0;
+  for (const [rarity, weight] of DROP_WEIGHTS) {
+    cumulative += weight;
+    if (r < cumulative) return rarity;
+  }
+  return Rarity.Common;
+}
+
+/**
+ * Pick `count` random cards from the opponent's deck pool, weighted by rarity.
+ * Falls back to lower rarities if no cards match the rolled rarity.
+ */
+export function rollBadgeCardDrops(opponentDeckIds: (string | number)[], count: number): string[] {
+  // De-duplicate deck IDs and resolve card data
+  const uniqueIds = [...new Set(opponentDeckIds.map(String))];
+  const cards = uniqueIds.map(id => CARD_DB[id]).filter(Boolean);
+  if (cards.length === 0) return [];
+
+  const result: string[] = [];
+
+  for (let i = 0; i < count; i++) {
+    const targetRarity = rollRarity();
+
+    // Find cards at target rarity, falling back to lower rarities
+    const fallbackIdx = RARITY_FALLBACK.indexOf(targetRarity);
+    let pool = cards.filter(c => c.rarity === targetRarity);
+
+    if (pool.length === 0) {
+      // Walk down the fallback chain
+      for (let j = fallbackIdx + 1; j < RARITY_FALLBACK.length; j++) {
+        pool = cards.filter(c => c.rarity === RARITY_FALLBACK[j]);
+        if (pool.length > 0) break;
+      }
+    }
+
+    // If still empty (shouldn't happen), pick any card
+    if (pool.length === 0) pool = cards;
+
+    const pick = pool[Math.floor(Math.random() * pool.length)];
+    result.push(String(pick.id));
+  }
+
+  return result;
+}

--- a/js/react/contexts/GameContext.tsx
+++ b/js/react/contexts/GameContext.tsx
@@ -9,6 +9,8 @@ import { useScreen } from './ScreenContext.js';
 import { useCampaign } from './CampaignContext.js';
 import { Audio } from '../../audio.js';
 import { OPPONENT_CONFIGS } from '../../cards.js';
+import { calculateBattleBadges, rollBadgeCardDrops } from '../../battle-badges.js';
+import type { BattleBadges } from '../../battle-badges.js';
 
 interface GameCtx {
   gameState:          GameState | null;
@@ -158,6 +160,20 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
         extra?: Record<string, unknown>,
       ): Record<string, unknown> => ({ result: r, stats, ...extra });
 
+      // Compute battle badges on victory
+      const badges: BattleBadges | null = result === 'victory' && stats ? calculateBattleBadges(stats) : null;
+
+      /** Apply badge coin multiplier to a base amount */
+      const applyBadgeMultiplier = (base: number): number =>
+        badges ? Math.round(base * badges.coinMultiplier) : base;
+
+      /** Roll S-rank card drops from opponent deck, returns card IDs or empty array */
+      const rollSRankDrops = (): string[] => {
+        if (!badges || badges.best !== 'S' || !opponentId) return [];
+        const cfg = (OPPONENT_CONFIGS as OpponentConfig[]).find(c => c.id === opponentId);
+        return cfg?.deckIds ? rollBadgeCardDrops(cfg.deckIds, 3) : [];
+      };
+
       // Campaign duel
       const pending = pendingDuelRef.current;
       if (pending) {
@@ -194,15 +210,22 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
               // Final gauntlet duel won — complete node, give rewards
               setPendingDuelRef.current(null);
               Progression.markNodeComplete(pending.nodeId);
-              if (pending.rewards) {
-                if (pending.rewards.coins) Progression.addCoins(pending.rewards.coins);
-                if (pending.rewards.cards?.length) Progression.addCardsToCollection(pending.rewards.cards);
-              }
+
+              // Badge-adjusted rewards
+              const badgeDrops = rollSRankDrops();
+              const adjustedRewards = { ...pending.rewards };
+              if (adjustedRewards.coins) adjustedRewards.coins = applyBadgeMultiplier(adjustedRewards.coins);
+              if (adjustedRewards.coins) Progression.addCoins(adjustedRewards.coins);
+              const allCards = [...(adjustedRewards.cards ?? []), ...badgeDrops];
+              if (allCards.length) Progression.addCardsToCollection(allCards);
+              if (badgeDrops.length) adjustedRewards.cards = allCards;
+
               refreshRef.current();
               refreshCampaignRef.current();
               if (pending.postDialogue && pending.postDialogue.length > 0) {
                 navigateToRef.current('duel-result', resultData('victory', {
-                  rewards: pending.rewards,
+                  rewards: adjustedRewards,
+                  badges,
                   nextScreen: 'dialogue',
                   dialogueData: {
                     scene: pending.postDialogue as unknown as Record<string, unknown>,
@@ -211,7 +234,8 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
                 }));
               } else {
                 navigateToRef.current('duel-result', resultData('victory', {
-                  rewards: pending.rewards,
+                  rewards: adjustedRewards,
+                  badges,
                   nextScreen: 'campaign',
                 }));
               }
@@ -239,10 +263,22 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
             } else {
               console.warn(`[GameContext] Campaign node "${pending.nodeId}" not found — skipping markNodeComplete.`);
             }
-            if (pending.rewards) {
-              if (pending.rewards.coins) Progression.addCoins(pending.rewards.coins);
-              if (pending.rewards.cards?.length) Progression.addCardsToCollection(pending.rewards.cards);
+
+            // Badge-adjusted rewards
+            const badgeDrops = result === 'victory' ? rollSRankDrops() : [];
+            const adjustedRewards = pending.rewards ? { ...pending.rewards } : undefined;
+            if (adjustedRewards?.coins && result === 'victory') {
+              adjustedRewards.coins = applyBadgeMultiplier(adjustedRewards.coins);
             }
+            if (adjustedRewards?.coins) Progression.addCoins(adjustedRewards.coins);
+            const allCards = [...(adjustedRewards?.cards ?? []), ...badgeDrops];
+            if (allCards.length) {
+              Progression.addCardsToCollection(allCards);
+              if (adjustedRewards && badgeDrops.length) adjustedRewards.cards = allCards;
+            }
+
+            // Overwrite pending.rewards reference for navigation below
+            (pending as { rewards: typeof adjustedRewards }).rewards = adjustedRewards;
           }
           // Also record the duel result for win/loss stats
           if (opponentId) {
@@ -253,6 +289,7 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
           if (result === 'victory' && pending.postDialogue && pending.postDialogue.length > 0) {
             navigateToRef.current('duel-result', resultData('victory', {
               rewards: pending.rewards,
+              badges,
               nextScreen: 'dialogue',
               dialogueData: {
                 scene: pending.postDialogue as unknown as Record<string, unknown>,
@@ -262,6 +299,7 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
           } else if (result === 'victory') {
             navigateToRef.current('duel-result', resultData('victory', {
               rewards: pending.rewards,
+              badges,
               nextScreen: 'campaign',
             }));
           } else if (isComplete && pending.postDialogue && pending.postDialogue.length > 0) {
@@ -288,18 +326,25 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
             const cfg = OPPONENT_CONFIGS.find((o) => o.id === opponentId);
             let coinsEarned = 0;
             if (cfg) {
-              coinsEarned = result === 'victory' ? cfg.coinsWin : 0;
+              coinsEarned = result === 'victory' ? applyBadgeMultiplier(cfg.coinsWin) : 0;
               Progression.addCoins(coinsEarned);
             }
+            // S-rank card drops
+            const badgeDrops = rollSRankDrops();
+            if (badgeDrops.length) Progression.addCardsToCollection(badgeDrops);
+
             refreshRef.current();
             navigateToRef.current('duel-result', resultData(result, {
-              rewards: coinsEarned > 0 ? { coins: coinsEarned } : undefined,
+              rewards: coinsEarned > 0 || badgeDrops.length > 0
+                ? { coins: coinsEarned || undefined, cards: badgeDrops.length > 0 ? badgeDrops : undefined }
+                : undefined,
+              badges,
               mode: 'free',
             }));
           })
         ).catch(e => console.error('[GameContext] Failed to apply standard duel result:', e));
       } else {
-        navigateToRef.current('duel-result', resultData(result, { mode: 'free' }));
+        navigateToRef.current('duel-result', resultData(result, { badges, mode: 'free' }));
       }
     },
   }), []); // stable — uses refs internally

--- a/js/react/screens/DuelResultScreen.module.css
+++ b/js/react/screens/DuelResultScreen.module.css
@@ -143,6 +143,55 @@
   font-size: 0.5rem;
 }
 
+/* ── Badges ──────────────────────────────────────────────── */
+.badges {
+  display: flex;
+  gap: 16px;
+  justify-content: center;
+  opacity: 0;
+}
+
+.badge {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 16px;
+  border: 1px solid rgba(255,255,255,0.15);
+  border-radius: 4px;
+  background: rgba(0,0,0,0.5);
+  min-width: 72px;
+}
+
+.badgeCategory {
+  font-size: 0.45rem;
+  letter-spacing: 2px;
+  color: #908070;
+  font-family: 'Press Start 2P', monospace;
+}
+
+.badgeRank {
+  font-size: 1rem;
+  font-family: 'Press Start 2P', monospace;
+  text-shadow: 0 0 12px currentColor;
+}
+
+.badgeS { color: #f5c518; border-color: rgba(245,197,24,0.4); }
+.badgeA { color: #c0c0c0; border-color: rgba(192,192,192,0.3); }
+.badgeB { color: #cd7f32; border-color: rgba(205,127,50,0.3); }
+
+.badgeMultiplier {
+  font-size: 0.45rem;
+  letter-spacing: 1px;
+  font-family: 'Press Start 2P', monospace;
+  margin-top: 4px;
+  opacity: 0;
+}
+
+.multiplierS { color: #f5c518; text-shadow: 0 0 10px rgba(245,197,24,0.5); }
+.multiplierA { color: #b0a090; }
+.multiplierB { color: #cd7f32; }
+
 /* ── Rewards ─────────────────────────────────────────────── */
 .rewards {
   display: flex;

--- a/js/react/screens/DuelResultScreen.tsx
+++ b/js/react/screens/DuelResultScreen.tsx
@@ -4,10 +4,11 @@ import { gsap } from 'gsap';
 import { useScreen } from '../contexts/ScreenContext.js';
 import { Audio } from '../../audio.js';
 import type { DuelStats } from '../../types.js';
+import type { BattleBadges } from '../../battle-badges.js';
 import styles from './DuelResultScreen.module.css';
 
 const PARTICLE_COUNT = 22;
-const ANIM_LOCK_MS = 3200;
+const ANIM_LOCK_MS = 3600;
 
 interface Rewards {
   coins?: number;
@@ -23,6 +24,7 @@ export default function DuelResultScreen() {
   const stats = screenData?.stats as DuelStats | undefined;
   const rewards = screenData?.rewards as Rewards | undefined;
   const mode = screenData?.mode as 'campaign' | 'free' | undefined;
+  const badges = screenData?.badges as BattleBadges | undefined;
 
   const [locked, setLocked] = useState(true);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -32,6 +34,8 @@ export default function DuelResultScreen() {
   const reasonRef = useRef<HTMLParagraphElement>(null);
   const statsPanelRef = useRef<HTMLDivElement>(null);
   const oppStatsPanelRef = useRef<HTMLDivElement>(null);
+  const badgesRef = useRef<HTMLDivElement>(null);
+  const badgeMultRef = useRef<HTMLDivElement>(null);
   const rewardsRef = useRef<HTMLDivElement>(null);
   const continueRef = useRef<HTMLParagraphElement>(null);
 
@@ -130,6 +134,24 @@ export default function DuelResultScreen() {
       }, 1.4);
     }
 
+    // Badges (victory only)
+    if (badgesRef.current) {
+      gsap.set(badgesRef.current, { y: 15, opacity: 0 });
+      tl.to(badgesRef.current, {
+        y: 0, opacity: 1, duration: 0.4,
+        ease: 'back.out(1.4)',
+      }, 1.6);
+    }
+
+    // Badge multiplier text
+    if (badgeMultRef.current) {
+      gsap.set(badgeMultRef.current, { opacity: 0 });
+      tl.to(badgeMultRef.current, {
+        opacity: 1, duration: 0.3,
+        ease: 'power2.out',
+      }, 1.9);
+    }
+
     // Rewards (victory only)
     if (rewardsRef.current) {
       gsap.set(rewardsRef.current, { y: 15, opacity: 0 });
@@ -139,7 +161,7 @@ export default function DuelResultScreen() {
         onStart: () => {
           if (victory && rewards?.coins) Audio.playSfx('sfx_coin');
         },
-      }, 1.8);
+      }, 2.1);
     }
 
     // Continue prompt
@@ -148,7 +170,7 @@ export default function DuelResultScreen() {
       tl.to(continueRef.current, {
         opacity: 1, duration: 0.3,
         ease: 'none',
-      }, 2.5);
+      }, 2.8);
     }
 
     // Unlock input after animation
@@ -273,6 +295,37 @@ export default function DuelResultScreen() {
               </div>
             </div>
           </div>
+        )}
+
+        {/* Battle Badges (victory only) */}
+        {victory && badges && (
+          <>
+            <div ref={badgesRef} className={styles.badges}>
+              {([badges.pow, badges.tec] as const).map((b) => (
+                <div
+                  key={b.category}
+                  className={`${styles.badge} ${b.rank === 'S' ? styles.badgeS : b.rank === 'A' ? styles.badgeA : styles.badgeB}`}
+                >
+                  <span className={styles.badgeCategory}>
+                    {t(`duelResult.badge_${b.category.toLowerCase()}`)}
+                  </span>
+                  <span className={styles.badgeRank}>
+                    {t(`duelResult.badge_rank_${b.rank.toLowerCase()}`)}
+                  </span>
+                </div>
+              ))}
+            </div>
+            <div
+              ref={badgeMultRef}
+              className={`${styles.badgeMultiplier} ${
+                badges.best === 'S' ? styles.multiplierS
+                : badges.best === 'A' ? styles.multiplierA
+                : styles.multiplierB
+              }`}
+            >
+              {t('duelResult.coin_multiplier', { multiplier: badges.coinMultiplier })}
+            </div>
+          </>
         )}
 
         {/* Rewards (victory only) */}

--- a/locales/de.json
+++ b/locales/de.json
@@ -395,6 +395,13 @@
     "win_reason_deckout": "Gegners Deck hatte keine Karten mehr.",
     "loss_reason_lp": "Deine Lebenspunkte wurden auf 0 reduziert.",
     "loss_reason_deckout": "Dein Deck hatte keine Karten mehr.",
-    "loss_reason_surrender": "Du hast aufgegeben."
+    "loss_reason_surrender": "Du hast aufgegeben.",
+    "badge_pow": "POW",
+    "badge_tec": "TEC",
+    "badge_rank_s": "S",
+    "badge_rank_a": "A",
+    "badge_rank_b": "B",
+    "coin_multiplier": "x{{multiplier}} Münzen",
+    "badge_cards_earned": "+{{count}} Karte(n) vom Gegner"
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -395,6 +395,13 @@
     "win_reason_deckout": "Opponent's deck ran out of cards.",
     "loss_reason_lp": "Your life points were reduced to 0.",
     "loss_reason_deckout": "Your deck ran out of cards.",
-    "loss_reason_surrender": "You surrendered."
+    "loss_reason_surrender": "You surrendered.",
+    "badge_pow": "POW",
+    "badge_tec": "TEC",
+    "badge_rank_s": "S",
+    "badge_rank_a": "A",
+    "badge_rank_b": "B",
+    "coin_multiplier": "x{{multiplier}} Coins",
+    "badge_cards_earned": "+{{count}} Card(s) from Enemy"
   }
 }

--- a/tests/battle-badges.test.js
+++ b/tests/battle-badges.test.js
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest';
+import { calculateBattleBadges, rollBadgeCardDrops } from '../js/battle-badges.ts';
+
+// ── Helpers ────────────────────────────────────────────────
+
+function makeStats(overrides = {}) {
+  return {
+    turns: 10,
+    monstersPlayed: 4,
+    fusionsPerformed: 1,
+    spellsActivated: 2,
+    trapsActivated: 0,
+    cardsDrawn: 8,
+    lpRemaining: 5000,
+    opponentLpRemaining: 0,
+    deckRemaining: 10,
+    graveyardSize: 8,
+    opponentMonstersPlayed: 5,
+    opponentFusionsPerformed: 1,
+    opponentSpellsActivated: 2,
+    opponentTrapsActivated: 1,
+    opponentDeckRemaining: 8,
+    opponentGraveyardSize: 6,
+    endReason: 'lp_zero',
+    ...overrides,
+  };
+}
+
+// ── POW tests ────────────────────────────────────────────────
+
+describe('calculateBattleBadges – POW scoring', () => {
+  it('gives POW-S for fast, dominant victory', () => {
+    const stats = makeStats({
+      turns: 3,
+      monstersPlayed: 2,
+      fusionsPerformed: 1,
+      cardsDrawn: 3,
+      lpRemaining: 8000,
+      opponentLpRemaining: 0,
+      endReason: 'lp_zero',
+    });
+    const badges = calculateBattleBadges(stats);
+    expect(badges.pow.rank).toBe('S');
+    expect(badges.pow.score).toBeGreaterThanOrEqual(80);
+  });
+
+  it('gives POW-B for slow, grindy victory', () => {
+    const stats = makeStats({
+      turns: 30,
+      monstersPlayed: 14,
+      fusionsPerformed: 0,
+      cardsDrawn: 25,
+      lpRemaining: 500,
+      opponentLpRemaining: 0,
+      endReason: 'lp_zero',
+    });
+    const badges = calculateBattleBadges(stats);
+    expect(badges.pow.rank).toBe('B');
+    expect(badges.pow.score).toBeLessThan(60);
+  });
+
+  it('penalizes deck-out victories for POW', () => {
+    const stats = makeStats({ endReason: 'deck_out' });
+    const badges = calculateBattleBadges(stats);
+    // Deck-out is -20 vs +2 for lp_zero → 22 point difference
+    const lpStats = makeStats({ endReason: 'lp_zero' });
+    const lpBadges = calculateBattleBadges(lpStats);
+    expect(badges.pow.score).toBe(lpBadges.pow.score - 22);
+  });
+});
+
+// ── TEC tests ────────────────────────────────────────────────
+
+describe('calculateBattleBadges – TEC scoring', () => {
+  it('gives TEC-S for minimal-resource victory', () => {
+    const stats = makeStats({
+      turns: 3,
+      monstersPlayed: 2,
+      fusionsPerformed: 0,
+      spellsActivated: 0,
+      trapsActivated: 0,
+      lpRemaining: 8000,
+      graveyardSize: 2,
+      endReason: 'lp_zero',
+    });
+    const badges = calculateBattleBadges(stats);
+    expect(badges.tec.rank).toBe('S');
+    expect(badges.tec.score).toBeGreaterThanOrEqual(80);
+  });
+
+  it('gives TEC-B for resource-heavy victory', () => {
+    const stats = makeStats({
+      turns: 25,
+      monstersPlayed: 12,
+      fusionsPerformed: 6,
+      spellsActivated: 7,
+      trapsActivated: 4,
+      lpRemaining: 1000,
+      graveyardSize: 22,
+      endReason: 'lp_zero',
+    });
+    const badges = calculateBattleBadges(stats);
+    expect(badges.tec.rank).toBe('B');
+    expect(badges.tec.score).toBeLessThan(60);
+  });
+
+  it('penalizes deck-out for TEC (-22 point swing)', () => {
+    const deckOutStats = makeStats({ endReason: 'deck_out' });
+    const lpStats = makeStats({ endReason: 'lp_zero' });
+    const lpScore = calculateBattleBadges(lpStats).tec.score;
+    const deckOutScore = calculateBattleBadges(deckOutStats).tec.score;
+    // LP win gives +2, deck_out gives -20 → 22 point difference
+    expect(lpScore - deckOutScore).toBe(22);
+  });
+});
+
+// ── Best rank & multiplier ───────────────────────────────────
+
+describe('calculateBattleBadges – best rank & multiplier', () => {
+  it('picks the best rank across both badges', () => {
+    // Fast dominant game → likely POW-S, TEC-S
+    const stats = makeStats({
+      turns: 3, monstersPlayed: 2, fusionsPerformed: 1,
+      spellsActivated: 0, trapsActivated: 0,
+      cardsDrawn: 3, lpRemaining: 8000, graveyardSize: 2,
+    });
+    const badges = calculateBattleBadges(stats);
+    expect(badges.best).toBe('S');
+    expect(badges.coinMultiplier).toBe(2.5);
+  });
+
+  it('returns 0.8 multiplier for B-rank', () => {
+    const stats = makeStats({
+      turns: 30, monstersPlayed: 14, fusionsPerformed: 6,
+      spellsActivated: 10, trapsActivated: 5,
+      cardsDrawn: 30, lpRemaining: 500, graveyardSize: 25,
+      endReason: 'deck_out',
+    });
+    const badges = calculateBattleBadges(stats);
+    expect(badges.best).toBe('B');
+    expect(badges.coinMultiplier).toBe(0.8);
+  });
+
+  it('returns 1.0 multiplier for A-rank', () => {
+    // Moderate game → likely A range for at least one
+    const stats = makeStats({
+      turns: 6, monstersPlayed: 4, fusionsPerformed: 1,
+      cardsDrawn: 6, lpRemaining: 6000, opponentLpRemaining: 0,
+    });
+    const badges = calculateBattleBadges(stats);
+    // POW should be A or S; check multiplier is correct for the rank
+    if (badges.best === 'A') expect(badges.coinMultiplier).toBe(1.0);
+    else if (badges.best === 'S') expect(badges.coinMultiplier).toBe(2.5);
+  });
+});
+
+// ── Card drops ───────────────────────────────────────────────
+
+describe('rollBadgeCardDrops', () => {
+  it('returns the requested number of card IDs', () => {
+    const drops = rollBadgeCardDrops(['1', '2', '3', '54', '55'], 3);
+    expect(drops).toHaveLength(3);
+    drops.forEach(id => expect(typeof id).toBe('string'));
+  });
+
+  it('returns empty array for empty deck', () => {
+    const drops = rollBadgeCardDrops([], 3);
+    expect(drops).toEqual([]);
+  });
+
+  it('de-duplicates deck IDs before picking', () => {
+    // Even with dupes, should still return valid picks
+    const drops = rollBadgeCardDrops(['54', '54', '54', '55', '55'], 3);
+    expect(drops).toHaveLength(3);
+  });
+
+  it('handles numeric deck IDs', () => {
+    const drops = rollBadgeCardDrops([54, 55, 56], 2);
+    expect(drops).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Add a Yu-Gi-Oh FM-inspired badge system that rates duel performance on
POW (power/aggression) and TEC (technical/efficiency) axes. Each badge
earns S/A/B rank based on scoring criteria like turns, monsters played,
fusions, spells/traps, LP remaining, and graveyard size.

Best rank across both badges determines coin reward multiplier:
- S = 250% coins + 3 random cards from enemy deck (rarity-weighted)
- A = 100% coins (baseline)
- B = 80% coins

https://claude.ai/code/session_0127nPHHoG41xfdXCrEqRtM6