### PR TITLE
feat(shop): remove starter packs, keep only tiered packages

### DIFF
--- a/js/react/screens/ShopScreen.tsx
+++ b/js/react/screens/ShopScreen.tsx
@@ -4,17 +4,14 @@ import { useScreen }      from '../contexts/ScreenContext.js';
 import { useProgression } from '../contexts/ProgressionContext.js';
 import { useCampaign }    from '../contexts/CampaignContext.js';
 import { Progression }    from '../../progression.js';
-import { getAllRaces, getRaceByKey, getRarityById } from '../../type-metadata.js';
-import { PACK_TYPES, openPack, openPackage, isPackageUnlocked, buildCardPool } from '../utils/pack-logic.js';
-import type { PackTypeInfo } from '../utils/pack-logic.js';
+import { getRarityById } from '../../type-metadata.js';
+import { openPackage, isPackageUnlocked, buildCardPool } from '../utils/pack-logic.js';
 import { SHOP_DATA } from '../../shop-data.js';
-import type { PackDef, PackageDef, PackSlotDef } from '../../shop-data.js';
+import type { PackageDef, PackSlotDef } from '../../shop-data.js';
 import { Audio }               from '../../audio.js';
-import { Rarity, Race } from '../../types.js';
+import { Rarity } from '../../types.js';
 import type { CardData } from '../../types.js';
 import styles from './ShopScreen.module.css';
-
-type Tab = 'standard' | 'packages';
 
 /** Compute total card count from slots. */
 function totalCards(slots: PackSlotDef[]): number {
@@ -80,23 +77,20 @@ export default function ShopScreen() {
   const bgUrl = SHOP_DATA.backgrounds[progress.currentChapter] ?? SHOP_DATA.backgrounds['ch1'] ?? '';
   const { t } = useTranslation();
 
-  const hasPackages = SHOP_DATA.packages.length > 0;
-  const [activeTab, setActiveTab] = useState<Tab>('standard');
   const [page, setPage] = useState(0);
   const itemsPerPage = useItemsPerPage();
-  const [infoTarget, setInfoTarget] = useState<{ pack: PackDef; type: 'pack' } | { pack: PackageDef; type: 'package' } | null>(null);
+  const [infoTarget, setInfoTarget] = useState<{ pack: PackageDef } | null>(null);
 
   // Touch swipe tracking
   const touchStartX = useRef(0);
   const touchStartY = useRef(0);
 
-  const packs = Object.values(PACK_TYPES);
   const unlockedPackages = SHOP_DATA.packages.filter(pkg => isPackageUnlocked(pkg));
-  const items = activeTab === 'standard' ? packs : unlockedPackages;
+  const items = unlockedPackages;
   const totalPages = Math.ceil(items.length / itemsPerPage);
 
-  // Reset page when switching tabs or when items per page changes
-  useEffect(() => { setPage(0); }, [activeTab, itemsPerPage]);
+  // Reset page when items per page changes
+  useEffect(() => { setPage(0); }, [itemsPerPage]);
 
   const goPage = useCallback((p: number) => {
     setPage(Math.max(0, Math.min(p, totalPages - 1)));
@@ -128,20 +122,8 @@ export default function ShopScreen() {
     navigateTo('pack-opening', { cards, preOpen });
   }
 
-  function buy(packType: string, race: string | null) {
-    const pt = PACK_TYPES[packType];
-    if (!pt || coins < pt.price) return;
-    if (!Progression.spendCoins(pt.price)) return;
-    Audio.playSfx('sfx_coin');
-    const preOpen = Progression.getCollection();
-    const cards   = openPack(packType, race !== null ? Number(race) as Race : null);
-    Progression.addCardsToCollection(cards.map((c: CardData) => c.id));
-    refresh();
-    navigateTo('pack-opening', { cards, preOpen });
-  }
-
-  function showInfo(pack: PackDef | PackageDef, type: 'pack' | 'package') {
-    setInfoTarget({ pack: pack as any, type });
+  function showInfo(pack: PackageDef) {
+    setInfoTarget({ pack });
   }
 
   // Slice items for current page
@@ -163,20 +145,6 @@ export default function ShopScreen() {
         <button className={`btn-secondary ${styles.backBtn}`} onClick={() => navigateTo('save-point')}>{t('shop.back')}</button>
       </div>
 
-      {/* Tabs */}
-      {hasPackages && (
-        <div className={styles.tabs}>
-          <button
-            className={`${styles.tabBtn}${activeTab === 'standard' ? ` ${styles.activeTab}` : ''}`}
-            onClick={() => setActiveTab('standard')}
-          >{t('shop.tab_standard')}</button>
-          <button
-            className={`${styles.tabBtn}${activeTab === 'packages' ? ` ${styles.activeTab}` : ''}`}
-            onClick={() => setActiveTab('packages')}
-          >{t('shop.tab_packages')}</button>
-        </div>
-      )}
-
       {/* Carousel */}
       <div className={styles.carousel} onTouchStart={onTouchStart} onTouchEnd={onTouchEnd}>
         {/* Arrow left */}
@@ -193,34 +161,18 @@ export default function ShopScreen() {
           className={styles.carouselTrack}
           style={{ '--items-per-page': itemsPerPage } as React.CSSProperties}
         >
-          {activeTab === 'standard'
-            ? (visibleItems as PackTypeInfo[]).map(pt => {
-                const packDef = SHOP_DATA.packs.find(p => p.id === pt.id)!;
-                const affordable = coins >= pt.price;
-                return (
-                  <PackTile
-                    key={pt.id}
-                    pt={pt}
-                    packDef={packDef}
-                    affordable={affordable}
-                    onBuy={buy}
-                    onInfo={() => showInfo(packDef, 'pack')}
-                  />
-                );
-              })
-            : (visibleItems as PackageDef[]).map(pkg => {
-                const affordable = coins >= pkg.price;
-                return (
-                  <PackageTile
-                    key={pkg.id}
-                    pkg={pkg}
-                    affordable={affordable}
-                    onBuy={buyPackage}
-                    onInfo={() => showInfo(pkg, 'package')}
-                  />
-                );
-              })
-          }
+          {(visibleItems as PackageDef[]).map(pkg => {
+            const affordable = coins >= pkg.price;
+            return (
+              <PackageTile
+                key={pkg.id}
+                pkg={pkg}
+                affordable={affordable}
+                onBuy={buyPackage}
+                onInfo={() => showInfo(pkg)}
+              />
+            );
+          })}
         </div>
 
         {/* Arrow right */}
@@ -252,64 +204,9 @@ export default function ShopScreen() {
       {infoTarget && (
         <PackInfoModal
           pack={infoTarget.pack}
-          type={infoTarget.type}
           onClose={() => setInfoTarget(null)}
         />
       )}
-    </div>
-  );
-}
-
-// ── Pack Tile ──────────────────────────────────────────────
-
-interface PackTileProps {
-  pt: PackTypeInfo;
-  packDef: PackDef;
-  affordable: boolean;
-  onBuy: (packType: string, race: string | null) => void;
-  onInfo: () => void;
-}
-
-function PackTile({ pt, packDef, affordable, onBuy, onInfo }: PackTileProps) {
-  const { t } = useTranslation();
-  const starterRace = Progression.getStarterRace() || '';
-  const raceKeys = getAllRaces().map(r => r.key);
-
-  function handleBuy() {
-    let race: string | null = null;
-    if (pt.id === 'race') {
-      const sel = document.getElementById(`shop-race-select-${pt.id}`) as HTMLSelectElement | null;
-      race = sel ? sel.value : starterRace || null;
-    }
-    onBuy(pt.id, race);
-  }
-
-  return (
-    <div
-      className={styles.packTile}
-      style={{ '--pack-color': pt.color } as React.CSSProperties}
-    >
-      <button className={styles.infoBtn} onClick={(e) => { e.stopPropagation(); onInfo(); }} aria-label="Pack info">?</button>
-
-      <div className={styles.packTop}>
-        <div className={styles.packIcon}>{pt.icon}</div>
-        <div className={styles.packName}>{t(`pack.${pt.id}_name`)}</div>
-        <div className={styles.packCardCount}>{t('shop.cards_count', { count: totalCards(packDef.slots) })}</div>
-      </div>
-
-      <div className={styles.packBottom}>
-        <div className={styles.packPrice}>◈ {pt.price.toLocaleString()}</div>
-        {pt.id === 'race' && (
-          <div className={styles.raceSelectWrap}>
-            <select id={`shop-race-select-${pt.id}`} className={styles.raceSelect} defaultValue={starterRace}>
-              {raceKeys.map(k => (
-                <option key={k} value={k}>{getRaceByKey(k)?.icon ?? ''} {t(`cards.race_${k}`)}</option>
-              ))}
-            </select>
-          </div>
-        )}
-        <button className={styles.buyBtn} disabled={!affordable} onClick={handleBuy}>{t('shop.buy_btn')}</button>
-      </div>
     </div>
   );
 }
@@ -352,27 +249,22 @@ function PackageTile({ pkg, affordable, onBuy, onInfo }: PackageTileProps) {
 // ── Pack Info Modal ────────────────────────────────────────
 
 interface PackInfoModalProps {
-  pack: PackDef | PackageDef;
-  type: 'pack' | 'package';
+  pack: PackageDef;
   onClose: () => void;
 }
 
-function PackInfoModal({ pack, type, onClose }: PackInfoModalProps) {
+function PackInfoModal({ pack, onClose }: PackInfoModalProps) {
   const { t } = useTranslation();
 
   const distribution = useMemo(() => computeDistribution(pack.slots), [pack]);
 
   const pool = useMemo(() => {
-    const cardPool = 'cardPool' in pack ? pack.cardPool : undefined;
-    return buildCardPool(cardPool);
+    return buildCardPool(pack.cardPool);
   }, [pack]);
 
   const poolByRarity = useMemo(() => countByRarity(pool), [pool]);
 
-  const isRacePack = type === 'pack' && (pack as PackDef).filter === 'byRace';
   const total = totalCards(pack.slots);
-  const displayName = type === 'pack' ? t(`pack.${pack.id}_name`) : pack.name;
-  const displayDesc = type === 'pack' ? t(`pack.${pack.id}_desc`) : pack.desc;
 
   return (
     <div className={styles.infoOverlay} onClick={onClose}>
@@ -381,8 +273,8 @@ function PackInfoModal({ pack, type, onClose }: PackInfoModalProps) {
         <div className={styles.infoModalHeader}>
           <span className={styles.infoModalIcon}>{pack.icon}</span>
           <div>
-            <div className={styles.infoModalTitle}>{displayName}</div>
-            <div className={styles.infoModalDesc}>{displayDesc}</div>
+            <div className={styles.infoModalTitle}>{pack.name}</div>
+            <div className={styles.infoModalDesc}>{pack.desc}</div>
           </div>
         </div>
 
@@ -427,7 +319,6 @@ function PackInfoModal({ pack, type, onClose }: PackInfoModalProps) {
               );
             })}
           </div>
-          {isRacePack && <div className={styles.raceNote}>{t('shop.info_race_note')}</div>}
         </div>
 
         <button className={styles.infoCloseBtn} onClick={onClose}>{t('shop.info_close')}</button>

--- a/js/react/utils/pack-logic.ts
+++ b/js/react/utils/pack-logic.ts
@@ -1,33 +1,9 @@
 import { CARD_DB } from '../../cards.js';
-import { Rarity, Race } from '../../types.js';
+import { Rarity } from '../../types.js';
 import { Progression } from '../../progression.js';
 import { SHOP_DATA } from '../../shop-data.js';
-import type { PackDef, PackSlotDef, PackageDef, CardFilter, CardPoolDef } from '../../shop-data.js';
+import type { PackSlotDef, PackageDef, CardFilter, CardPoolDef } from '../../shop-data.js';
 import type { CardData } from '../../types.js';
-
-// ── Public API (same shape as before) ───────────────────────
-
-export type PackTypeInfo = { id: string; name: string; desc: string; price: number; icon: string; color: string };
-
-/** Derive PACK_TYPES record from SHOP_DATA so existing consumers keep working. */
-export const PACK_TYPES: Record<string, PackTypeInfo> = new Proxy({} as Record<string, PackTypeInfo>, {
-  get(_target, prop: string) {
-    const pack = SHOP_DATA.packs.find(p => p.id === prop);
-    if (!pack) return undefined;
-    return { id: pack.id, name: pack.name, desc: pack.desc, price: pack.price, icon: pack.icon, color: pack.color };
-  },
-  ownKeys() {
-    return SHOP_DATA.packs.map(p => p.id);
-  },
-  getOwnPropertyDescriptor(_target, prop: string) {
-    const pack = SHOP_DATA.packs.find(p => p.id === prop);
-    if (!pack) return undefined;
-    return { configurable: true, enumerable: true, value: { id: pack.id, name: pack.name, desc: pack.desc, price: pack.price, icon: pack.icon, color: pack.color } };
-  },
-  has(_target, prop: string) {
-    return SHOP_DATA.packs.some(p => p.id === prop);
-  },
-});
 
 // ── Global rarity drop rates ────────────────────────────────
 
@@ -59,32 +35,9 @@ function _pickRarityFromSlot(slot: PackSlotDef): Rarity {
   return slot.rarity as Rarity;
 }
 
-// ── Card pool helpers ───────────────────────────────────────
-
-function _allCardsByRarity(rarity: Rarity, race: Race | null): CardData[] {
-  return (Object.values(CARD_DB) as CardData[]).filter(c =>
-    c.rarity === rarity && (!race || c.race === race)
-  );
-}
-
-function _pickCard(rarity: Rarity, race: Race | null): CardData {
-  let pool = _allCardsByRarity(rarity, race);
-  if (!pool.length) {
-    const fallbacks: Partial<Record<Rarity, Rarity>> = {
-      [Rarity.UltraRare]: Rarity.SuperRare,
-      [Rarity.SuperRare]: Rarity.Rare,
-      [Rarity.Rare]:      Rarity.Uncommon,
-      [Rarity.Uncommon]:  Rarity.Common,
-    };
-    pool = _allCardsByRarity(fallbacks[rarity] || Rarity.Common, race);
-  }
-  if (!pool.length) pool = Object.values(CARD_DB) as CardData[];
-  return pool[Math.floor(Math.random() * pool.length)];
-}
-
 // ── Expand slots into individual rarity picks ───────────────
 
-function _expandSlots(packDef: PackDef): Rarity[] {
+function _expandSlots(packDef: { slots: PackSlotDef[] }): Rarity[] {
   const rarities: Rarity[] = [];
   for (const slot of packDef.slots) {
     for (let i = 0; i < slot.count; i++) {
@@ -115,7 +68,7 @@ function _applyPity(rarities: Rarity[]): Rarity[] {
   return rarities;
 }
 
-// ── Card Pool Filtering (for packages) ──────────────────────
+// ── Card Pool Filtering ─────────────────────────────────────
 
 /**
  * Test whether a card matches a single CardFilter using AND logic:
@@ -197,43 +150,7 @@ export function isPackageUnlocked(pkg: PackageDef): boolean {
 
 // ── Main public function ────────────────────────────────────
 
-export function openPack(packType: string, race: Race | null = null): CardData[] {
-  const packDef = SHOP_DATA.packs.find(p => p.id === packType);
-  if (!packDef) return [];
-
-  const targetRace: Race | null =
-    packDef.filter === 'byRace' ? race
-    : null;
-
-  const rarities = _applyPity(_expandSlots(packDef));
-
-  if (packDef.cardPool) {
-    let pool = buildCardPool(packDef.cardPool);
-    if (targetRace != null) {
-      const raceFiltered = pool.filter(c => c.race === targetRace);
-      if (raceFiltered.length) pool = raceFiltered;
-    }
-    return rarities.map(rarity => {
-      let candidates = pool.filter(c => (c.rarity ?? Rarity.Common) === rarity);
-      const fallbacks: Partial<Record<Rarity, Rarity>> = {
-        [Rarity.UltraRare]: Rarity.SuperRare,
-        [Rarity.SuperRare]: Rarity.Rare,
-        [Rarity.Rare]:      Rarity.Uncommon,
-        [Rarity.Uncommon]:  Rarity.Common,
-      };
-      while (!candidates.length && fallbacks[rarity]) {
-        rarity = fallbacks[rarity]!;
-        candidates = pool.filter(c => (c.rarity ?? Rarity.Common) === rarity);
-      }
-      if (!candidates.length) candidates = pool.length ? pool : Object.values(CARD_DB) as CardData[];
-      return candidates[Math.floor(Math.random() * candidates.length)];
-    });
-  }
-
-  return rarities.map(r => _pickCard(r, targetRace));
-}
-
-/** Open a curated card package by ID. Uses the package's cardPool filter instead of race filtering. */
+/** Open a curated card package by ID. Uses the package's cardPool filter. */
 export function openPackage(packageId: string): CardData[] {
   const pkg = SHOP_DATA.packages.find(p => p.id === packageId);
   if (!pkg) return [];

--- a/js/shop-data.ts
+++ b/js/shop-data.ts
@@ -73,53 +73,12 @@ export interface ShopData {
   backgrounds: Record<string, string>;  // chapter key -> resolved URL
 }
 
-// ── Slot templates ──────────────────────────────────────────
-
-const STANDARD_SLOTS: PackSlotDef[] = [
-  { count: 8 },                                                         // slots 1-8: global rarity distribution
-  { count: 1, pool: 'guaranteed_rare_plus', distribution: { '4': 0.75, '6': 0.20, '8': 0.05 } }, // slot 9
-];
-
-const RARITY_SLOTS: PackSlotDef[] = [
-  { count: 7, rarity: 4 },                                              // slots 1-7: Rare
-  { count: 2, pool: 'guaranteed_sr_plus', distribution: { '4': 0.55, '6': 0.30, '8': 0.15 } }, // slots 8-9
-];
-
-// ── Default shop data (matches original hardcoded values) ───
+// ── Default shop data ───────────────────────────────────────
 
 export const SHOP_DATA: ShopData = {
   backgrounds: {},
   packages: [],
-  packs: [
-    {
-      id: 'race',
-      name: 'Race Pack',
-      desc: '9 cards \u00b7 Chosen race \u00b7 Standard',
-      price: 350,
-      icon: '\u2694',
-      color: '#a06020',
-      slots: STANDARD_SLOTS,
-      filter: 'byRace',
-    },
-    {
-      id: 'aether',
-      name: 'Jade Pack',
-      desc: '9 cards \u00b7 All races \u00b7 Standard',
-      price: 500,
-      icon: '\u25c8',
-      color: '#2a7848',
-      slots: STANDARD_SLOTS,
-    },
-    {
-      id: 'rarity',
-      name: 'Rarity Pack',
-      desc: '9 cards \u00b7 Min. Rare \u00b7 Increased SR/UR chance',
-      price: 600,
-      icon: '\u2605',
-      color: '#c0a020',
-      slots: RARITY_SLOTS,
-    },
-  ],
+  packs: [],
   currency: { nameKey: 'common.coins', icon: '\u25c8' },
 };
 

--- a/public/base.tcg-src/shop.json
+++ b/public/base.tcg-src/shop.json
@@ -1,57 +1,5 @@
 {
-  "packs": [
-    {
-      "id": "aether",
-      "name": "Jade Pack",
-      "desc": "9 cards · All races · Standard",
-      "price": 450,
-      "icon": "◈",
-      "color": "#2a7848",
-      "slots": [
-        { "count": 8 },
-        { "count": 1, "pool": "guaranteed_rare_plus", "distribution": { "4": 0.75, "6": 0.2, "8": 0.05 } }
-      ]
-    },
-    {
-      "id": "race",
-      "name": "Race Pack",
-      "desc": "9 cards · Chosen race · Max. Rare · Max. 2500 ATK",
-      "price": 500,
-      "icon": "⚔",
-      "color": "#a06020",
-      "slots": [
-        { "count": 8 },
-        { "count": 1, "pool": "guaranteed_rare_plus", "distribution": { "4": 0.75, "6": 0.2, "8": 0.05 } }
-      ],
-      "filter": "byRace",
-      "cardPool": {
-        "include": { "maxRarity": 4, "maxAtk": 2500 }
-      }
-    },
-    {
-      "id": "rarity",
-      "name": "Rarity Pack",
-      "desc": "9 cards · Min. Rare · Increased SR/UR chance",
-      "price": 600,
-      "icon": "★",
-      "color": "#c0a020",
-      "slots": [
-        {
-          "count": 7,
-          "rarity": 4
-        },
-        {
-          "count": 2,
-          "pool": "guaranteed_sr_plus",
-          "distribution": {
-            "4": 0.55,
-            "6": 0.3,
-            "8": 0.15
-          }
-        }
-      ]
-    }
-  ],
+  "packs": [],
   "packages": [
     {
       "id": "tier_1_recruit",

--- a/tests/pack-logic.test.js
+++ b/tests/pack-logic.test.js
@@ -2,53 +2,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { CARD_DB } from '../js/cards.js';
 import { Rarity, Race, CardType } from '../js/types.js';
-import { PACK_TYPES, openPack, RARITY_DROP_RATES } from '../js/react/utils/pack-logic.js';
+import { RARITY_DROP_RATES, openPackage, buildCardPool } from '../js/react/utils/pack-logic.js';
+import { SHOP_DATA } from '../js/shop-data.js';
 import { Progression } from '../js/progression.js';
-
-// ── Helpers ────────────────────────────────────────────────
-
-/** Collect all cards from CARD_DB as an array. */
-function allCards() {
-  return Object.values(CARD_DB);
-}
-
-/** Open many packs and flatten results into a single array. */
-function openMany(packType, count, race = null) {
-  const cards = [];
-  for (let i = 0; i < count; i++) {
-    cards.push(...openPack(packType, race));
-  }
-  return cards;
-}
-
-// ── PACK_TYPES structure ──────────────────────────────────
-
-describe('PACK_TYPES', () => {
-  it('contains the expected pack type keys', () => {
-    expect(Object.keys(PACK_TYPES)).toEqual(
-      expect.arrayContaining(['race', 'aether', 'rarity'])
-    );
-  });
-
-  it('each pack type has required fields with correct types', () => {
-    for (const [key, pack] of Object.entries(PACK_TYPES)) {
-      expect(pack.id).toBe(key);
-      expect(typeof pack.name).toBe('string');
-      expect(pack.name.length).toBeGreaterThan(0);
-      expect(typeof pack.desc).toBe('string');
-      expect(typeof pack.price).toBe('number');
-      expect(pack.price).toBeGreaterThan(0);
-      expect(typeof pack.icon).toBe('string');
-      expect(typeof pack.color).toBe('string');
-      expect(pack.color).toMatch(/^#[0-9a-f]{6}$/i);
-    }
-  });
-
-  it('pack prices are ordered: aether < race < rarity', () => {
-    expect(PACK_TYPES.aether.price).toBeLessThan(PACK_TYPES.race.price);
-    expect(PACK_TYPES.race.price).toBeLessThan(PACK_TYPES.rarity.price);
-  });
-});
 
 // ── RARITY_DROP_RATES ────────────────────────────────────
 
@@ -65,23 +21,29 @@ describe('RARITY_DROP_RATES', () => {
   });
 });
 
-// ── openPack — basic behavior ─────────────────────────────
+// ── openPackage ──────────────────────────────────────────
 
-describe('openPack', () => {
+describe('openPackage', () => {
   beforeEach(() => {
     localStorage.clear();
   });
 
-  it('returns exactly 9 cards for each pack type', () => {
-    for (const packType of Object.keys(PACK_TYPES)) {
-      const cards = openPack(packType);
-      expect(cards).toHaveLength(9);
+  it('returns empty array for unknown package ID', () => {
+    const cards = openPackage('nonexistent');
+    expect(cards).toHaveLength(0);
+  });
+
+  it('returns correct number of cards for each package', () => {
+    for (const pkg of SHOP_DATA.packages) {
+      const cards = openPackage(pkg.id);
+      const expectedCount = pkg.slots.reduce((sum, s) => sum + s.count, 0);
+      expect(cards).toHaveLength(expectedCount);
     }
   });
 
   it('all returned cards are valid CardData objects from CARD_DB', () => {
-    for (const packType of Object.keys(PACK_TYPES)) {
-      const cards = openPack(packType);
+    for (const pkg of SHOP_DATA.packages) {
+      const cards = openPackage(pkg.id);
       for (const card of cards) {
         expect(card).toHaveProperty('id');
         expect(card).toHaveProperty('name');
@@ -91,255 +53,44 @@ describe('openPack', () => {
     }
   });
 
-  it('returns CardData objects (not undefined or null)', () => {
-    const cards = openPack('aether');
-    cards.forEach(card => {
-      expect(card).toBeDefined();
-      expect(card).not.toBeNull();
-    });
-  });
-});
-
-// ── openPack — race filtering ─────────────────────────────
-
-describe('openPack race filtering', () => {
-  beforeEach(() => {
-    localStorage.clear();
-  });
-
-  it('race pack returns only cards matching the specified race', () => {
-    const race = Race.Dragon;
-    // Open many packs to get a good sample
-    const cards = openMany('race', 20, race);
-    for (const card of cards) {
-      // Cards without a race (spells/traps) should not appear because
-      // the filter requires c.race === race. But if fallback kicks in
-      // due to empty pools, any card is valid. We check with generous bounds.
-      if (card.race !== undefined) {
-        expect(card.race).toBe(race);
-      }
-    }
-  });
-
-  it('race pack works for multiple different races', () => {
-    const races = [Race.Warrior, Race.Spellcaster, Race.Beast];
-    for (const race of races) {
-      const cards = openPack('race', race);
+  it('respects cardPool maxAtk filter', () => {
+    const pkg = SHOP_DATA.packages.find(p => p.cardPool?.include?.maxAtk);
+    if (!pkg) return; // skip if no package has maxAtk filter
+    const maxAtk = pkg.cardPool.include.maxAtk;
+    // Open many times to get a good sample
+    for (let i = 0; i < 20; i++) {
+      const cards = openPackage(pkg.id);
       for (const card of cards) {
-        if (card.race !== undefined) {
-          expect(card.race).toBe(race);
+        if (card.atk !== undefined) {
+          expect(card.atk).toBeLessThanOrEqual(maxAtk);
         }
       }
     }
   });
-
-
-  it('aether pack ignores race parameter and returns cards from any race', () => {
-    const cards = openMany('aether', 20);
-    const races = new Set(cards.map(c => c.race).filter(r => r !== undefined));
-    // Aether packs should include multiple races over many openings
-    expect(races.size).toBeGreaterThan(1);
-  });
 });
 
-// ── openPack — rarity distribution ────────────────────────
+// ── buildCardPool ────────────────────────────────────────
 
-describe('openPack rarity distribution', () => {
-  beforeEach(() => {
-    localStorage.clear();
+describe('buildCardPool', () => {
+  it('returns all cards when no filter is provided', () => {
+    const pool = buildCardPool(undefined);
+    expect(pool.length).toBe(Object.values(CARD_DB).length);
   });
 
-  it('standard packs (aether): global rarity distribution with pity guarantee', () => {
-    // 8 slots use global distribution (60% C, 30% U, 8.9% R, 1% SR, 0.1% UR)
-    // + 1 guaranteed rare+ slot (75% R, 20% SR, 5% UR)
-    // Pity: if no card >= Rare, one card is upgraded to Rare
-    const iterations = 200;
-    const counts = { common: 0, uncommon: 0, rare: 0, superRare: 0, ultraRare: 0 };
-    for (let i = 0; i < iterations; i++) {
-      const cards = openPack('aether');
-      for (const card of cards) {
-        switch (card.rarity) {
-          case Rarity.Common:    counts.common++;    break;
-          case Rarity.Uncommon:  counts.uncommon++;  break;
-          case Rarity.Rare:      counts.rare++;      break;
-          case Rarity.SuperRare: counts.superRare++; break;
-          case Rarity.UltraRare: counts.ultraRare++; break;
-        }
-      }
-    }
-    const total = iterations * 9;
-    // Expected: ~53% Common, ~27% Uncommon, ~16% Rare (including pity + guaranteed slot)
-    expect(counts.common / total).toBeGreaterThan(0.35);
-    expect(counts.common / total).toBeLessThan(0.75);
-    expect(counts.uncommon / total).toBeGreaterThan(0.10);
-    expect(counts.uncommon / total).toBeLessThan(0.40);
-    expect(counts.rare / total).toBeGreaterThan(0.05);
-    // SR + UR should appear but be relatively rare
-    expect(counts.superRare + counts.ultraRare).toBeGreaterThan(0);
-  });
-
-  it('pity system: every pack contains at least one Rare-or-better card', () => {
-    const iterations = 500;
-    for (let i = 0; i < iterations; i++) {
-      const cards = openPack('aether');
-      const hasRareOrBetter = cards.some(c => c.rarity >= Rarity.Rare);
-      expect(hasRareOrBetter).toBe(true);
-    }
-  });
-
-  it('rarity packs: all cards are at least Rare', () => {
-    const iterations = 50;
-    for (let i = 0; i < iterations; i++) {
-      const cards = openPack('rarity');
-      for (const card of cards) {
-        expect(card.rarity).toBeGreaterThanOrEqual(Rarity.Rare);
+  it('filters by maxAtk', () => {
+    const pool = buildCardPool({ include: { maxAtk: 1500 } });
+    for (const card of pool) {
+      if (card.atk !== undefined) {
+        expect(card.atk).toBeLessThanOrEqual(1500);
       }
     }
   });
 
-  it('rarity packs have higher SR/UR rate than standard packs', () => {
-    const iterations = 200;
-    let rarityHighCount = 0;
-    let aetherHighCount = 0;
-
-    for (let i = 0; i < iterations; i++) {
-      const rarityCards = openPack('rarity');
-      const aetherCards = openPack('aether');
-      rarityHighCount += rarityCards.filter(c =>
-        c.rarity === Rarity.SuperRare || c.rarity === Rarity.UltraRare
-      ).length;
-      aetherHighCount += aetherCards.filter(c =>
-        c.rarity === Rarity.SuperRare || c.rarity === Rarity.UltraRare
-      ).length;
-    }
-
-    expect(rarityHighCount).toBeGreaterThan(aetherHighCount);
-  });
-
-  it('rarity pack slot 9 has elevated SR/UR chance', () => {
-    // Slot 9 in rarity pack: 15% UR, 30% SR, 55% Rare
-    // Over many trials, we should see SR+UR in roughly 45% of slot-9 draws
-    const iterations = 300;
-    let highRarityCount = 0;
-    for (let i = 0; i < iterations; i++) {
-      const cards = openPack('rarity');
-      const lastCard = cards[8]; // slot 9 (0-indexed)
-      if (lastCard.rarity === Rarity.SuperRare || lastCard.rarity === Rarity.UltraRare) {
-        highRarityCount++;
-      }
-    }
-    // Expected ~45%, allow generous bounds: 20% - 70%
-    const rate = highRarityCount / iterations;
-    expect(rate).toBeGreaterThan(0.20);
-    expect(rate).toBeLessThan(0.70);
-  });
-
-  it('standard pack slot 9 can produce UltraRare cards', () => {
-    // 5% chance per pack for UR in slot 9; over 500 packs should see at least one
-    const iterations = 500;
-    let foundUR = false;
-    for (let i = 0; i < iterations; i++) {
-      const cards = openPack('aether');
-      if (cards[8].rarity === Rarity.UltraRare) {
-        foundUR = true;
-        break;
-      }
-    }
-    expect(foundUR).toBe(true);
-  });
-});
-
-// ── Edge cases ────────────────────────────────────────────
-
-describe('openPack edge cases', () => {
-  beforeEach(() => {
-    localStorage.clear();
-  });
-
-  it('unknown pack type returns empty array', () => {
-    // Data-driven packs: unknown pack ID has no definition, so openPack returns []
-    const cards = openPack('nonexistent');
-    expect(cards).toHaveLength(0);
-  });
-
-  it('race with very few cards still returns 9 cards via fallback', () => {
-    // Even a race with sparse rarity distribution should work due to fallback logic
-    // Try every race to ensure none crashes
-    for (const raceValue of Object.values(Race)) {
-      if (typeof raceValue !== 'number') continue;
-      const cards = openPack('race', raceValue);
-      expect(cards).toHaveLength(9);
-      cards.forEach(card => {
-        expect(card).toBeDefined();
-        expect(card).not.toBeNull();
-      });
-    }
-  });
-
-  it('race pack with race=null behaves like aether (no race filter)', () => {
-    const cards = openMany('race', 30, null);
-    const races = new Set(cards.map(c => c.race).filter(r => r !== undefined));
-    // With null race, cards should come from multiple races
-    expect(races.size).toBeGreaterThan(1);
-  });
-
-  it('multiple openPack calls return different results (randomness)', () => {
-    // Open 10 packs and verify they are not all identical
-    const packs = [];
-    for (let i = 0; i < 10; i++) {
-      packs.push(openPack('aether').map(c => c.id).join(','));
-    }
-    const unique = new Set(packs);
-    expect(unique.size).toBeGreaterThan(1);
-  });
-
-});
-
-// ── _pickCard fallback behavior (tested indirectly) ───────
-
-describe('rarity fallback behavior', () => {
-  beforeEach(() => {
-    localStorage.clear();
-  });
-
-  it('race pack for a race missing UltraRare cards still returns 9 cards', () => {
-    // Find a race that has no UR cards (if any)
-    for (const raceValue of Object.values(Race)) {
-      if (typeof raceValue !== 'number') continue;
-      const urCards = allCards().filter(
-        c => c.rarity === Rarity.UltraRare && c.race === raceValue
-      );
-      if (urCards.length === 0) {
-        // This race has no UR cards — rarity pack with this race should still work
-        const cards = openPack('race', raceValue);
-        expect(cards).toHaveLength(9);
-        break;
-      }
-    }
-  });
-
-  it('all cards returned have valid rarity values', () => {
-    const validRarities = [
-      Rarity.Common, Rarity.Uncommon, Rarity.Rare,
-      Rarity.SuperRare, Rarity.UltraRare,
-    ];
-    for (const packType of Object.keys(PACK_TYPES)) {
-      const cards = openPack(packType);
-      for (const card of cards) {
-        if (card.rarity !== undefined) {
-          expect(validRarities).toContain(card.rarity);
-        }
-      }
-    }
-  });
-
-  it('all cards returned have valid card types', () => {
-    const validTypes = [CardType.Monster, CardType.Fusion, CardType.Spell, CardType.Trap, CardType.Equipment];
-    for (const packType of Object.keys(PACK_TYPES)) {
-      const cards = openPack(packType);
-      for (const card of cards) {
-        expect(validTypes).toContain(card.type);
-      }
+  it('filters by maxRarity', () => {
+    const pool = buildCardPool({ include: { maxRarity: Rarity.Rare } });
+    for (const card of pool) {
+      const rarity = card.rarity ?? Rarity.Common;
+      expect(rarity).toBeLessThanOrEqual(Rarity.Rare);
     }
   });
 });


### PR DESCRIPTION
Starter packs (Jade Pack, Race Pack, Rarity Pack) were overpowered.
Remove them entirely from the shop — only tiered packages remain.

- Empty packs array in shop.json and shop-data.ts defaults
- Remove PACK_TYPES proxy, openPack(), and PackTile from ShopScreen
- Remove tab system (standard/packages) since only packages exist
- Update pack-logic tests to cover openPackage and buildCardPool

https://claude.ai/code/session_01ELWkgwWuucmxrUcVQ3xWqP