### PR TITLE
fix(ui): show deck card count in portrait mode duel screen

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1198,6 +1198,7 @@ button { cursor: pointer; border: none; font-family: inherit; transition: none; 
   }
   .phud-opp    { color: #ff8080; }
   .phud-player { color: #80ff80; }
+  .phud-deck   { opacity: 0.7; font-size: 8px; margin-left: 2px; }
   .phud-phase {
     font-family: var(--font-stats);
     font-size: 6px;

--- a/js/react/screens/GameScreen.tsx
+++ b/js/react/screens/GameScreen.tsx
@@ -89,9 +89,9 @@ export default function GameScreen() {
         >☰</button>
 
         <div className="portrait-hud">
-          <span className="phud-lp phud-opp">♥ {opp.lp}</span>
+          <span className="phud-lp phud-opp">♥ {opp.lp} <span className="phud-deck">🂠{opp.deck?.length ?? 0}</span></span>
           <span className="phud-phase">{PHASE_LABEL[phase] ?? phase}</span>
-          <span className="phud-lp phud-player">♥ {player.lp}</span>
+          <span className="phud-lp phud-player">♥ {player.lp} <span className="phud-deck">🂠{player.deck?.length ?? 0}</span></span>
         </div>
 
         <button


### PR DESCRIPTION
The deck count (🂠) was only displayed in the LPPanel inside
#field-right-center, which is hidden (display:none) on portrait/mobile
layouts (max-width: 540px). Added deck counts to the portrait HUD bar
so they are visible on all screen sizes.

https://claude.ai/code/session_01931rm1gKPJZGcJ7rki1P37