### PR TITLE
feat(ui): use 3x3 grid with full Card component in pack opening summary

### DIFF
--- a/js/react/screens/PackOpeningScreen.module.css
+++ b/js/react/screens/PackOpeningScreen.module.css
@@ -257,37 +257,16 @@
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(3, 1fr);
   gap: 10px;
   max-width: 800px;
   width: 100%;
   margin-bottom: 24px;
 }
 
-@media (min-width: 600px) {
-  .grid { grid-template-columns: repeat(3, 1fr); }
-}
-
 .cardWrapper {
   animation: packReveal 0.4s ease both;
   position: relative;
-}
-
-.cardInner {
-  border-radius: 0;
-  padding: 8px;
-  font-size: 0.75rem;
-  min-height: 120px;
-  position: relative;
-  overflow: hidden;
-  border: 2px solid var(--rarity-color, #aaa);
-  background: #111828;
-}
-
-.rarityBar {
-  position: absolute;
-  top: 0; left: 0; right: 0;
-  height: 3px;
 }
 
 .newBadge {
@@ -303,19 +282,6 @@
   z-index: 1;
   text-shadow: none;
 }
-
-.cardInner :global(.card-header) {
-  display: flex;
-  justify-content: space-between;
-  margin-top: 4px;
-  margin-bottom: 4px;
-}
-
-.cardInner :global(.card-name) { font-weight: bold; color: #d0e0ff; font-size: 0.8rem; }
-.cardInner :global(.card-level) { color: #c8a84b; font-size: 0.65rem; }
-.cardInner :global(.card-type-line) { color: #6080a0; font-size: 0.65rem; margin-bottom: 3px; }
-.cardInner :global(.card-desc) { color: #8090a8; font-size: 0.65rem; line-height: 1.3; max-height: 3.9em; overflow: hidden; }
-.cardInner :global(.card-footer) { display: flex; justify-content: space-between; margin-top: 4px; color: #90b0d0; font-size: 0.7rem; }
 
 /* Same styles for reveal card inner text */
 .revealCard :global(.card-header) {

--- a/js/react/screens/PackOpeningScreen.tsx
+++ b/js/react/screens/PackOpeningScreen.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useRef, useState, useCallback } from 'react';
 import { gsap } from 'gsap';
 import { useScreen }   from '../contexts/ScreenContext.js';
 import { getRarityById } from '../../type-metadata.js';
-import { cardTypeCss, ATTR_CSS } from '../components/Card.js';
+import { Card, cardTypeCss, ATTR_CSS } from '../components/Card.js';
 import { Audio }        from '../../audio.js';
 import { CardType, Rarity } from '../../types.js';
 import type { CardData }          from '../../types.js';
@@ -334,36 +334,14 @@ export default function PackOpeningScreen() {
         <div className={styles.grid}>
           {sortedCards.map((card, i) => {
             const isNew = !ownedBefore.has(card.id);
-            const rarColor = getRarityById((card as any).rarity)?.color ?? '#aaa';
             return (
               <div
                 key={i}
                 className={styles.cardWrapper}
                 style={{ animationDelay: `${i * 0.08}s` }}
               >
-                <div
-                  className={`${styles.cardInner} card ${cardTypeCss(card)}-card attr-${card.attribute ? ATTR_CSS[card.attribute] || 'spell' : 'spell'}`}
-                  style={{ '--rarity-color': rarColor } as React.CSSProperties}
-                >
-                  {isNew && <div className={styles.newBadge}>{t('pack_opening.new_badge')}</div>}
-                  <div className={styles.rarityBar} style={{ background: rarColor }} />
-                  <div className="card-header">
-                    <span className="card-name">{card.name}</span>
-                    <span className="card-level">
-                      {card.level ? '★'.repeat(Math.min(card.level, 5)) : ''}
-                    </span>
-                  </div>
-                  <div className="card-body">
-                    <div className="card-type-line">{getTypeLabel(card, t)}</div>
-                    <div className="card-desc">{card.description || ''}</div>
-                  </div>
-                  {card.atk !== undefined && (
-                    <div className="card-footer">
-                      <span>ATK {card.atk}</span>
-                      <span>DEF {card.def}</span>
-                    </div>
-                  )}
-                </div>
+                {isNew && <div className={styles.newBadge}>{t('pack_opening.new_badge')}</div>}
+                <Card card={card} />
               </div>
             );
           })}


### PR DESCRIPTION
Replace the 2-column simplified card layout with a consistent 3-column
grid using the reusable Card component (with art area, attribute orb,
race badge, rarity text, level stars, and proper stats bar).

https://claude.ai/code/session_01LDCpjeWrMXfPP8VG5cX7MW