### PR TITLE
feat(ui): show individual card details on victory screen rewards

### DIFF
--- a/js/react/contexts/GameContext.tsx
+++ b/js/react/contexts/GameContext.tsx
@@ -217,6 +217,7 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
               if (adjustedRewards.coins) adjustedRewards.coins = applyBadgeMultiplier(adjustedRewards.coins);
               if (adjustedRewards.coins) Progression.addCoins(adjustedRewards.coins);
               const allCards = [...(adjustedRewards.cards ?? []), ...badgeDrops];
+              const newCardIds = allCards.filter(id => !Progression.ownsCard(id));
               if (allCards.length) Progression.addCardsToCollection(allCards);
               if (badgeDrops.length) adjustedRewards.cards = allCards;
 
@@ -226,6 +227,7 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
                 navigateToRef.current('duel-result', resultData('victory', {
                   rewards: adjustedRewards,
                   badges,
+                  newCardIds,
                   nextScreen: 'dialogue',
                   dialogueData: {
                     scene: pending.postDialogue as unknown as Record<string, unknown>,
@@ -236,6 +238,7 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
                 navigateToRef.current('duel-result', resultData('victory', {
                   rewards: adjustedRewards,
                   badges,
+                  newCardIds,
                   nextScreen: 'campaign',
                 }));
               }
@@ -272,6 +275,7 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
             }
             if (adjustedRewards?.coins) Progression.addCoins(adjustedRewards.coins);
             const allCards = [...(adjustedRewards?.cards ?? []), ...badgeDrops];
+            const newCardIds = allCards.filter(id => !Progression.ownsCard(id));
             if (allCards.length) {
               Progression.addCardsToCollection(allCards);
               if (adjustedRewards && badgeDrops.length) adjustedRewards.cards = allCards;
@@ -290,6 +294,7 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
             navigateToRef.current('duel-result', resultData('victory', {
               rewards: pending.rewards,
               badges,
+              newCardIds,
               nextScreen: 'dialogue',
               dialogueData: {
                 scene: pending.postDialogue as unknown as Record<string, unknown>,
@@ -300,6 +305,7 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
             navigateToRef.current('duel-result', resultData('victory', {
               rewards: pending.rewards,
               badges,
+              newCardIds,
               nextScreen: 'campaign',
             }));
           } else if (isComplete && pending.postDialogue && pending.postDialogue.length > 0) {
@@ -331,6 +337,7 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
             }
             // S-rank card drops
             const badgeDrops = rollSRankDrops();
+            const newCardIds = badgeDrops.filter(id => !Progression.ownsCard(id));
             if (badgeDrops.length) Progression.addCardsToCollection(badgeDrops);
 
             refreshRef.current();
@@ -339,6 +346,7 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
                 ? { coins: coinsEarned || undefined, cards: badgeDrops.length > 0 ? badgeDrops : undefined }
                 : undefined,
               badges,
+              newCardIds: newCardIds.length > 0 ? newCardIds : undefined,
               mode: 'free',
             }));
           })

--- a/js/react/screens/DuelResultScreen.module.css
+++ b/js/react/screens/DuelResultScreen.module.css
@@ -214,6 +214,45 @@
   text-shadow: 0 0 10px rgba(128,200,255,0.4);
 }
 
+.rewardCardList {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.rewardCardRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.5rem;
+  font-family: 'Press Start 2P', monospace;
+  letter-spacing: 0.5px;
+}
+
+.rewardCardRarity {
+  text-shadow: 0 0 8px currentColor;
+  min-width: 70px;
+  text-align: right;
+}
+
+.rewardCardType {
+  opacity: 0.7;
+  min-width: 55px;
+  text-align: center;
+}
+
+.rewardCardName {
+  color: #e0e0e0;
+  text-shadow: 0 0 6px rgba(224,224,224,0.3);
+}
+
+.rewardNewBadge {
+  color: #50e880;
+  text-shadow: 0 0 10px rgba(80,232,128,0.6);
+  font-size: 0.45rem;
+}
+
 /* ── Unlock notification ─────────────────────────────────── */
 .unlockText {
   font-size: 0.55rem;

--- a/js/react/screens/DuelResultScreen.tsx
+++ b/js/react/screens/DuelResultScreen.tsx
@@ -3,6 +3,8 @@ import { useTranslation } from 'react-i18next';
 import { gsap } from 'gsap';
 import { useScreen } from '../contexts/ScreenContext.js';
 import { Audio } from '../../audio.js';
+import { CARD_DB } from '../../cards.js';
+import { getRarityById, getCardTypeById } from '../../type-metadata.js';
 import type { DuelStats } from '../../types.js';
 import type { BattleBadges } from '../../battle-badges.js';
 import styles from './DuelResultScreen.module.css';
@@ -25,6 +27,8 @@ export default function DuelResultScreen() {
   const rewards = screenData?.rewards as Rewards | undefined;
   const mode = screenData?.mode as 'campaign' | 'free' | undefined;
   const badges = screenData?.badges as BattleBadges | undefined;
+  const newCardIds = screenData?.newCardIds as string[] | undefined;
+  const newCardSet = useMemo(() => new Set(newCardIds ?? []), [newCardIds]);
 
   const [locked, setLocked] = useState(true);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -337,8 +341,30 @@ export default function DuelResultScreen() {
               </div>
             )}
             {(rewards.cards?.length ?? 0) > 0 && (
-              <div className={`${styles.rewardItem} ${styles.rewardCards}`}>
-                {t('duelResult.cards_earned', { count: rewards.cards!.length })}
+              <div className={styles.rewardCardList}>
+                {rewards.cards!.map((cardId, i) => {
+                  const card = CARD_DB[cardId];
+                  if (!card) return null;
+                  const rarityMeta = getRarityById(card.rarity ?? 0);
+                  const typeMeta = getCardTypeById(card.type);
+                  const isNew = newCardSet.has(cardId);
+                  return (
+                    <div key={`${cardId}-${i}`} className={styles.rewardCardRow}>
+                      {rarityMeta && (
+                        <span className={styles.rewardCardRarity} style={{ color: rarityMeta.color }}>
+                          {rarityMeta.value}
+                        </span>
+                      )}
+                      {typeMeta && (
+                        <span className={styles.rewardCardType} style={{ color: typeMeta.color }}>
+                          {typeMeta.value}
+                        </span>
+                      )}
+                      <span className={styles.rewardCardName}>{card.name}</span>
+                      {isNew && <span className={styles.rewardNewBadge}>{t('pack_opening.new_badge')}</span>}
+                    </div>
+                  );
+                })}
               </div>
             )}
           </div>


### PR DESCRIPTION
Replace the generic "+N Card(s) Obtained" summary with per-card rows
showing rarity (colored), card type, name, and a NEW badge for cards
not previously in the player's collection.

https://claude.ai/code/session_01CbPpFyfQBNQjJ1ze8K55P5