### PR TITLE
feat(shop): add global rarity drop rates and pity system

### DIFF
--- a/js/battle-badges.ts
+++ b/js/battle-badges.ts
@@ -1,6 +1,7 @@
 import type { DuelStats } from './types.js';
 import { Rarity } from './types.js';
 import { CARD_DB } from './cards.js';
+import { RARITY_DROP_RATES } from './react/utils/pack-logic.js';
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -159,14 +160,6 @@ export function calculateBattleBadges(stats: DuelStats): BattleBadges {
 
 // ── S-rank card drops ────────────────────────────────────────
 
-const DROP_WEIGHTS: [Rarity, number][] = [
-  [Rarity.Common, 0.50],
-  [Rarity.Uncommon, 0.30],
-  [Rarity.Rare, 0.149],
-  [Rarity.SuperRare, 0.05],
-  [Rarity.UltraRare, 0.001],
-];
-
 const RARITY_FALLBACK: Rarity[] = [
   Rarity.UltraRare, Rarity.SuperRare, Rarity.Rare, Rarity.Uncommon, Rarity.Common,
 ];
@@ -174,9 +167,12 @@ const RARITY_FALLBACK: Rarity[] = [
 function rollRarity(): Rarity {
   const r = Math.random();
   let cumulative = 0;
-  for (const [rarity, weight] of DROP_WEIGHTS) {
-    cumulative += weight;
-    if (r < cumulative) return rarity;
+  const entries = Object.entries(RARITY_DROP_RATES)
+    .map(([k, v]) => [Number(k), v] as [number, number])
+    .sort((a, b) => a[1] - b[1]);
+  for (const [rarity, prob] of entries) {
+    cumulative += prob;
+    if (r < cumulative) return rarity as Rarity;
   }
   return Rarity.Common;
 }

--- a/js/react/utils/pack-logic.ts
+++ b/js/react/utils/pack-logic.ts
@@ -29,25 +29,34 @@ export const PACK_TYPES: Record<string, PackTypeInfo> = new Proxy({} as Record<s
   },
 });
 
+// ── Global rarity drop rates ────────────────────────────────
+
+/** Default drop-chance distribution used for any slot without an explicit rarity or distribution. */
+export const RARITY_DROP_RATES: Record<string, number> = {
+  [Rarity.Common]:    0.60,
+  [Rarity.Uncommon]:  0.30,
+  [Rarity.Rare]:      0.089,
+  [Rarity.SuperRare]: 0.01,
+  [Rarity.UltraRare]: 0.001,
+};
+
 // ── Data-driven rarity picker ───────────────────────────────
 
 function _pickRarityFromSlot(slot: PackSlotDef): Rarity {
-  if (slot.distribution) {
+  const dist = slot.distribution ?? (slot.rarity == null ? RARITY_DROP_RATES : undefined);
+  if (dist) {
     const r = Math.random();
     let cumulative = 0;
-    const entries = Object.entries(slot.distribution)
+    const entries = Object.entries(dist)
       .map(([k, v]) => [Number(k), v] as [number, number])
-      .sort((a, b) => b[1] - a[1]); // sort by probability desc for stable iteration
-    // iterate from lowest probability to highest to match cumulative check
-    entries.sort((a, b) => a[1] - b[1]);
+      .sort((a, b) => a[1] - b[1]);
     for (const [rarity, prob] of entries) {
       cumulative += prob;
       if (r < cumulative) return rarity as Rarity;
     }
-    // fallback to last entry
     return entries[entries.length - 1][0] as Rarity;
   }
-  return (slot.rarity ?? Rarity.Common) as Rarity;
+  return slot.rarity as Rarity;
 }
 
 // ── Card pool helpers ───────────────────────────────────────
@@ -82,6 +91,27 @@ function _expandSlots(packDef: PackDef): Rarity[] {
       rarities.push(_pickRarityFromSlot(slot));
     }
   }
+  return rarities;
+}
+
+// ── Pity system ────────────────────────────────────────────
+
+/**
+ * If no card in the array is Rare or better, replace one card with Rare.
+ * Prefers replacing Uncommon over Common (highest rarity below Rare first).
+ */
+function _applyPity(rarities: Rarity[]): Rarity[] {
+  if (rarities.some(r => r >= Rarity.Rare)) return rarities;
+
+  let replaceIdx = 0;
+  let bestRarity = -1;
+  for (let i = 0; i < rarities.length; i++) {
+    if (rarities[i] > bestRarity) {
+      bestRarity = rarities[i];
+      replaceIdx = i;
+    }
+  }
+  rarities[replaceIdx] = Rarity.Rare;
   return rarities;
 }
 
@@ -175,7 +205,7 @@ export function openPack(packType: string, race: Race | null = null): CardData[]
     packDef.filter === 'byRace' ? race
     : null;
 
-  const rarities = _expandSlots(packDef);
+  const rarities = _applyPity(_expandSlots(packDef));
 
   if (packDef.cardPool) {
     let pool = buildCardPool(packDef.cardPool);
@@ -209,7 +239,7 @@ export function openPackage(packageId: string): CardData[] {
   if (!pkg) return [];
 
   const pool = buildCardPool(pkg.cardPool);
-  const rarities = _expandSlots(pkg);
+  const rarities = _applyPity(_expandSlots(pkg));
 
   return rarities.map(rarity => {
     let candidates = pool.filter(c => (c.rarity ?? Rarity.Common) === rarity);

--- a/js/shop-data.ts
+++ b/js/shop-data.ts
@@ -76,9 +76,7 @@ export interface ShopData {
 // ── Slot templates ──────────────────────────────────────────
 
 const STANDARD_SLOTS: PackSlotDef[] = [
-  { count: 5, rarity: 1 },                                              // slots 1-5: Common
-  { count: 2, rarity: 2 },                                              // slots 6-7: Uncommon
-  { count: 1, rarity: 4 },                                              // slot 8: Rare
+  { count: 8 },                                                         // slots 1-8: global rarity distribution
   { count: 1, pool: 'guaranteed_rare_plus', distribution: { '4': 0.75, '6': 0.20, '8': 0.05 } }, // slot 9
 ];
 

--- a/public/base.tcg-src/shop.json
+++ b/public/base.tcg-src/shop.json
@@ -8,27 +8,8 @@
       "icon": "◈",
       "color": "#2a7848",
       "slots": [
-        {
-          "count": 5,
-          "rarity": 1
-        },
-        {
-          "count": 2,
-          "rarity": 2
-        },
-        {
-          "count": 1,
-          "rarity": 4
-        },
-        {
-          "count": 1,
-          "pool": "guaranteed_rare_plus",
-          "distribution": {
-            "4": 0.75,
-            "6": 0.2,
-            "8": 0.05
-          }
-        }
+        { "count": 8 },
+        { "count": 1, "pool": "guaranteed_rare_plus", "distribution": { "4": 0.75, "6": 0.2, "8": 0.05 } }
       ]
     },
     {
@@ -39,27 +20,8 @@
       "icon": "⚔",
       "color": "#a06020",
       "slots": [
-        {
-          "count": 5,
-          "rarity": 1
-        },
-        {
-          "count": 2,
-          "rarity": 2
-        },
-        {
-          "count": 1,
-          "rarity": 4
-        },
-        {
-          "count": 1,
-          "pool": "guaranteed_rare_plus",
-          "distribution": {
-            "4": 0.75,
-            "6": 0.2,
-            "8": 0.05
-          }
-        }
+        { "count": 8 },
+        { "count": 1, "pool": "guaranteed_rare_plus", "distribution": { "4": 0.75, "6": 0.2, "8": 0.05 } }
       ],
       "filter": "byRace",
       "cardPool": {
@@ -102,9 +64,7 @@
         "include": { "maxAtk": 1500 }
       },
       "slots": [
-        { "count": 5, "rarity": 1 },
-        { "count": 2, "rarity": 2 },
-        { "count": 1, "rarity": 4 },
+        { "count": 8 },
         { "count": 1, "pool": "guaranteed_rare_plus", "distribution": { "4": 0.75, "6": 0.20, "8": 0.05 } }
       ]
     },
@@ -120,9 +80,7 @@
         "include": { "maxAtk": 1800 }
       },
       "slots": [
-        { "count": 5, "rarity": 1 },
-        { "count": 2, "rarity": 2 },
-        { "count": 1, "rarity": 4 },
+        { "count": 8 },
         { "count": 1, "pool": "guaranteed_rare_plus", "distribution": { "4": 0.75, "6": 0.20, "8": 0.05 } }
       ]
     },
@@ -138,9 +96,7 @@
         "include": { "maxAtk": 2100 }
       },
       "slots": [
-        { "count": 5, "rarity": 1 },
-        { "count": 2, "rarity": 2 },
-        { "count": 1, "rarity": 4 },
+        { "count": 8 },
         { "count": 1, "pool": "guaranteed_rare_plus", "distribution": { "4": 0.75, "6": 0.20, "8": 0.05 } }
       ]
     },
@@ -156,9 +112,7 @@
         "include": { "maxAtk": 2500 }
       },
       "slots": [
-        { "count": 5, "rarity": 1 },
-        { "count": 2, "rarity": 2 },
-        { "count": 1, "rarity": 4 },
+        { "count": 8 },
         { "count": 1, "pool": "guaranteed_rare_plus", "distribution": { "4": 0.75, "6": 0.20, "8": 0.05 } }
       ]
     },
@@ -174,9 +128,7 @@
         "include": { "maxAtk": 3000, "maxRarity": 6 }
       },
       "slots": [
-        { "count": 5, "rarity": 1 },
-        { "count": 2, "rarity": 2 },
-        { "count": 1, "rarity": 4 },
+        { "count": 8 },
         { "count": 1, "pool": "guaranteed_rare_plus", "distribution": { "4": 0.75, "6": 0.20, "8": 0.05 } }
       ]
     },
@@ -189,9 +141,7 @@
       "color": "#c0a020",
       "unlockCondition": { "type": "nodeComplete", "nodeId": "duel_31" },
       "slots": [
-        { "count": 5, "rarity": 1 },
-        { "count": 2, "rarity": 2 },
-        { "count": 1, "rarity": 4 },
+        { "count": 8 },
         { "count": 1, "pool": "guaranteed_rare_plus", "distribution": { "4": 0.75, "6": 0.20, "8": 0.05 } }
       ]
     }

--- a/tests/pack-logic.test.js
+++ b/tests/pack-logic.test.js
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { CARD_DB } from '../js/cards.js';
 import { Rarity, Race, CardType } from '../js/types.js';
-import { PACK_TYPES, openPack } from '../js/react/utils/pack-logic.js';
+import { PACK_TYPES, openPack, RARITY_DROP_RATES } from '../js/react/utils/pack-logic.js';
 import { Progression } from '../js/progression.js';
 
 // ── Helpers ────────────────────────────────────────────────
@@ -47,6 +47,21 @@ describe('PACK_TYPES', () => {
   it('pack prices are ordered: aether < race < rarity', () => {
     expect(PACK_TYPES.aether.price).toBeLessThan(PACK_TYPES.race.price);
     expect(PACK_TYPES.race.price).toBeLessThan(PACK_TYPES.rarity.price);
+  });
+});
+
+// ── RARITY_DROP_RATES ────────────────────────────────────
+
+describe('RARITY_DROP_RATES', () => {
+  it('probabilities sum to 1.0', () => {
+    const sum = Object.values(RARITY_DROP_RATES).reduce((a, b) => a + b, 0);
+    expect(sum).toBeCloseTo(1.0, 5);
+  });
+
+  it('contains all five rarities', () => {
+    expect(Object.keys(RARITY_DROP_RATES).map(Number).sort((a, b) => a - b)).toEqual([
+      Rarity.Common, Rarity.Uncommon, Rarity.Rare, Rarity.SuperRare, Rarity.UltraRare,
+    ]);
   });
 });
 
@@ -134,10 +149,10 @@ describe('openPack rarity distribution', () => {
     localStorage.clear();
   });
 
-  it('standard packs (aether): slots 1-5 are Common, 6-7 Uncommon, 8 Rare', () => {
-    // We can't directly test slot assignment, but we can verify that
-    // over many packs the distribution roughly matches expectations.
-    // Standard pack: 5 Common + 2 Uncommon + 1 Rare + 1 (Rare/SR/UR) = 9
+  it('standard packs (aether): global rarity distribution with pity guarantee', () => {
+    // 8 slots use global distribution (60% C, 30% U, 8.9% R, 1% SR, 0.1% UR)
+    // + 1 guaranteed rare+ slot (75% R, 20% SR, 5% UR)
+    // Pity: if no card >= Rare, one card is upgraded to Rare
     const iterations = 200;
     const counts = { common: 0, uncommon: 0, rare: 0, superRare: 0, ultraRare: 0 };
     for (let i = 0; i < iterations; i++) {
@@ -153,14 +168,23 @@ describe('openPack rarity distribution', () => {
       }
     }
     const total = iterations * 9;
-    // Expected: ~55.5% Common, ~22.2% Uncommon, ~17-22% Rare, some SR/UR
-    expect(counts.common / total).toBeGreaterThan(0.40);
-    expect(counts.common / total).toBeLessThan(0.70);
+    // Expected: ~53% Common, ~27% Uncommon, ~16% Rare (including pity + guaranteed slot)
+    expect(counts.common / total).toBeGreaterThan(0.35);
+    expect(counts.common / total).toBeLessThan(0.75);
     expect(counts.uncommon / total).toBeGreaterThan(0.10);
-    expect(counts.uncommon / total).toBeLessThan(0.35);
+    expect(counts.uncommon / total).toBeLessThan(0.40);
     expect(counts.rare / total).toBeGreaterThan(0.05);
     // SR + UR should appear but be relatively rare
     expect(counts.superRare + counts.ultraRare).toBeGreaterThan(0);
+  });
+
+  it('pity system: every pack contains at least one Rare-or-better card', () => {
+    const iterations = 500;
+    for (let i = 0; i < iterations; i++) {
+      const cards = openPack('aether');
+      const hasRareOrBetter = cards.some(c => c.rarity >= Rarity.Rare);
+      expect(hasRareOrBetter).toBe(true);
+    }
   });
 
   it('rarity packs: all cards are at least Rare', () => {


### PR DESCRIPTION
Introduce RARITY_DROP_RATES (C:60%, U:30%, R:8.9%, SR:1%, UR:0.1%)
used by all standard pack slots and victory card drops. Add pity
system to shop packs: if no card >= Rare is drawn, one card is
upgraded to Rare (replacing highest sub-Rare rarity first).

https://claude.ai/code/session_01QVSF1tYmfUc1N97Xw5rAGg