### PR TITLE
fix(equipment): allow equipping cards to player monsters and fix removal cleanup

### DIFF
--- a/js/engine.ts
+++ b/js/engine.ts
@@ -571,6 +571,7 @@ export class GameEngine {
 
   /** Remove all equipment attached to a monster at the given zone/owner, sending them to graveyard. */
   _removeEquipmentForMonster(monsterOwner: Owner, monsterZone: number): void {
+    const targetFC = this.state[monsterOwner].field.monsters[monsterZone];
     // Equipment can be owned by either player — scan both sides
     for (const side of ['player', 'opponent'] as Owner[]) {
       const st = this.state[side];
@@ -578,6 +579,12 @@ export class GameEngine {
         const fst = st.field.spellTraps[z];
         if (!fst || fst.card.type !== CardType.Equipment) continue;
         if (fst.equippedOwner === monsterOwner && fst.equippedMonsterZone === monsterZone) {
+          // Reverse bonuses applied by equipCard()
+          if (targetFC) {
+            targetFC.permATKBonus -= (fst.card.atkBonus ?? 0);
+            targetFC.permDEFBonus -= (fst.card.defBonus ?? 0);
+            targetFC.equippedCards = targetFC.equippedCards.filter(eq => eq.zone !== z);
+          }
           this.addLog(`${fst.card.name} was destroyed (equipped monster left the field).`);
           st.graveyard.push(fst.card);
           st.field.spellTraps[z] = null;

--- a/js/react/screens/game/HandArea.tsx
+++ b/js/react/screens/game/HandArea.tsx
@@ -5,7 +5,7 @@ import { useModal }     from '../../contexts/ModalContext.js';
 import { useSelection } from '../../contexts/SelectionContext.js';
 import { HandCard }     from '../../components/HandCard.js';
 import { checkFusion, resolveFusionChain, CARD_DB } from '../../../cards.js';
-import { isMonsterType } from '../../../types.js';
+import { isMonsterType, CardType, meetsEquipRequirement } from '../../../types.js';
 import type { CardData } from '../../../types.js';
 import type { FieldCard } from '../../../field.js';
 
@@ -18,6 +18,7 @@ export function HandArea() {
   if (!gameState) return null;
 
   const player   = gameState.player;
+  const opponent = gameState.opponent;
   const phase    = gameState.phase;
   const isMyTurn = gameState.activePlayer === 'player';
   const selMode  = sel.mode;
@@ -126,10 +127,15 @@ export function HandArea() {
         {player.hand.map((card, i) => {
           const isNewlyDrawn = i >= newDrawBase;
           const isMon        = isMonsterType(card.type);
+          const isEquip      = card.type === CardType.Equipment;
           const playable     = isMyTurn && phase === 'main' && (
             isMon
               ? !player.normalSummonUsed && player.field.monsters.some(z => z === null)
-              : player.field.spellTraps.some(z => z === null)
+              : isEquip
+                ? player.field.spellTraps.some(z => z === null)
+                  && (player.field.monsters.some(m => m && !m.faceDown && meetsEquipRequirement(card, m.card))
+                   || opponent.field.monsters.some(m => m && !m.faceDown && meetsEquipRequirement(card, m.card)))
+                : player.field.spellTraps.some(z => z === null)
           );
           const inFusion     = fusionGroup.includes(i);
           const fusionIdx    = inFusion ? fusionGroup.indexOf(i) : undefined;

--- a/js/react/screens/game/PlayerField.tsx
+++ b/js/react/screens/game/PlayerField.tsx
@@ -33,6 +33,7 @@ export function PlayerField({ showDirect, setShowDirect }: Props) {
   function isPlayerMonsterInteractive(zone: number) {
     if (!player.field.monsters[zone]) return false;
     if (!isMyTurn || phase === 'battle') return false;
+    if (selMode === 'spell-target' || selMode === 'field-spell-target' || selMode === 'equip-target') return false;
     return phase === 'main';
   }
 


### PR DESCRIPTION
PlayerField.isPlayerMonsterInteractive() returned true during main phase
regardless of selection mode, and FieldCardComponent checks interactive
before targetable in its click handler. This meant clicking a player
monster in equip-target mode opened the card detail modal instead of
selecting it as an equip target.

Also fixes _removeEquipmentForMonster() to reverse permATKBonus/permDEFBonus
and clean up equippedCards array when equipment is destroyed, and updates
HandArea playable logic to require valid monster targets for equipment cards.

https://claude.ai/code/session_01M8jnEHdtp7gzhgk19nutyY