### PR TITLE
fix(engine): handle phoenixRevival passive in _destroyMonster

### DIFF
--- a/js/engine.ts
+++ b/js/engine.ts
@@ -974,6 +974,16 @@ export class GameEngine {
     st.field.monsters[zone] = null;
     this._removeEquipmentForMonster(owner, zone);
     this.ui.render(this.state);
+
+    // Phoenix Revival: revive once after destruction
+    if (fc.phoenixRevival && !fc.phoenixRevivalUsed) {
+      this.addLog(`${fc.card.name} rises from the graveyard!`);
+      const revived = await this.specialSummonFromGrave(owner, fc.card);
+      if (revived) {
+        const revivedFC = st.field.monsters.find(m => m !== null && m.card.id === fc.card.id);
+        if (revivedFC) revivedFC.phoenixRevivalUsed = true;
+      }
+    }
   }
 
   _buildSpellContext(owner: Owner, targetInfo: FieldCard | CardData | null): EffectContext {

--- a/tests/engine.spells.test.js
+++ b/tests/engine.spells.test.js
@@ -468,3 +468,47 @@ describe('activateFieldSpell', () => {
   });
 });
 
+// ── Phoenix Revival (passive: revive from grave on destroy) ──
+
+describe('phoenixRevival passive', () => {
+  it('revives monster to field after battle destruction', async () => {
+    const { engine } = makeEngine();
+    engine.state.phase = 'battle';
+    // Place phoenix (ATK 1200) for player and a stronger opponent monster
+    placeMonster(engine, 'player', { ...CARD.phoenix_monster }, 0);
+    placeMonster(engine, 'opponent', { ...CARD.monsterB }, 0); // ATK 1500
+
+    // Opponent attacks player's phoenix — phoenix loses and is destroyed
+    await engine.attack('opponent', 0, 0);
+
+    // Phoenix should have been revived from graveyard
+    const revived = engine.state.player.field.monsters.find(m => m !== null && m.card.id === 'TST_PHOENIX');
+    expect(revived).not.toBeNull();
+    // Graveyard should not contain the phoenix anymore
+    expect(engine.state.player.graveyard.find(c => c.id === 'TST_PHOENIX')).toBeUndefined();
+  });
+
+  it('marks phoenixRevivalUsed so it only revives once', async () => {
+    const { engine } = makeEngine();
+    engine.state.phase = 'battle';
+    placeMonster(engine, 'player', { ...CARD.phoenix_monster }, 0);
+    placeMonster(engine, 'opponent', { ...CARD.monsterB }, 0);
+
+    // First destruction — should revive
+    await engine.attack('opponent', 0, 0);
+    const revived = engine.state.player.field.monsters.find(m => m !== null && m.card.id === 'TST_PHOENIX');
+    expect(revived).not.toBeNull();
+    expect(revived.phoenixRevivalUsed).toBe(true);
+
+    // Second destruction — should NOT revive
+    engine.state.opponent.field.monsters[0].hasAttacked = false;
+    const revivedZone = engine.state.player.field.monsters.indexOf(revived);
+    await engine.attack('opponent', 0, revivedZone);
+
+    // Phoenix should now be in the graveyard, not on the field
+    const revivedAgain = engine.state.player.field.monsters.find(m => m !== null && m.card.id === 'TST_PHOENIX');
+    expect(revivedAgain).toBeUndefined();
+    expect(engine.state.player.graveyard.find(c => c.id === 'TST_PHOENIX')).toBeDefined();
+  });
+});
+


### PR DESCRIPTION
Monsters with the phoenixRevival passive flag (e.g. Celestial Phoenix #150)
were not being revived after battle destruction because _destroyMonster never
checked the flag. Now checks fc.phoenixRevival after destruction and calls
specialSummonFromGrave, marking phoenixRevivalUsed to prevent infinite loops.

https://claude.ai/code/session_018kBA5hrqSEeS71sfxt7hN1