### PR TITLE
fix(ui): separate loading screen from press start and load instantly

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,8 @@
   <title>Echoes of Sanguo</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Pixelify+Sans:wght@400;700&family=Press+Start+2P&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Pixelify+Sans:wght@400;700&family=Press+Start+2P&display=swap" rel="stylesheet" media="print" onload="this.media='all'">
+  <noscript><link href="https://fonts.googleapis.com/css2?family=Pixelify+Sans:wght@400;700&family=Press+Start+2P&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="css/style.css">
   <link rel="stylesheet" href="css/progression.css">
 </head>
@@ -17,32 +18,33 @@
       position: fixed; inset: 0;
       display: flex; align-items: center; justify-content: center;
       flex-direction: column; gap: 24px;
-      background: url('/title-bg.png') center center/cover no-repeat, #080c18;
+      background: radial-gradient(ellipse at center, #101828 0%, #060a14 70%);
       z-index: 100;
     }
     .loading-screen p {
-      font-family: 'Press Start 2P', monospace;
-      font-size: 0.75rem;
-      letter-spacing: 3px;
-      color: #f0d080;
-      text-shadow: 0 0 10px rgba(255, 220, 100, 0.6);
-      animation: loading-blink 1.2s step-start infinite;
+      font-family: monospace;
+      font-size: 0.65rem;
+      letter-spacing: 5px;
+      text-transform: uppercase;
+      color: #8899aa;
+      text-shadow: 0 0 8px rgba(100, 140, 180, 0.4);
+      animation: loading-pulse 2s ease-in-out infinite;
     }
     .loading-bar-track {
-      width: 200px; height: 6px;
-      background: rgba(255, 255, 255, 0.1);
-      border-radius: 3px;
+      width: 200px; height: 4px;
+      background: rgba(255, 255, 255, 0.08);
+      border-radius: 2px;
       overflow: hidden;
     }
     .loading-bar-fill {
       height: 100%; width: 0%;
-      background: #f0d080;
-      border-radius: 3px;
+      background: #667888;
+      border-radius: 2px;
       transition: width 0.3s ease;
     }
-    @keyframes loading-blink {
-      0%, 100% { opacity: 1; }
-      50% { opacity: 0; }
+    @keyframes loading-pulse {
+      0%, 100% { opacity: 0.4; }
+      50% { opacity: 1; }
     }
   </style>
   <div class="loading-screen">

--- a/js/main.ts
+++ b/js/main.ts
@@ -25,4 +25,13 @@ try {
 await import('./progression.js');
 await import('./i18n.js');          // must come after progression.js (reads saved language)
 await import('./engine.js');
+
+// Fade out loading screen and wait for fonts before mounting React
+const loadingScreen = document.querySelector('.loading-screen') as HTMLElement | null;
+if (loadingScreen) {
+  loadingScreen.style.transition = 'opacity 0.3s ease';
+  loadingScreen.style.opacity = '0';
+  await new Promise(r => setTimeout(r, 300));
+}
+await document.fonts.ready;
 await import('./react/index.js');


### PR DESCRIPTION
Make the loading screen render on the very first paint frame by removing
dependencies on external Google Fonts and title-bg.png. Use system monospace
font, dark gradient background, and muted colors to visually distinguish it
from the press start screen. Add smooth fade-out transition before React mounts
and ensure fonts are ready via document.fonts.ready.

https://claude.ai/code/session_01KVU4MM56pDFVi6qG1866Mb