### PR TITLE
fix(ui): align opponent stats order with player stats on duel result screen

### DIFF
--- a/js/react/screens/DuelResultScreen.tsx
+++ b/js/react/screens/DuelResultScreen.tsx
@@ -213,11 +213,11 @@ export default function DuelResultScreen() {
 
   const opponentStatRows = stats
     ? [
-        { label: t('duelResult.opp_stat_lp'),       value: stats.opponentLpRemaining },
         { label: t('duelResult.opp_stat_monsters'),  value: stats.opponentMonstersPlayed },
         { label: t('duelResult.opp_stat_fusions'),   value: stats.opponentFusionsPerformed },
         { label: t('duelResult.opp_stat_spells'),    value: stats.opponentSpellsActivated },
         { label: t('duelResult.opp_stat_traps'),     value: stats.opponentTrapsActivated },
+        { label: t('duelResult.opp_stat_lp'),        value: stats.opponentLpRemaining },
       ]
     : [];
 


### PR DESCRIPTION
Moved LP Remaining to the end of opponent stats to match the player stats
order (Monsters, Fusions, Spells, Traps, LP).

https://claude.ai/code/session_01FVojp6oFrnvc7uyu8b6XCo