### PR TITLE
fix(ui): fix facedown spell/trap i18n keys and add color differentiation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -561,6 +561,12 @@ button { cursor: pointer; border: none; font-family: inherit; transition: none; 
   background: rgba(0,0,0,0.3);
 }
 .own-facedown { filter: brightness(0.7); }
+.facedown-spell { background: #002018 !important; border-color: rgba(40,160,120,0.6) !important; }
+.facedown-trap  { background: #200810 !important; border-color: rgba(180,40,80,0.6) !important; }
+.facedown-equip { background: #1a1008 !important; border-color: rgba(224,128,48,0.6) !important; }
+.facedown-spell .facedown-overlay { color: rgba(50,160,100,0.8); }
+.facedown-trap  .facedown-overlay { color: rgba(200,60,80,0.8); }
+.facedown-equip .facedown-overlay { color: rgba(224,148,68,0.8); }
 
 /* Equipment badge on equipped monsters */
 .equip-badge {

--- a/js/react/components/FieldSpellTrapComponent.tsx
+++ b/js/react/components/FieldSpellTrapComponent.tsx
@@ -24,7 +24,8 @@ export function FieldSpellTrapComponent({ fst, owner, zone, interactive, onClick
   if (fst.faceDown && !isPlayer) {
     cls = 'card field-card face-down st-facedown';
   } else if (fst.faceDown && isPlayer) {
-    cls = 'card field-card face-down own-facedown attr-spell';
+    const fdType = card.type === CardType.Trap ? 'facedown-trap' : card.type === CardType.Equipment ? 'facedown-equip' : 'facedown-spell';
+    cls = `card field-card face-down own-facedown ${fdType}`;
   } else {
     cls = `card field-card ${cardTypeCss(card)}-card attr-spell`;
   }
@@ -53,7 +54,7 @@ export function FieldSpellTrapComponent({ fst, owner, zone, interactive, onClick
            onClick={interactive ? onClick : undefined}
            onContextMenu={!IS_TOUCH ? handleContextMenu : undefined}>
         <div className="facedown-overlay">
-          {card.type === CardType.Trap ? t('game.facedown_trap') : card.type === CardType.Equipment ? t('game.facedown_equip') : t('game.facedown_spell')}
+          {card.type === CardType.Trap ? t('card_action.facedown_trap') : card.type === CardType.Equipment ? t('card_action.facedown_equip') : t('card_action.facedown_spell')}
         </div>
       </div>
     );


### PR DESCRIPTION
Wrong i18n namespace (game. → card_action.) caused raw keys to display.
Added distinct background/border colors for facedown spell (green), trap
(red), and equipment (orange) cards so players can tell them apart.

https://claude.ai/code/session_01GHMAVMmBoSCScSvf7BZ9gq