### PR TITLE
feat(ui): optimize collection layout, add NEW badge and newest sort

### DIFF
--- a/js/react/contexts/GameContext.tsx
+++ b/js/react/contexts/GameContext.tsx
@@ -428,6 +428,9 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
       loadDeck();
       // Read deck from Progression to ensure it's fresh
       import('../../progression.js').then(({ Progression }) => {
+        // Clear NEW badges when a duel starts
+        const col = Progression.getCollection();
+        Progression.markCardsAsSeen(col.map(e => e.id));
         const saved = Progression.getDeck();
         const rawIds = (saved && saved.length > 0) ? saved : [...PLAYER_DECK_IDS];
         // Strip stale or invalid card IDs so makeDeck() never crashes

--- a/js/react/screens/CollectionScreen.module.css
+++ b/js/react/screens/CollectionScreen.module.css
@@ -124,6 +124,15 @@
   pointer-events: none; z-index: 5;
 }
 
+.newBadge {
+  position: absolute; top: 2px; left: 2px;
+  background: #f97316; color: #fff;
+  font-size: 8px; font-weight: bold;
+  padding: 1px 4px; border-radius: 0;
+  pointer-events: none; z-index: 5;
+  line-height: 1.2;
+}
+
 .cardMeta { font-size: 0.65rem; color: #506080; margin-top: 2px; }
 
 .unknownLabel {

--- a/js/react/screens/CollectionScreen.tsx
+++ b/js/react/screens/CollectionScreen.tsx
@@ -1,9 +1,10 @@
-import { useState }      from 'react';
+import { useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useScreen }      from '../contexts/ScreenContext.js';
 import { useProgression } from '../contexts/ProgressionContext.js';
 import { useModal }        from '../contexts/ModalContext.js';
 import { CARD_DB } from '../../cards.js';
+import { Progression }     from '../../progression.js';
 import { Card, cardTypeCss, ATTR_CSS } from '../components/Card.js';
 import { attachHover }     from '../components/hoverApi.js';
 import { Race, Rarity } from '../../types.js';
@@ -24,6 +25,9 @@ export default function CollectionScreen() {
 
   const countMap: Record<string, number> = {};
   collection.forEach(e => { countMap[e.id] = e.count; });
+
+  const seenCards = useMemo(() => Progression.getSeenCards(), [collection]);
+  const isNew = (id: string) => !seenCards.has(id) && (countMap[id] || 0) > 0;
 
   const totalCards = Object.keys(CARD_DB).length;
   const ownedCount = Object.keys(countMap).length;
@@ -94,6 +98,7 @@ export default function CollectionScreen() {
                 </div>
                 {owned > 1 && <div className={styles.cardCount}>×{owned}</div>}
                 <div className={styles.rarityDot} style={{ background: rarColor }} />
+                {isNew(card.id) && <div className={styles.newBadge}>NEW</div>}
               </div>
             );
           }

--- a/js/react/screens/DeckbuilderScreen.module.css
+++ b/js/react/screens/DeckbuilderScreen.module.css
@@ -186,7 +186,16 @@
   background: #f97316; color: #fff;
   font-size: 9px; font-weight: bold;
   padding: 1px 5px; border-radius: 0;
-  margin-left: 5px; vertical-align: middle;
+  vertical-align: middle;
+}
+
+.newBadgeGrid {
+  position: absolute; top: 2px; left: 2px;
+  background: #f97316; color: #fff;
+  font-size: 8px; font-weight: bold;
+  padding: 1px 4px; border-radius: 0;
+  pointer-events: none; z-index: 5;
+  line-height: 1.2;
 }
 
 /* ── Card wrap ── */

--- a/js/react/screens/DeckbuilderScreen.tsx
+++ b/js/react/screens/DeckbuilderScreen.tsx
@@ -18,7 +18,7 @@ const MAX_COPIES = GAME_RULES.maxCardCopies;
 
 type ViewMode = 'large' | 'small' | 'table';
 type ActiveTab = 'collection' | 'deck';
-type SortColumn = 'id' | 'rarity' | 'name' | 'atk' | 'def' | 'type' | 'race' | 'collection' | 'inDeck';
+type SortColumn = 'id' | 'rarity' | 'name' | 'atk' | 'def' | 'type' | 'race' | 'collection' | 'inDeck' | 'newest';
 type SortDir = 'asc' | 'desc';
 
 export default function DeckbuilderScreen() {
@@ -133,21 +133,20 @@ export default function DeckbuilderScreen() {
         case 'race':       cmp = ((a.race as number) ?? 0) - ((b.race as number) ?? 0); break;
         case 'collection': cmp = (collectionCount[a.id] || 0) - (collectionCount[b.id] || 0); break;
         case 'inDeck':     cmp = (copyMap[a.id] || 0) - (copyMap[b.id] || 0); break;
+        case 'newest':     cmp = (isNew(a.id) ? 1 : 0) - (isNew(b.id) ? 1 : 0); break;
       }
       return sortDirection === 'asc' ? cmp : -cmp;
     });
     return sorted;
-  }, [displayedCards, sortColumn, sortDirection, collectionCount, copyMap]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [displayedCards, sortColumn, sortDirection, collectionCount, copyMap, seenCards]);
 
   const visibleCards = sortedCards.slice(0, visibleCount);
 
-  // Mark all visible cards as seen after mount
+  // Refresh seen cards when collection changes (e.g. after returning from a duel)
   useEffect(() => {
-    const ids = collectionCards.map(c => c.id);
-    Progression.markCardsAsSeen(ids);
     setSeenCards(Progression.getSeenCards());
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [collection]);
 
   function isNew(id: string) { return !seenCards.has(id); }
 
@@ -342,6 +341,7 @@ export default function DeckbuilderScreen() {
                       <Card card={card} />
                     </div>
                     {copies > 0 && <div className={styles.copyBadge}>{copies}/{maxCopiesFor(card.id)}</div>}
+                    {isNew(card.id) && <div className={styles.newBadgeGrid}>NEW</div>}
                   </div>
                 );
               })}
@@ -375,11 +375,11 @@ export default function DeckbuilderScreen() {
                     <th className={styles.sortable} onClick={() => toggleSort('race')}>
                       {t('deckbuilder.table_race')}{sortIndicator('race')}
                     </th>
-                    <th className={styles.sortable} onClick={() => toggleSort('collection')}>
-                      {t('deckbuilder.table_collection')}{sortIndicator('collection')}
-                    </th>
                     <th className={styles.sortable} onClick={() => toggleSort('inDeck')}>
                       {t('deckbuilder.table_in_deck')}{sortIndicator('inDeck')}
+                    </th>
+                    <th className={styles.sortable} onClick={() => toggleSort('newest')}>
+                      {t('deckbuilder.table_new')}{sortIndicator('newest')}
                     </th>
                   </tr>
                 </thead>
@@ -408,10 +408,7 @@ export default function DeckbuilderScreen() {
                         onDoubleClick={() => handleCardDoubleClick(card)}
                         ref={el => { if (el) attachHover(el as any, card, null); }}
                       >
-                        <td>
-                          {card.id}
-                          {isNew(card.id) && <span className={styles.newBadge}>NEW</span>}
-                        </td>
+                        <td>{card.id}</td>
                         <td>
                           <span style={{ color: rarColor }}>
                             {rarMeta?.value ?? '\u2014'}
@@ -422,8 +419,8 @@ export default function DeckbuilderScreen() {
                         <td>{card.def !== undefined ? card.def : '\u2014'}</td>
                         <td style={{ color: typeColor }}>{typeLbl}</td>
                         <td>{raceLbl}</td>
-                        <td>{ownedCount}</td>
-                        <td>{copies} / {maxCopiesFor(card.id)}</td>
+                        <td>{copies} / {ownedCount}</td>
+                        <td>{isNew(card.id) && <span className={styles.newBadge}>NEW</span>}</td>
                       </tr>
                     );
                   })}

--- a/locales/de.json
+++ b/locales/de.json
@@ -143,6 +143,7 @@
     "table_race": "Rasse",
     "table_collection": "Sammlung",
     "table_in_deck": "Im Deck",
+    "table_new": "Neu",
     "tab_collection": "Sammlung",
     "tab_deck": "Deck",
     "add_to_deck": "Zum Deck hinzufügen",

--- a/locales/en.json
+++ b/locales/en.json
@@ -143,6 +143,7 @@
     "table_race": "Race",
     "table_collection": "Collection",
     "table_in_deck": "In Deck",
+    "table_new": "New",
     "tab_collection": "Collection",
     "tab_deck": "Deck",
     "add_to_deck": "Add to Deck",


### PR DESCRIPTION
- Merge Collection + In Deck columns into compact "copies/owned" format
- Add NEW badge to deckbuilder (grid + table) and collection screen
- NEW badge persists until next duel starts (cleared in startGame)
- Add "New" sortable column to sort by newest cards
- Remove mark-as-seen on deckbuilder mount (now on duel start)

https://claude.ai/code/session_01XeGvgS2YhmDxgU4pyxJwwj