### PR TITLE
fix(ui): standardize back button position to top-left corner across all screens

### DIFF
--- a/js/react/screens/CollectionScreen.module.css
+++ b/js/react/screens/CollectionScreen.module.css
@@ -19,6 +19,7 @@
   margin-bottom: 12px;
   flex-wrap: wrap;
   gap: 8px;
+  position: relative;
 }
 
 .title {
@@ -29,7 +30,13 @@
 }
 
 .stats { color: #7090b0; font-size: 0.85rem; }
-.backBtn { font-size: 0.85rem; }
+.backBtn {
+  position: absolute;
+  left: 0;
+  top: 0;
+  font-size: 0.8rem;
+  padding: 6px 12px;
+}
 
 .filters {
   display: flex;

--- a/js/react/screens/DeckbuilderScreen.module.css
+++ b/js/react/screens/DeckbuilderScreen.module.css
@@ -13,6 +13,15 @@
   border-bottom: 2px solid var(--border-glow);
   flex-shrink: 0;
   flex-wrap: wrap;
+  position: relative;
+}
+
+.backBtn {
+  position: absolute;
+  left: 0;
+  top: 0;
+  font-size: 0.8rem;
+  padding: 6px 12px;
 }
 
 .title {

--- a/js/react/screens/DeckbuilderScreen.tsx
+++ b/js/react/screens/DeckbuilderScreen.tsx
@@ -240,7 +240,7 @@ export default function DeckbuilderScreen() {
             style={{ opacity: deckFull ? 1 : 0.4, cursor: deckFull ? 'pointer' : 'not-allowed' }}
             onClick={saveDeck}
           >{t('deckbuilder.save_btn')}</button>
-          <button id="btn-db-back" className="btn-secondary" onClick={() => navigateTo('save-point')}>{t('deckbuilder.back')}</button>
+          <button id="btn-db-back" className={`btn-secondary ${styles.backBtn}`} onClick={() => navigateTo('save-point')}>{t('deckbuilder.back')}</button>
         </div>
         <div className={`${styles.tabs} ml-auto`}>
           <button

--- a/js/react/screens/PackOpeningScreen.module.css
+++ b/js/react/screens/PackOpeningScreen.module.css
@@ -304,6 +304,15 @@
   justify-content: center;
 }
 
+.backBtn {
+  position: absolute;
+  left: 12px;
+  top: 12px;
+  font-size: 0.8rem;
+  padding: 6px 12px;
+  z-index: 10;
+}
+
 /* Skip hint at bottom of screen */
 .skipHint {
   position: absolute;

--- a/js/react/screens/PackOpeningScreen.tsx
+++ b/js/react/screens/PackOpeningScreen.tsx
@@ -326,6 +326,7 @@ export default function PackOpeningScreen() {
   // Phase 3: Summary
   return (
     <div className={styles.screen}>
+      <button className={`btn-secondary ${styles.backBtn}`} onClick={() => navigateTo('shop')}>{t('pack_opening.back_shop')}</button>
       <div className={styles.summaryPhase}>
         <div className={styles.header}>
           <h2 className={styles.title}>{t('pack_opening.title')}</h2>
@@ -348,7 +349,6 @@ export default function PackOpeningScreen() {
         </div>
 
         <div className={styles.buttons}>
-          <button className="btn-secondary" onClick={() => navigateTo('shop')}>{t('pack_opening.back_shop')}</button>
           <button className="btn-primary" onClick={() => navigateTo('save-point')}>{t('pack_opening.home')}</button>
         </div>
       </div>

--- a/js/react/screens/ShopScreen.module.css
+++ b/js/react/screens/ShopScreen.module.css
@@ -54,7 +54,13 @@
   font-weight: bold;
 }
 
-.backBtn { font-size: 0.85rem; }
+.backBtn {
+  position: absolute;
+  left: 0;
+  top: 0;
+  font-size: 0.8rem;
+  padding: 6px 12px;
+}
 
 /* ── Tabs ── */
 


### PR DESCRIPTION
Back buttons were inconsistently positioned — some in flex headers, some
absolutely positioned. Standardized all to use absolute positioning in
top-left corner, matching the CampaignScreen/OpponentScreen pattern.

https://claude.ai/code/session_014hTH96gUnhF5GFXUPBGfF2