### PR TITLE
fix(ui): deckbuilder title overlap and missing race display

### DIFF
--- a/src/react/screens/DeckbuilderScreen.module.css
+++ b/src/react/screens/DeckbuilderScreen.module.css
@@ -16,29 +16,25 @@
 .titleRow {
   display: flex; align-items: center;
   padding: 8px 12px;
-  position: relative;
 }
 
 .backBtn {
   font-size: 0.8rem;
   padding: 6px 12px;
   flex-shrink: 0;
-  z-index: 1;
 }
 
 .title {
-  position: absolute; left: 0; right: 0;
+  flex: 1; min-width: 0;
   text-align: center;
   font-size: 1.125rem; font-weight: bold;
   color: var(--gold-light); letter-spacing: 3px;
   text-transform: uppercase;
-  pointer-events: none;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
 
 .saveBtn {
-  margin-left: auto;
   flex-shrink: 0;
-  z-index: 1;
 }
 
 .tabRow {

--- a/src/type-metadata.ts
+++ b/src/type-metadata.ts
@@ -84,10 +84,10 @@ export interface TypeMetaData {
 }
 
 export function applyTypeMeta(data: TypeMetaData): void {
-  if (data.races)      TYPE_META.races      = data.races;
-  if (data.attributes) TYPE_META.attributes = data.attributes;
-  if (data.rarities)   TYPE_META.rarities   = data.rarities;
-  if (data.cardTypes)  TYPE_META.cardTypes  = data.cardTypes;
+  if (data.races)      TYPE_META.races      = data.races.map(r => r.value ? r : { ...r, value: r.key });
+  if (data.attributes) TYPE_META.attributes = data.attributes.map(a => a.value ? a : { ...a, value: a.key });
+  if (data.rarities)   TYPE_META.rarities   = data.rarities.map(r => r.value ? r : { ...r, value: r.key });
+  if (data.cardTypes)  TYPE_META.cardTypes  = data.cardTypes.map(c => c.value ? c : { ...c, value: c.key });
   rebuildIndices();
 }
 


### PR DESCRIPTION
Title: replace absolute positioning with flexbox so the title no longer
overlaps the Back/Save buttons on narrow screens.

Races: fall back to the metadata `key` when `value` is not set, so races
still display even when the locale translation keys don't match the
metadata keys (e.g. races.json uses "Water" but locale has "Aqua").

https://claude.ai/code/session_01J42WkTEidrxXHimUVWiTC2