### PR TITLE
feat(ui): improve card pack opening animation with full spectacle effects

### DIFF
--- a/css/animations.css
+++ b/css/animations.css
@@ -272,7 +272,7 @@
   100% { opacity: 0; }
 }
 
-/* Golden sparkle particles radiate outward (for SR/UR cards) */
+/* Sparkle particles radiate outward — color via --sparkle-color */
 @keyframes sparkleParticle {
   0% {
     transform: translate(-50%, -50%) rotate(var(--sparkle-angle)) translateY(0) scale(0.3);
@@ -291,7 +291,7 @@
   }
 }
 
-/* Golden burst flash behind rare card on reveal */
+/* Burst flash behind rare card on reveal */
 @keyframes sparkleBurst {
   0%   { transform: translate(-50%, -50%) scale(0.1); opacity: 1; }
   40%  { transform: translate(-50%, -50%) scale(1.5);  opacity: 0.8; }
@@ -309,6 +309,32 @@
   0%, 100% { transform: rotate(0deg); }
   25%  { transform: rotate(-3deg); }
   75%  { transform: rotate(3deg); }
+}
+
+/* Rotating light rays behind SR/UR cards */
+@keyframes lightRays {
+  0%   { transform: translate(-50%, -50%) rotate(0deg); }
+  100% { transform: translate(-50%, -50%) rotate(360deg); }
+}
+
+/* Pulsing background glow for rare cards */
+@keyframes bgPulse {
+  0%, 100% { opacity: 0.3; transform: scale(1); }
+  50%      { opacity: 0.7; transform: scale(1.05); }
+}
+
+/* Light beam sway and fade */
+@keyframes lightBeamFade {
+  0%   { opacity: 0; transform: translate(-50%, -50%) rotate(var(--beam-angle, 0deg)) scaleY(0.3); }
+  20%  { opacity: 0.8; transform: translate(-50%, -50%) rotate(var(--beam-angle, 0deg)) scaleY(1); }
+  70%  { opacity: 0.6; transform: translate(-50%, -50%) rotate(calc(var(--beam-angle, 0deg) + 3deg)) scaleY(1); }
+  100% { opacity: 0; transform: translate(-50%, -50%) rotate(calc(var(--beam-angle, 0deg) + 5deg)) scaleY(0.8); }
+}
+
+/* Tap prompt pulse */
+@keyframes tapPulse {
+  0%, 100% { opacity: 0.5; transform: scale(1); }
+  50%      { opacity: 1; transform: scale(1.05); }
 }
 
 /* ── Reduced Motion ─────────────────────────────────────── */

--- a/js/react/screens/PackOpeningScreen.module.css
+++ b/js/react/screens/PackOpeningScreen.module.css
@@ -10,6 +10,7 @@
   justify-content: center;
   overflow: hidden;
   user-select: none;
+  will-change: transform;
 }
 
 /* ── Phase 1: Pack Tear-Open ─────────────────────────────── */
@@ -32,6 +33,12 @@
   border: 2px solid #c8a84b;
   box-shadow: 0 0 20px rgba(200, 168, 75, 0.3), 0 4px 20px rgba(0, 0, 0, 0.6);
   overflow: hidden;
+  cursor: pointer;
+  transition: box-shadow 0.2s;
+}
+
+.packWrapper:hover {
+  box-shadow: 0 0 30px rgba(200, 168, 75, 0.5), 0 4px 24px rgba(0, 0, 0, 0.7);
 }
 
 .packFoil {
@@ -73,6 +80,38 @@
   text-shadow: 1px 1px 0 #000;
   letter-spacing: 1px;
   text-transform: uppercase;
+}
+
+/* Tap prompt below pack */
+.tapPrompt {
+  margin-top: 24px;
+  font-size: 0.7rem;
+  color: #c8a84b;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  animation: tapPulse 1.2s ease-in-out infinite;
+  text-shadow: 0 0 8px rgba(200, 168, 75, 0.4);
+}
+
+/* Tap counter dots */
+.tapDots {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.tapDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #1a1040;
+  border: 1px solid #c8a84b40;
+  transition: background 0.2s, box-shadow 0.2s;
+}
+
+.tapDot.filled {
+  background: #c8a84b;
+  box-shadow: 0 0 6px rgba(200, 168, 75, 0.8);
 }
 
 /* Pack halves for tear animation */
@@ -137,12 +176,74 @@
   justify-content: center;
   flex: 1;
   width: 100%;
+  perspective: 600px;
 }
 
+/* ── Card flip container ─── */
 .revealCard {
   position: absolute;
   width: 160px;
   min-height: 200px;
+  opacity: 0;
+  will-change: transform, opacity;
+  perspective: 600px;
+}
+
+@media (min-width: 480px) {
+  .revealCard { width: 180px; min-height: 230px; }
+}
+
+.revealCardInner {
+  position: relative;
+  width: 100%;
+  min-height: inherit;
+  transform-style: preserve-3d;
+  will-change: transform;
+}
+
+/* Card back face */
+.revealCardBack {
+  position: absolute;
+  inset: 0;
+  backface-visibility: hidden;
+  border-radius: 0;
+  border: 3px solid #286e3a;
+  background: #081610;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.cardBackPattern {
+  width: 100%;
+  height: 100%;
+  min-height: 200px;
+  background: repeating-conic-gradient(#081610 0% 25%, rgba(30, 90, 50, 0.15) 0% 50%) 0 0 / 8px 8px;
+  image-rendering: pixelated;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+@media (min-width: 480px) {
+  .cardBackPattern { min-height: 230px; }
+}
+
+.backLabel {
+  font-size: 32px;
+  color: rgba(50, 140, 70, 0.3);
+  font-weight: bold;
+  letter-spacing: -2px;
+}
+
+/* Card front face */
+.revealCardFront {
+  position: relative;
+  width: 100%;
+  min-height: inherit;
+  backface-visibility: hidden;
+  transform: rotateY(180deg);
   border-radius: 0;
   padding: 10px;
   font-size: 0.8rem;
@@ -150,16 +251,131 @@
   border: 3px solid var(--rarity-color, #aaa);
   background: #111828;
   box-shadow: 0 0 12px rgba(0, 0, 0, 0.8);
+}
+
+.revealCardFront.sparkle {
+  animation: rareBorderGlow 0.8s ease-in-out 3;
+}
+
+/* ── Rarity background FX ─── */
+.bgEffect {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 199;
   opacity: 0;
-  will-change: transform, opacity;
+  will-change: opacity;
 }
 
-@media (min-width: 480px) {
-  .revealCard { width: 180px; min-height: 230px; }
+.bgUncommon {
+  background: radial-gradient(ellipse at center, rgba(40, 60, 120, 0.3) 0%, transparent 70%);
+  animation: bgPulse 2s ease-in-out infinite;
 }
 
-.revealCard.sparkle {
-  animation: rareBorderGlow 0.8s ease-in-out 2;
+.bgRare {
+  background: radial-gradient(ellipse at center, rgba(80, 60, 180, 0.4) 0%, rgba(40, 30, 120, 0.2) 40%, transparent 70%);
+  animation: bgPulse 1.5s ease-in-out infinite;
+}
+
+.bgSuperRare {
+  background: radial-gradient(ellipse at center, rgba(200, 168, 75, 0.15) 0%, transparent 60%);
+}
+
+.bgUltraRare {
+  background: radial-gradient(ellipse at center, rgba(200, 100, 255, 0.15) 0%, transparent 60%);
+}
+
+/* Rotating light rays for SR */
+.lightRaysContainer {
+  position: fixed;
+  left: 50%;
+  top: 50%;
+  width: 500px;
+  height: 500px;
+  pointer-events: none;
+  z-index: 198;
+  opacity: 0;
+  will-change: opacity, transform;
+}
+
+.lightRaysSR {
+  width: 100%;
+  height: 100%;
+  background: conic-gradient(
+    from 0deg,
+    transparent 0deg,
+    rgba(200, 168, 75, 0.15) 10deg,
+    transparent 20deg,
+    transparent 40deg,
+    rgba(200, 168, 75, 0.12) 50deg,
+    transparent 60deg,
+    transparent 80deg,
+    rgba(200, 168, 75, 0.15) 90deg,
+    transparent 100deg,
+    transparent 120deg,
+    rgba(200, 168, 75, 0.12) 130deg,
+    transparent 140deg,
+    transparent 160deg,
+    rgba(200, 168, 75, 0.15) 170deg,
+    transparent 180deg,
+    transparent 200deg,
+    rgba(200, 168, 75, 0.12) 210deg,
+    transparent 220deg,
+    transparent 240deg,
+    rgba(200, 168, 75, 0.15) 250deg,
+    transparent 260deg,
+    transparent 280deg,
+    rgba(200, 168, 75, 0.12) 290deg,
+    transparent 300deg,
+    transparent 320deg,
+    rgba(200, 168, 75, 0.15) 330deg,
+    transparent 340deg,
+    transparent 360deg
+  );
+  animation: lightRays 8s linear infinite;
+}
+
+.lightRaysUR {
+  width: 100%;
+  height: 100%;
+  background: conic-gradient(
+    from 0deg,
+    transparent 0deg,
+    rgba(255, 80, 80, 0.15) 10deg,
+    transparent 20deg,
+    transparent 30deg,
+    rgba(255, 200, 60, 0.15) 40deg,
+    transparent 50deg,
+    transparent 60deg,
+    rgba(100, 255, 100, 0.15) 70deg,
+    transparent 80deg,
+    transparent 90deg,
+    rgba(80, 160, 255, 0.15) 100deg,
+    transparent 110deg,
+    transparent 120deg,
+    rgba(200, 100, 255, 0.15) 130deg,
+    transparent 140deg,
+    transparent 160deg,
+    rgba(255, 80, 80, 0.15) 170deg,
+    transparent 180deg,
+    transparent 190deg,
+    rgba(255, 200, 60, 0.15) 200deg,
+    transparent 210deg,
+    transparent 220deg,
+    rgba(100, 255, 100, 0.15) 230deg,
+    transparent 240deg,
+    transparent 250deg,
+    rgba(80, 160, 255, 0.15) 260deg,
+    transparent 270deg,
+    transparent 280deg,
+    rgba(200, 100, 255, 0.15) 290deg,
+    transparent 300deg,
+    transparent 320deg,
+    rgba(255, 80, 80, 0.12) 330deg,
+    transparent 340deg,
+    transparent 360deg
+  );
+  animation: lightRays 6s linear infinite;
 }
 
 /* Sparkle particle for SR/UR */
@@ -170,11 +386,19 @@
   left: 50%;
   top: 50%;
   clip-path: polygon(50% 0%, 100% 50%, 50% 100%, 0% 50%);
-  background: linear-gradient(135deg, #ffd700 0%, #fff8dc 50%, #ffd700 100%);
-  box-shadow: 0 0 6px rgba(255, 215, 0, 0.8);
+  background: linear-gradient(135deg, var(--sparkle-color, #ffd700) 0%, #fff8dc 50%, var(--sparkle-color, #ffd700) 100%);
+  box-shadow: 0 0 6px var(--sparkle-color, rgba(255, 215, 0, 0.8));
   pointer-events: none;
   will-change: transform, opacity;
   animation: sparkleParticle 0.8s ease-out forwards;
+}
+
+/* Smaller variant for Rare tier */
+.sparkle-particle-small {
+  composes: sparkle-particle;
+  width: 6px;
+  height: 6px;
+  box-shadow: 0 0 3px var(--sparkle-color, rgba(120, 160, 255, 0.6));
 }
 
 /* Sparkle burst behind card */
@@ -185,10 +409,37 @@
   width: 180px;
   height: 180px;
   border-radius: 50%;
-  background: radial-gradient(circle, rgba(255, 215, 0, 0.5) 0%, rgba(255, 215, 0, 0.1) 40%, transparent 70%);
+  background: radial-gradient(circle, var(--sparkle-color, rgba(255, 215, 0, 0.5)) 0%, var(--sparkle-color, rgba(255, 215, 0, 0.1)) 40%, transparent 70%);
   pointer-events: none;
   animation: sparkleBurst 0.7s ease-out forwards;
   z-index: -1;
+}
+
+/* Large burst for UR */
+.sparkle-burst-large {
+  composes: sparkle-burst;
+  width: 280px;
+  height: 280px;
+}
+
+/* Light beam for SR/UR */
+.lightBeam {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 3px;
+  height: 200px;
+  background: linear-gradient(
+    to bottom,
+    transparent 0%,
+    var(--sparkle-color, rgba(255, 215, 0, 0.6)) 30%,
+    var(--sparkle-color, rgba(255, 215, 0, 0.8)) 50%,
+    var(--sparkle-color, rgba(255, 215, 0, 0.6)) 70%,
+    transparent 100%
+  );
+  pointer-events: none;
+  transform-origin: center center;
+  animation: lightBeamFade 1.2s ease-out forwards;
 }
 
 /* Rarity bar on reveal card */
@@ -227,11 +478,16 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.35rem;
+  font-size: 0.5rem;
   color: #6080a0;
   overflow: hidden;
   opacity: 0.7;
   transition: opacity 0.2s;
+}
+
+.miniCardIcon {
+  font-size: 0.5rem;
+  line-height: 1;
 }
 
 /* ── Phase 3: Summary Grid ───────────────────────────────── */
@@ -284,18 +540,18 @@
 }
 
 /* Same styles for reveal card inner text */
-.revealCard :global(.card-header) {
+.revealCardFront :global(.card-header) {
   display: flex;
   justify-content: space-between;
   margin-top: 4px;
   margin-bottom: 4px;
 }
 
-.revealCard :global(.card-name) { font-weight: bold; color: #d0e0ff; font-size: 0.9rem; }
-.revealCard :global(.card-level) { color: #c8a84b; font-size: 0.7rem; }
-.revealCard :global(.card-type-line) { color: #6080a0; font-size: 0.7rem; margin-bottom: 3px; }
-.revealCard :global(.card-desc) { color: #8090a8; font-size: 0.7rem; line-height: 1.3; max-height: 3.9em; overflow: hidden; }
-.revealCard :global(.card-footer) { display: flex; justify-content: space-between; margin-top: 4px; color: #90b0d0; font-size: 0.75rem; }
+.revealCardFront :global(.card-name) { font-weight: bold; color: #d0e0ff; font-size: 0.9rem; }
+.revealCardFront :global(.card-level) { color: #c8a84b; font-size: 0.7rem; }
+.revealCardFront :global(.card-type-line) { color: #6080a0; font-size: 0.7rem; margin-bottom: 3px; }
+.revealCardFront :global(.card-desc) { color: #8090a8; font-size: 0.7rem; line-height: 1.3; max-height: 3.9em; overflow: hidden; }
+.revealCardFront :global(.card-footer) { display: flex; justify-content: space-between; margin-top: 4px; color: #90b0d0; font-size: 0.75rem; }
 
 .buttons {
   display: flex;

--- a/js/react/screens/PackOpeningScreen.tsx
+++ b/js/react/screens/PackOpeningScreen.tsx
@@ -12,19 +12,34 @@ import styles from './PackOpeningScreen.module.css';
 
 type Phase = 'pack' | 'reveal' | 'summary';
 
-/* ── Timing constants ──────────────────────────────────── */
+/* ── Constants ────────────────────────────────────────────── */
+const TAPS_TO_OPEN = 3;
+
 const HOLD_BY_RARITY: Record<number, number> = {
   [Rarity.Common]:    0.5,
   [Rarity.Uncommon]:  0.5,
   [Rarity.Rare]:      0.8,
-  [Rarity.SuperRare]: 1.0,
-  [Rarity.UltraRare]: 1.2,
+  [Rarity.SuperRare]: 1.2,
+  [Rarity.UltraRare]: 1.6,
 };
 
-const SPARKLE_RARITIES = new Set([Rarity.SuperRare, Rarity.UltraRare]);
-const SPARKLE_COUNT = 12;
+/** Rarity → sparkle config */
+const SPARKLE_CONFIG: Record<number, { count: number; color: string; beams: number; burstSize: 'normal' | 'large'; small: boolean }> = {
+  [Rarity.Rare]:      { count: 6,  color: '#7090ff', beams: 0, burstSize: 'normal', small: true },
+  [Rarity.SuperRare]: { count: 12, color: '#ffd700', beams: 4, burstSize: 'normal', small: false },
+  [Rarity.UltraRare]: { count: 18, color: '#e080ff', beams: 6, burstSize: 'large',  small: false },
+};
 
-/* ── Helpers ───────────────────────────────────────────── */
+/** Card type icons for mini strip */
+const TYPE_ICONS: Record<number, string> = {
+  [CardType.Monster]: '⚔',
+  [CardType.Fusion]: '★',
+  [CardType.Spell]: '✦',
+  [CardType.Trap]: '⚡',
+  [CardType.Equipment]: '🛡',
+};
+
+/* ── Helpers ───────────────────────────────────────────────── */
 
 function getTypeLabel(card: CardData, t: (k: string) => string) {
   if (card.type === CardType.Monster && card.effect) return t('pack_opening.type_effect');
@@ -34,25 +49,68 @@ function getTypeLabel(card: CardData, t: (k: string) => string) {
   return t('pack_opening.type_trap');
 }
 
-function spawnSparkles(container: HTMLElement) {
-  for (let i = 0; i < SPARKLE_COUNT; i++) {
+function spawnRevealFX(container: HTMLElement, rarity: number) {
+  const cfg = SPARKLE_CONFIG[rarity];
+  if (!cfg) return;
+
+  // Spawn sparkle particles
+  for (let i = 0; i < cfg.count; i++) {
     const el = document.createElement('div');
-    el.className = styles['sparkle-particle'];
-    el.style.setProperty('--sparkle-angle', `${(i / SPARKLE_COUNT) * 360}deg`);
+    el.className = cfg.small ? styles['sparkle-particle-small'] : styles['sparkle-particle'];
+    el.style.setProperty('--sparkle-angle', `${(i / cfg.count) * 360}deg`);
+    el.style.setProperty('--sparkle-color', cfg.color);
     el.style.animationDelay = `${Math.random() * 0.15}s`;
     container.appendChild(el);
     el.addEventListener('animationend', () => el.remove(), { once: true });
     setTimeout(() => { if (el.parentNode) el.remove(); }, 1200);
   }
-  // burst
+
+  // Spawn light beams for SR/UR
+  for (let i = 0; i < cfg.beams; i++) {
+    const beam = document.createElement('div');
+    beam.className = styles.lightBeam;
+    beam.style.setProperty('--beam-angle', `${(i / cfg.beams) * 180}deg`);
+    beam.style.setProperty('--sparkle-color', cfg.color);
+    beam.style.animationDelay = `${i * 0.08}s`;
+    container.appendChild(beam);
+    beam.addEventListener('animationend', () => beam.remove(), { once: true });
+    setTimeout(() => { if (beam.parentNode) beam.remove(); }, 1500);
+  }
+
+  // Spawn burst
   const burst = document.createElement('div');
-  burst.className = styles['sparkle-burst'];
+  burst.className = cfg.burstSize === 'large' ? styles['sparkle-burst-large'] : styles['sparkle-burst'];
+  burst.style.setProperty('--sparkle-color', cfg.color);
   container.appendChild(burst);
   burst.addEventListener('animationend', () => burst.remove(), { once: true });
   setTimeout(() => { if (burst.parentNode) burst.remove(); }, 1000);
 }
 
-/* ── Component ─────────────────────────────────────────── */
+/** Screen shake utility */
+function shakeScreen(screenEl: HTMLElement, intensity: number, duration: number) {
+  const tl = gsap.timeline();
+  const steps = Math.floor(duration / 0.03);
+  for (let i = 0; i < steps; i++) {
+    const x = (Math.random() - 0.5) * 2 * intensity;
+    const y = (Math.random() - 0.5) * 2 * intensity;
+    tl.to(screenEl, { x, y, duration: 0.03, ease: 'none' });
+  }
+  tl.to(screenEl, { x: 0, y: 0, duration: 0.05, ease: 'steps(2)' });
+  return tl;
+}
+
+/** Get rarity background class */
+function getBgClass(rarity: number): string {
+  switch (rarity) {
+    case Rarity.Uncommon:  return styles.bgUncommon;
+    case Rarity.Rare:      return styles.bgRare;
+    case Rarity.SuperRare: return styles.bgSuperRare;
+    case Rarity.UltraRare: return styles.bgUltraRare;
+    default: return '';
+  }
+}
+
+/* ── Component ─────────────────────────────────────────────── */
 
 export default function PackOpeningScreen() {
   const { navigateTo, screenData } = useScreen();
@@ -68,14 +126,20 @@ export default function PackOpeningScreen() {
   );
 
   const [phase, setPhase] = useState<Phase>('pack');
+  const [tapCount, setTapCount] = useState(0);
+  const [tearing, setTearing] = useState(false);
   const [revealIndex, setRevealIndex] = useState(-1);
   const [showFlash, setShowFlash] = useState(false);
+  const [currentRarity, setCurrentRarity] = useState<number>(Rarity.Common);
   const skipRef = useRef(false);
   const tlRef = useRef<gsap.core.Timeline | null>(null);
   const packRef = useRef<HTMLDivElement>(null);
   const leftRef = useRef<HTMLDivElement>(null);
   const rightRef = useRef<HTMLDivElement>(null);
   const revealCardRef = useRef<HTMLDivElement>(null);
+  const screenRef = useRef<HTMLDivElement>(null);
+  const lightRaysRef = useRef<HTMLDivElement>(null);
+  const bgRef = useRef<HTMLDivElement>(null);
 
   /* ── Reduced motion: skip everything ─── */
   useEffect(() => {
@@ -88,14 +152,42 @@ export default function PackOpeningScreen() {
   /* ── Skip handler ─── */
   const handleSkip = useCallback(() => {
     if (phase === 'summary') return;
+    if (phase === 'pack' && !tearing) return; // don't skip during tap phase
     skipRef.current = true;
     tlRef.current?.kill();
     setPhase('summary');
-  }, [phase]);
+  }, [phase, tearing]);
 
-  /* ── Phase 1: Pack tear-open animation ─── */
+  /* ── Pack tap handler ─── */
+  const handlePackTap = useCallback(() => {
+    if (tearing || skipRef.current) return;
+    const pack = packRef.current;
+    if (!pack) return;
+
+    const newCount = tapCount + 1;
+    setTapCount(newCount);
+    Audio.playSfx('sfx_button');
+
+    // Escalating wobble
+    const wobbleIntensity = newCount * 3; // 3°, 6°, 9°+
+    const wobbleScale = 1 + newCount * 0.02;
+    const tl = gsap.timeline();
+    tl.to(pack, { rotation: -wobbleIntensity, scale: wobbleScale, duration: 0.08, ease: 'steps(2)' })
+      .to(pack, { rotation: wobbleIntensity, scale: wobbleScale, duration: 0.08, ease: 'steps(2)' })
+      .to(pack, { rotation: -wobbleIntensity * 0.5, duration: 0.06, ease: 'steps(2)' })
+      .to(pack, { rotation: 0, scale: 1, duration: 0.06, ease: 'steps(2)' });
+
+    if (newCount >= TAPS_TO_OPEN) {
+      // Trigger tear on last tap
+      tl.eventCallback('onComplete', () => {
+        setTearing(true);
+      });
+    }
+  }, [tapCount, tearing]);
+
+  /* ── Phase 1: Pack tear-open animation (triggered when tearing=true) ─── */
   useEffect(() => {
-    if (phase !== 'pack') return;
+    if (phase !== 'pack' || !tearing) return;
     if (skipRef.current) { setPhase('summary'); return; }
 
     const pack = packRef.current;
@@ -112,11 +204,11 @@ export default function PackOpeningScreen() {
     });
     tlRef.current = tl;
 
-    // Wobble the pack
-    tl.to(pack, { rotation: -3, duration: 0.12, ease: 'steps(3)' })
-      .to(pack, { rotation: 3, duration: 0.12, ease: 'steps(3)' })
-      .to(pack, { rotation: -2, duration: 0.1, ease: 'steps(2)' })
-      .to(pack, { rotation: 0, duration: 0.08, ease: 'steps(2)' });
+    // Final dramatic wobble before tear
+    tl.to(pack, { rotation: -8, scale: 1.08, duration: 0.1, ease: 'steps(3)' })
+      .to(pack, { rotation: 8, scale: 1.08, duration: 0.1, ease: 'steps(3)' })
+      .to(pack, { rotation: -10, scale: 1.1, duration: 0.08, ease: 'steps(2)' })
+      .to(pack, { rotation: 0, scale: 1, duration: 0.06, ease: 'steps(2)' });
 
     // Hide original, show halves
     tl.call(() => {
@@ -126,20 +218,23 @@ export default function PackOpeningScreen() {
 
     // Tear apart
     tl.to(left, {
-      x: -80, rotation: -12, opacity: 0,
+      x: -100, rotation: -15, opacity: 0,
       duration: 0.4, ease: 'steps(6)',
     }, '+=0')
       .to(right, {
-        x: 80, rotation: 12, opacity: 0,
+        x: 100, rotation: 15, opacity: 0,
         duration: 0.4, ease: 'steps(6)',
       }, '<');
 
-    // Flash
-    tl.call(() => setShowFlash(true), undefined, '-=0.15');
+    // Flash + screen shake
+    tl.call(() => {
+      setShowFlash(true);
+      if (screenRef.current) shakeScreen(screenRef.current, 3, 0.3);
+    }, undefined, '-=0.15');
     tl.to({}, { duration: 0.5 }); // wait for flash to fade
 
     return () => { tl.kill(); };
-  }, [phase]);
+  }, [phase, tearing]);
 
   /* ── Phase 2: Card reveal sequence ─── */
   useEffect(() => {
@@ -154,47 +249,97 @@ export default function PackOpeningScreen() {
       for (let i = 0; i < sortedCards.length; i++) {
         if (cancelled || skipRef.current) break;
 
-        // Update index to render the card
+        const card = sortedCards[i];
+        const rarity = card.rarity ?? Rarity.Common;
+
+        // Update index & rarity to render the card
         setRevealIndex(i);
+        setCurrentRarity(rarity);
 
         // Wait a tick for React to render
         await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
         if (cancelled || skipRef.current) break;
 
         const cardEl = revealCardRef.current;
+        const screenEl = screenRef.current;
+        const bgEl = bgRef.current;
+        const raysEl = lightRaysRef.current;
         if (!cardEl) continue;
 
-        const card = sortedCards[i];
-        const rarity = card.rarity ?? Rarity.Common;
         const holdTime = HOLD_BY_RARITY[rarity] ?? 0.5;
-        const isSparkly = SPARKLE_RARITIES.has(rarity);
+        const hasSparkle = rarity in SPARKLE_CONFIG;
+        const hasBg = rarity >= Rarity.Uncommon;
+        const hasRays = rarity >= Rarity.SuperRare;
 
-        Audio.playSfx('sfx_pack_reveal');
-
-        // Animate card: slide from top to center
         const tl = gsap.timeline();
         currentTl = tl;
         tlRef.current = tl;
 
-        gsap.set(cardEl, { y: '-120vh', opacity: 0, scale: 0.85 });
+        // Find the inner element for flip
+        const innerEl = cardEl.querySelector(`.${styles.revealCardInner}`) as HTMLElement | null;
+        const frontEl = cardEl.querySelector(`.${styles.revealCardFront}`) as HTMLElement | null;
 
+        // Reset card state: face-down, off-screen
+        gsap.set(cardEl, { y: '-120vh', opacity: 0, scale: 0.85 });
+        if (innerEl) gsap.set(innerEl, { rotateY: 0 });
+
+        // Fade in background effect
+        if (hasBg && bgEl) {
+          tl.to(bgEl, { opacity: 1, duration: 0.3, ease: 'steps(4)' }, 0);
+        }
+
+        // Fade in light rays for SR/UR
+        if (hasRays && raysEl) {
+          tl.to(raysEl, { opacity: 1, duration: 0.4, ease: 'steps(5)' }, 0);
+        }
+
+        // Card entrance: slide from top (face-down)
         tl.to(cardEl, {
           y: 0, opacity: 1, scale: 1,
           duration: 0.45, ease: 'steps(8)',
-        });
+        }, 0);
 
-        // Sparkle effect for SR/UR
-        if (isSparkly) {
-          tl.call(() => {
-            if (cardEl) {
-              spawnSparkles(cardEl);
-              cardEl.classList.add(styles.sparkle);
-            }
+        // Brief pause before flip
+        tl.to({}, { duration: 0.15 });
+
+        // Card flip: face-down → face-up
+        if (innerEl) {
+          tl.to(innerEl, {
+            rotateY: 180, duration: 0.4, ease: 'steps(6)',
           });
         }
 
-        // Hold
+        // Play reveal SFX at flip moment
+        tl.call(() => {
+          Audio.playSfx('sfx_pack_reveal');
+        }, undefined, '-=0.2');
+
+        // Screen shake for SR/UR at flip moment
+        if (rarity >= Rarity.SuperRare && screenEl) {
+          const shakeIntensity = rarity === Rarity.UltraRare ? 5 : 3;
+          tl.call(() => {
+            shakeScreen(screenEl, shakeIntensity, 0.35);
+          }, undefined, '-=0.1');
+        }
+
+        // Sparkle + beam effects after flip
+        if (hasSparkle) {
+          tl.call(() => {
+            if (cardEl) spawnRevealFX(cardEl, rarity);
+            if (frontEl) frontEl.classList.add(styles.sparkle);
+          });
+        }
+
+        // Hold to admire
         tl.to({}, { duration: holdTime });
+
+        // Fade out background + rays
+        if (hasBg && bgEl) {
+          tl.to(bgEl, { opacity: 0, duration: 0.2, ease: 'steps(3)' }, `-=${0.15}`);
+        }
+        if (hasRays && raysEl) {
+          tl.to(raysEl, { opacity: 0, duration: 0.2, ease: 'steps(3)' }, '<');
+        }
 
         // Shrink & move down to mini strip area
         tl.to(cardEl, {
@@ -211,6 +356,8 @@ export default function PackOpeningScreen() {
       }
 
       if (!cancelled && !skipRef.current) {
+        // Brief pause before summary
+        await new Promise(r => setTimeout(r, 300));
         setPhase('summary');
       }
     }
@@ -228,10 +375,10 @@ export default function PackOpeningScreen() {
   // Phase 1: Pack
   if (phase === 'pack') {
     return (
-      <div className={styles.screen} onClick={handleSkip}>
+      <div ref={screenRef} className={styles.screen} onClick={tearing ? handleSkip : undefined}>
         {showFlash && <div className={styles.flash} />}
         <div className={styles.packPhase}>
-          <div ref={packRef} className={styles.packWrapper}>
+          <div ref={packRef} className={styles.packWrapper} onClick={handlePackTap}>
             <div className={styles.packFoil} />
             <div className={styles.packLabel}>
               <div className={styles.packIcon}>🀄</div>
@@ -251,7 +398,21 @@ export default function PackOpeningScreen() {
             </div>
           </div>
 
-          <div className={styles.skipHint}>{t('pack_opening.skip_hint')}</div>
+          {/* Tap prompt + dots */}
+          {!tearing && (
+            <>
+              <div className={styles.tapPrompt}>{t('pack_opening.tap_hint')}</div>
+              <div className={styles.tapDots}>
+                {Array.from({ length: TAPS_TO_OPEN }).map((_, i) => (
+                  <div key={i} className={`${styles.tapDot} ${i < tapCount ? styles.filled : ''}`} />
+                ))}
+              </div>
+            </>
+          )}
+
+          {tearing && (
+            <div className={styles.skipHint}>{t('pack_opening.skip_hint')}</div>
+          )}
         </div>
       </div>
     );
@@ -261,37 +422,64 @@ export default function PackOpeningScreen() {
   if (phase === 'reveal') {
     const currentCard = revealIndex >= 0 ? sortedCards[revealIndex] : null;
     const rarColor = currentCard ? (getRarityById((currentCard as any).rarity)?.color ?? '#aaa') : '#aaa';
+    const bgClass = getBgClass(currentRarity);
+    const hasRays = currentRarity >= Rarity.SuperRare;
 
     return (
-      <div className={styles.screen} onClick={handleSkip}>
+      <div ref={screenRef} className={styles.screen} onClick={handleSkip}>
+        {/* Rarity background glow */}
+        <div ref={bgRef} className={`${styles.bgEffect} ${bgClass}`} />
+
+        {/* Rotating light rays for SR/UR */}
+        {hasRays && (
+          <div ref={lightRaysRef} className={styles.lightRaysContainer}>
+            <div className={currentRarity === Rarity.UltraRare ? styles.lightRaysUR : styles.lightRaysSR} />
+          </div>
+        )}
+
         <div className={styles.revealPhase}>
           <div className={styles.revealStage}>
             {currentCard && (
               <div
                 ref={revealCardRef}
-                className={`${styles.revealCard} card ${cardTypeCss(currentCard)}-card attr-${currentCard.attribute ? ATTR_CSS[currentCard.attribute] || 'spell' : 'spell'}`}
+                className={styles.revealCard}
                 style={{ '--rarity-color': rarColor } as React.CSSProperties}
               >
-                <div className={styles.revealRarityBar} style={{ background: rarColor }} />
-                {!ownedBefore.has(currentCard.id) && (
-                  <div className={styles.newBadge}>{t('pack_opening.new_badge')}</div>
-                )}
-                <div className="card-header">
-                  <span className="card-name">{currentCard.name}</span>
-                  <span className="card-level">
-                    {currentCard.level ? '★'.repeat(Math.min(currentCard.level, 5)) : ''}
-                  </span>
-                </div>
-                <div className="card-body">
-                  <div className="card-type-line">{getTypeLabel(currentCard, t)}</div>
-                  <div className="card-desc">{currentCard.description || ''}</div>
-                </div>
-                {currentCard.atk !== undefined && (
-                  <div className="card-footer">
-                    <span>ATK {currentCard.atk}</span>
-                    <span>DEF {currentCard.def}</span>
+                <div className={styles.revealCardInner}>
+                  {/* Back face (visible initially) */}
+                  <div className={styles.revealCardBack}>
+                    <div className={styles.cardBackPattern}>
+                      <span className={styles.backLabel}>A</span>
+                    </div>
                   </div>
-                )}
+
+                  {/* Front face (revealed after flip) */}
+                  <div
+                    className={`${styles.revealCardFront} card ${cardTypeCss(currentCard)}-card attr-${currentCard.attribute ? ATTR_CSS[currentCard.attribute] || 'spell' : 'spell'}`}
+                    style={{ '--rarity-color': rarColor } as React.CSSProperties}
+                  >
+                    <div className={styles.revealRarityBar} style={{ background: rarColor }} />
+                    {!ownedBefore.has(currentCard.id) && (
+                      <div className={styles.newBadge}>{t('pack_opening.new_badge')}</div>
+                    )}
+                    <div className="card-header">
+                      <span className="card-name">{currentCard.name}</span>
+                      <span className="card-level">
+                        {currentCard.level ? '★'.repeat(Math.min(currentCard.level, 5)) : ''}
+                      </span>
+                    </div>
+                    <div className="card-body">
+                      <div className="card-type-line">{getTypeLabel(currentCard, t)}</div>
+                      <div className="card-desc">{currentCard.description || ''}</div>
+                    </div>
+                    {currentCard.atk !== undefined && (
+                      <div className="card-footer">
+                        <span>ATK {currentCard.atk}</span>
+                        <span>DEF {currentCard.def}</span>
+                      </div>
+                    )}
+                  </div>
+                </div>
               </div>
             )}
           </div>
@@ -305,13 +493,14 @@ export default function PackOpeningScreen() {
           <div className={styles.miniStrip}>
             {sortedCards.slice(0, revealIndex).map((card, i) => {
               const rc = getRarityById((card as any).rarity)?.color ?? '#aaa';
+              const icon = TYPE_ICONS[card.type] ?? '?';
               return (
                 <div
                   key={i}
                   className={styles.miniCard}
                   style={{ '--rarity-color': rc, borderColor: rc } as React.CSSProperties}
                 >
-                  <span>{card.name?.charAt(0) ?? '?'}</span>
+                  <span className={styles.miniCardIcon}>{icon}</span>
                 </div>
               );
             })}
@@ -338,7 +527,7 @@ export default function PackOpeningScreen() {
               <div
                 key={i}
                 className={styles.cardWrapper}
-                style={{ animationDelay: `${i * 0.08}s` }}
+                style={{ animationDelay: `${i * 0.12}s` }}
               >
                 {isNew && <div className={styles.newBadge}>{t('pack_opening.new_badge')}</div>}
                 <Card card={card} />

--- a/locales/de.json
+++ b/locales/de.json
@@ -114,7 +114,8 @@
     "type_spell": "Zauber",
     "type_trap": "Falle",
     "type_equipment": "Ausrüstung",
-    "skip_hint": "Tippen zum Überspringen"
+    "skip_hint": "Tippen zum Überspringen",
+    "tap_hint": "Tippen zum Öffnen!"
   },
   "collection": {
     "title": "📚 MEINE SAMMLUNG",

--- a/locales/en.json
+++ b/locales/en.json
@@ -114,7 +114,8 @@
     "type_spell": "Spell",
     "type_trap": "Trap",
     "type_equipment": "Equipment",
-    "skip_hint": "Tap to skip"
+    "skip_hint": "Tap to skip",
+    "tap_hint": "Tap to open!"
   },
   "collection": {
     "title": "📚 MY COLLECTION",


### PR DESCRIPTION
- Add tap-to-open interaction: 3 taps with escalating wobble intensity
- Add card flip reveal: cards arrive face-down and flip with 3D rotation
- Add rarity-based background FX: blue glow (Rare), golden rays (SR), rainbow rays (UR)
- Enhance sparkle system: silver particles (Rare), gold + beams (SR), rainbow + large burst (UR)
- Add screen shake on SR/UR reveals
- Improve mini strip with card type icons
- Increase summary stagger delay for smoother entrance

https://claude.ai/code/session_01MpboMhdLqAwT4NFgSzan8J