### PR TITLE
Use optional chaining for dialogue length checks

### DIFF
--- a/src/campaign-duel-result.ts
+++ b/src/campaign-duel-result.ts
@@ -87,7 +87,7 @@ export function computeCampaignDuelNav(
     ops.recordDuelResult(opponentId, result === 'victory');
   }
 
-  if (result === 'victory' && pending.postDialogue && pending.postDialogue.dialogue.length > 0) {
+  if (result === 'victory' && pending.postDialogue && pending.postDialogue.dialogue?.length > 0) {
     return {
       screen: 'duel-result',
       data: resultData('victory', {
@@ -115,7 +115,7 @@ export function computeCampaignDuelNav(
     };
   }
 
-  if (isComplete && pending.postDialogue && pending.postDialogue.dialogue.length > 0) {
+  if (isComplete && pending.postDialogue && pending.postDialogue.dialogue?.length > 0) {
     return {
       screen: 'dialogue',
       data: {

--- a/src/react/contexts/GameContext.tsx
+++ b/src/react/contexts/GameContext.tsx
@@ -251,7 +251,7 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
 
               refreshRef.current();
               refreshCampaignRef.current();
-              if (pending.postDialogue && pending.postDialogue.dialogue.length > 0) {
+              if (pending.postDialogue && pending.postDialogue.dialogue?.length > 0) {
                 navigateToRef.current('duel-result', resultData('victory', {
                   rewards: adjustedRewards,
                   badges,

--- a/src/react/screens/CampaignScreen.tsx
+++ b/src/react/screens/CampaignScreen.tsx
@@ -185,7 +185,7 @@ export default function CampaignScreen() {
             rewardConfig: node.rewardConfig,
             postDialogue: node.postDialogue ?? null,
           });
-          if (node.preDialogue && node.preDialogue.dialogue.length > 0) {
+          if (node.preDialogue && node.preDialogue.dialogue?.length > 0) {
             navigateTo('dialogue', {
               scene: node.preDialogue,
               nextScreen: 'game',


### PR DESCRIPTION
## Summary
Updated dialogue length checks throughout the codebase to use optional chaining (`?.`) operator instead of direct property access, improving null safety and reducing potential runtime errors.

## Key Changes
- **src/campaign-duel-result.ts**: Updated 2 instances of `pending.postDialogue.dialogue.length` to use optional chaining (`pending.postDialogue.dialogue?.length`)
- **src/react/contexts/GameContext.tsx**: Updated 1 instance of `pending.postDialogue.dialogue.length` to use optional chaining
- **src/react/screens/CampaignScreen.tsx**: Updated 1 instance of `node.preDialogue.dialogue.length` to use optional chaining

## Implementation Details
These changes replace direct property access with the optional chaining operator (`?.`), which safely accesses the `length` property and returns `undefined` if the `dialogue` property is nullish. This is a defensive programming improvement that prevents potential "Cannot read property 'length' of undefined" errors while maintaining the same logical behavior in conditional checks.

https://claude.ai/code/session_015G1tgcTWUs8XHDi2GKbAiN