### PR TITLE
fix(ui): replace pixel fonts with system font stack for readability

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -51,12 +51,12 @@ html {
 html, body {
   width: 100%; height: 100%;
   overflow: hidden;
-  font-family: 'Pixelify Sans', monospace;
+  font-family: var(--font-stats);
   background: var(--bg);
   color: var(--text);
   user-select: none;
-  -webkit-font-smoothing: none;
-  -moz-osx-font-smoothing: unset;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
   image-rendering: pixelated;
 }
 
@@ -617,7 +617,7 @@ button { cursor: pointer; border: none; font-family: inherit; transition: none; 
   border-radius: 50%;
   pointer-events: none;
   z-index: 10;
-  font-family: 'Press Start 2P', monospace;
+  font-family: var(--font-stats);
 }
 
 /* Floating fusion bar (long-press fusion group) */
@@ -630,7 +630,7 @@ button { cursor: pointer; border: none; font-family: inherit; transition: none; 
   background: rgba(0, 0, 0, 0.85);
   border: 2px solid #ffd700;
   border-radius: 8px;
-  font-family: 'Pixelify Sans', 'Press Start 2P', monospace;
+  font-family: var(--font-stats);
   font-size: 10px;
   color: #eee;
   position: absolute;
@@ -843,7 +843,7 @@ button { cursor: pointer; border: none; font-family: inherit; transition: none; 
   padding: 8px 12px;
   margin: 8px 0 4px;
   text-align: center;
-  font-family: 'Pixelify Sans', monospace;
+  font-family: var(--font-stats);
   font-size: 0.75rem;
   color: #ffcccc;
   line-height: 1.5;
@@ -1186,14 +1186,14 @@ button { cursor: pointer; border: none; font-family: inherit; transition: none; 
     overflow: hidden;
   }
   .phud-lp {
-    font-family: 'Press Start 2P', monospace;
+    font-family: var(--font-stats);
     font-size: 9px;
     white-space: nowrap;
   }
   .phud-opp    { color: #ff8080; }
   .phud-player { color: #80ff80; }
   .phud-phase {
-    font-family: 'Press Start 2P', monospace;
+    font-family: var(--font-stats);
     font-size: 6px;
     color: #d0c090;
     text-align: center;
@@ -1275,7 +1275,7 @@ button { cursor: pointer; border: none; font-family: inherit; transition: none; 
     height: 48px;
     padding: 0 14px;
     border-radius: 8px;
-    font-family: 'Press Start 2P', monospace;
+    font-family: var(--font-stats);
     font-size: 0.6rem;
     letter-spacing: 0.5px;
     cursor: pointer;

--- a/index.html
+++ b/index.html
@@ -4,10 +4,6 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>Echoes of Sanguo</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Pixelify+Sans:wght@400;700&family=Press+Start+2P&display=swap" rel="stylesheet" media="print" onload="this.media='all'">
-  <noscript><link href="https://fonts.googleapis.com/css2?family=Pixelify+Sans:wght@400;700&family=Press+Start+2P&display=swap" rel="stylesheet"></noscript>
   <link rel="stylesheet" href="css/style.css">
   <link rel="stylesheet" href="css/progression.css">
 </head>

--- a/js/react/screens/CampaignScreen.module.css
+++ b/js/react/screens/CampaignScreen.module.css
@@ -25,7 +25,7 @@
   color: #c8a84b;
   text-shadow: 2px 2px 0 #000;
   margin: 0 0 4px;
-  font-family: 'Press Start 2P', monospace;
+  font-family: var(--font-stats);
 }
 
 .backBtn {
@@ -50,7 +50,7 @@
   max-width: 220px;
   padding: 6px 12px;
   font-size: 0.6rem;
-  font-family: 'Press Start 2P', monospace;
+  font-family: var(--font-stats);
   background: rgba(20, 30, 50, 0.9);
   border: 1px solid #c8a84b;
   border-radius: 2px;
@@ -73,7 +73,7 @@
 .chapterSelect option {
   background: #0c1428;
   color: #c8a84b;
-  font-family: 'Press Start 2P', monospace;
+  font-family: var(--font-stats);
   font-size: 0.6rem;
   padding: 4px 8px;
 }
@@ -160,7 +160,7 @@
   color: #8090a0;
   text-align: center;
   margin-top: 2px;
-  font-family: 'Pixelify Sans', monospace;
+  font-family: var(--font-stats);
   max-width: 60px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -178,7 +178,7 @@
 .nodeStatus {
   font-size: 0.4rem;
   margin-top: 1px;
-  font-family: 'Pixelify Sans', monospace;
+  font-family: var(--font-stats);
 }
 
 .statusCompleted {
@@ -219,7 +219,7 @@
   font-size: 0.75rem;
   line-height: 1.6;
   margin-bottom: 16px;
-  font-family: 'Pixelify Sans', monospace;
+  font-family: var(--font-stats);
 }
 
 .dialogueClose {

--- a/js/react/screens/DuelResultScreen.module.css
+++ b/js/react/screens/DuelResultScreen.module.css
@@ -46,7 +46,7 @@
   letter-spacing: 6px;
   color: var(--accent, #d4a017);
   text-shadow: 0 0 20px var(--glow, rgba(212,160,23,0.6)), 2px 2px 8px #000;
-  font-family: 'Press Start 2P', monospace;
+  font-family: var(--font-stats);
   margin: 0;
   opacity: 0;
 }
@@ -114,7 +114,7 @@
   letter-spacing: 2px;
   color: var(--accent, #d4a017);
   text-shadow: 0 0 8px var(--glow, rgba(212,160,23,0.4));
-  font-family: 'Press Start 2P', monospace;
+  font-family: var(--font-stats);
   margin: 0 0 8px 0;
 }
 
@@ -139,7 +139,7 @@
 
 .statValue {
   color: var(--accent, #d4a017);
-  font-family: 'Press Start 2P', monospace;
+  font-family: var(--font-stats);
   font-size: 0.5rem;
 }
 
@@ -167,12 +167,12 @@
   font-size: 0.45rem;
   letter-spacing: 2px;
   color: #908070;
-  font-family: 'Press Start 2P', monospace;
+  font-family: var(--font-stats);
 }
 
 .badgeRank {
   font-size: 1rem;
-  font-family: 'Press Start 2P', monospace;
+  font-family: var(--font-stats);
   text-shadow: 0 0 12px currentColor;
 }
 
@@ -183,7 +183,7 @@
 .badgeMultiplier {
   font-size: 0.45rem;
   letter-spacing: 1px;
-  font-family: 'Press Start 2P', monospace;
+  font-family: var(--font-stats);
   margin-top: 4px;
   opacity: 0;
 }
@@ -206,7 +206,7 @@
   letter-spacing: 1px;
   color: #d4a017;
   text-shadow: 0 0 10px rgba(212,160,23,0.5);
-  font-family: 'Press Start 2P', monospace;
+  font-family: var(--font-stats);
 }
 
 .rewardCards {
@@ -220,7 +220,7 @@
   letter-spacing: 2px;
   color: #50e880;
   text-shadow: 0 0 12px rgba(80,232,128,0.6);
-  font-family: 'Press Start 2P', monospace;
+  font-family: var(--font-stats);
   opacity: 0;
 }
 

--- a/js/react/screens/PressStartScreen.module.css
+++ b/js/react/screens/PressStartScreen.module.css
@@ -20,7 +20,7 @@
   letter-spacing: 2px;
   color: var(--gold-light);
   text-shadow: 2px 2px 8px #000, 0 0 30px rgba(0,0,0,0.95);
-  font-family: 'Press Start 2P', monospace;
+  font-family: var(--font-stats);
   line-height: 1.3;
   margin: 0;
 }

--- a/js/react/screens/TitleScreen.module.css
+++ b/js/react/screens/TitleScreen.module.css
@@ -22,7 +22,7 @@
   letter-spacing: 2px;
   color: var(--gold-light);
   text-shadow: 2px 2px 8px #000, 0 0 20px rgba(0,0,0,0.9);
-  font-family: 'Press Start 2P', monospace;
+  font-family: var(--font-stats);
   line-height: 1.1;
   margin: 10px 0;
   white-space: nowrap;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -5,8 +5,8 @@ export default {
   theme: {
     extend: {
       fontFamily: {
-        pixel: ['"Pixelify Sans"', 'monospace'],
-        title: ['"Press Start 2P"', 'monospace'],
+        pixel: ['var(--font-stats)'],
+        title: ['var(--font-stats)'],
       },
       borderRadius: {
         DEFAULT: '0',


### PR DESCRIPTION
Replace 'Press Start 2P' and 'Pixelify Sans' with the system font stack
(--font-stats) used by ATK/DEF values. Removes Google Fonts imports and
enables proper font smoothing.

https://claude.ai/code/session_01LcC1LbcJP7u7X9Y11QqY2d