### PR TITLE
feat(gameplay): Add OneMove rule, remove End Phase, improve spell/trap handling

### DIFF
--- a/src/ai-orchestrator.ts
+++ b/src/ai-orchestrator.ts
@@ -163,10 +163,7 @@ export async function aiTurn(deps?: AIDependencies, config?: AIOrchestratorConfi
     if (await aiBattlePhase(deps)) return;
   }
 
-  EchoesOfSanguo.log('PHASE', 'End Phase – AI cleanup.');
-  state.phase = 'end';
-  deps.render(state);
-  await deps.delay(300);
+  EchoesOfSanguo.log('PHASE', 'End of AI turn – cleanup.');
 
   deps.resetMonsterFlags('opponent');
   deps.returnTempStolenMonsters('opponent');
@@ -177,6 +174,7 @@ export async function aiTurn(deps?: AIDependencies, config?: AIOrchestratorConfi
   state.activePlayer = 'player';
   state.phase = 'main';
   state.turn++;
+  state.oneMoveActionUsed = false;
   deps.addLog(`=== Round ${state.turn} - Your turn! ===`);
 
   EchoesOfSanguo.groupEnd();

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -131,6 +131,7 @@ export class GameEngine {
       },
       log: [],
       firstTurnNoAttack: true,
+      oneMoveActionUsed: false,
     } as GameState;
     this.drawCard('player',   5);
     this.drawCard('opponent', 5);
@@ -414,6 +415,7 @@ export class GameEngine {
       await this._checkAnySummonTraps(owner, zone);
     }
     this.ui.render(this.state);
+    if (owner === this.state.activePlayer) this._triggerOneMoveAdvance();
     return true;
   }
 
@@ -500,6 +502,7 @@ export class GameEngine {
     this.addLog(`${ownerLabel(owner)}: Card placed face-down.`);
     this.ui.playSfx?.('sfx_card_play');
     this.ui.render(this.state);
+    if (owner === this.state.activePlayer) this._triggerOneMoveAdvance();
     return true;
   }
 
@@ -555,6 +558,7 @@ export class GameEngine {
     }
     st.graveyard.push(card);
     this.ui.render(this.state);
+    if (owner === this.state.activePlayer) this._triggerOneMoveAdvance();
     return true;
   }
 
@@ -586,6 +590,7 @@ export class GameEngine {
     st.graveyard.push(fst.card);
     st.field.spellTraps[zone] = null;
     this.ui.render(this.state);
+    if (owner === this.state.activePlayer) this._triggerOneMoveAdvance();
     return true;
   }
 
@@ -627,6 +632,7 @@ export class GameEngine {
     st.graveyard.push(fst.card);
     st.field.spellTraps[zone] = null;
     this.ui.render(this.state);
+    if (owner === this.state.activePlayer) this._triggerOneMoveAdvance();
     return result;
   }
 
@@ -672,6 +678,7 @@ export class GameEngine {
     }
 
     this.ui.render(this.state);
+    if (owner === this.state.activePlayer) this._triggerOneMoveAdvance();
     return true;
   }
 
@@ -851,6 +858,7 @@ export class GameEngine {
     this.ui.render(this.state);
     await this._triggerEffect(fc, owner, 'onSummon', zone);
     TriggerBus.emit('onSummon', { engine: this, owner, card: fc.card, fieldCard: fc, zone });
+    if (owner === this.state.activePlayer) this._triggerOneMoveAdvance();
     return true;
   }
 
@@ -925,6 +933,7 @@ export class GameEngine {
     this.ui.render(this.state);
     await this._triggerEffect(fc, owner, 'onSummon', zone);
     TriggerBus.emit('onSummon', { engine: this, owner, card: fc.card, fieldCard: fc, zone });
+    if (owner === this.state.activePlayer) this._triggerOneMoveAdvance();
     return true;
   }
 
@@ -958,6 +967,7 @@ export class GameEngine {
     this.ui.render(this.state);
     await this._triggerEffect(fc, owner, 'onSummon', fieldZone);
     TriggerBus.emit('onSummon', { engine: this, owner, card: fc.card, fieldCard: fc, zone: fieldZone });
+    if (owner === this.state.activePlayer) this._triggerOneMoveAdvance();
     return true;
   }
 
@@ -1361,21 +1371,56 @@ export class GameEngine {
     return null;
   }
 
+  _hasPlayableCard(owner: Owner): boolean {
+    const st = this.state[owner];
+    for (const card of st.hand) {
+      if (card.type === CardType.Monster || card.type === CardType.Fusion) {
+        if (!st.normalSummonUsed && st.field.monsters.some(z => z === null)) return true;
+      }
+      if (card.type === CardType.Spell) return true;
+      if (card.type === CardType.Trap) return true;
+      if (card.type === CardType.Equipment) return true;
+    }
+    for (const fst of st.field.spellTraps) {
+      if (fst && fst.faceDown && (fst.card.type === CardType.Spell || fst.card.type === CardType.Trap)) return true;
+    }
+    return false;
+  }
+
+  _triggerOneMoveAdvance(): void {
+    if (!GAME_RULES.oneMoveEnabled) return;
+    if (this.state.oneMoveActionUsed) return;
+    this.state.oneMoveActionUsed = true;
+    this.advancePhase();
+  }
+
   advancePhase(){
-    const phases = ['main','battle','end'];
+    const phases = ['main','battle'] as Phase[];
     const idx = phases.indexOf(this.state.phase);
     if(idx < phases.length - 1){
       let nextPhase = phases[idx+1] as Phase;
-      // First turn: skip battle phase entirely (FM-style)
       if(nextPhase === 'battle' && this.state.firstTurnNoAttack){
         this.state.firstTurnNoAttack = false;
-        nextPhase = 'end';
+        this.endTurn();
+        return;
+      }
+      if(nextPhase === 'battle' && GAME_RULES.oneMoveEnabled && !this.state.oneMoveActionUsed && !this._hasPlayableCard(this.state.activePlayer)){
+        this.state.oneMoveActionUsed = true;
       }
       this.state.phase = nextPhase;
-      const names: Partial<Record<Phase, string>> = { main:'Main Phase', battle:'Battle Phase', end:'End Phase' };
+      const names: Partial<Record<Phase, string>> = { main:'Main Phase', battle:'Battle Phase' };
       this.addLog(`--- ${names[this.state.phase] ?? this.state.phase} ---`);
       this.ui.render(this.state);
     } else {
+      this._resetMonsterFlags(this.state.activePlayer);
+      this._returnTempStolenMonsters(this.state.activePlayer);
+      this._returnSpiritMonsters(this.state.activePlayer);
+      this._tickTurnCounters(this.state.activePlayer);
+      this.state[this.state.activePlayer].normalSummonUsed = false;
+      const opp = this.state.activePlayer === 'player' ? 'opponent' : 'player';
+      this.state[opp].normalSummonUsed = false;
+      const hand = this.state[this.state.activePlayer].hand;
+      while(hand.length > GAME_RULES.handLimitEnd){ hand.shift(); }
       this.endTurn();
     }
   }
@@ -1454,8 +1499,6 @@ export class GameEngine {
   }
 
   endTurn(){
-    // Clear only the current player's per-turn flags.
-    // The opponent's flags are cleared by _aiTurn at the end of the AI's turn.
     this._resetMonsterFlags('player');
     this._returnTempStolenMonsters('player');
     this._returnSpiritMonsters('player');
@@ -1481,6 +1524,7 @@ export class GameEngine {
         this.state.activePlayer = 'player';
         this.state.phase = 'main';
         this.state.turn++;
+        this.state.oneMoveActionUsed = false;
         this.addLog(`[ERROR] Opponent AI crashed. Your turn (Round ${this.state.turn}).`);
         this.refillHand('player');
         this.ui.render(this.state);

--- a/src/react/modals/CardDetailModal.tsx
+++ b/src/react/modals/CardDetailModal.tsx
@@ -90,8 +90,17 @@ export function CardDetailModal({ modal }: Props) {
           closeModal();
         }));
     } else if (isSp && phase === 'main') {
+      actions.push(actionBtn(t('card_action.activate'), () => {
+        game.activateSpell('player', index);
+        closeModal();
+      }));
       actions.push(actionBtn(t('card_action.set_spell'), () => {
         setSel({ mode: 'place-spell', placeHandIndex: index, hint: t('card_action.hint_choose_spell_zone') });
+        closeModal();
+      }));
+    } else if (isSp && phase === 'battle' && source === 'field-spell') {
+      actions.push(actionBtn(t('card_action.activate'), () => {
+        game.activateSpellFromField('player', index);
         closeModal();
       }));
     }

--- a/src/react/screens/game/PlayerField.tsx
+++ b/src/react/screens/game/PlayerField.tsx
@@ -48,7 +48,10 @@ export function PlayerField({ showDirect, setShowDirect }: Props) {
   function isPlayerSpellTrapInteractive(zone: number) {
     const fst = player.field.spellTraps[zone];
     if (!fst) return false;
-    return isMyTurn && phase === 'main' && fst.faceDown && fst.card.type === CardType.Spell;
+    if (!isMyTurn) return false;
+    if (phase === 'main' && fst.faceDown && fst.card.type === CardType.Spell) return true;
+    if (phase === 'battle' && fst.faceDown) return true;
+    return false;
   }
 
   function isPlayerMonsterViewable(zone: number) {
@@ -171,8 +174,11 @@ export function PlayerField({ showDirect, setShowDirect }: Props) {
 
   const onFieldSpellTrapClick = useCallback((zone: number, fst: FieldSpellTrap) => {
     const game = gameRef.current;
-    if (!game || !isMyTurn || phase !== 'main' || !fst.faceDown) return;
-    if (fst.card.type === CardType.Spell) {
+    if (!game || !isMyTurn || !fst.faceDown) return;
+    if (phase === 'main' && fst.card.type === CardType.Spell) {
+      openModal({ type: 'card-detail', card: fst.card, index: zone, state: gameState, source: 'field-spell' });
+    }
+    if (phase === 'battle') {
       openModal({ type: 'card-detail', card: fst.card, index: zone, state: gameState, source: 'field-spell' });
     }
   }, [gameRef, isMyTurn, phase, openModal, gameState]);

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -18,6 +18,7 @@ export const GAME_RULES = {
   craftingEnabled: false,
   craftingCurrency: undefined as string | undefined,
   craftingCost: 0,
+  oneMoveEnabled: false,
 };
 
 export type GameRules = typeof GAME_RULES;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 export type Owner        = 'player' | 'opponent';
-export type Phase        = 'draw' | 'main' | 'battle' | 'end';
+export type Phase        = 'draw' | 'main' | 'battle';
 export type Position     = 'atk' | 'def';
 export type TrapTrigger  = 'onAttack' | 'onOwnMonsterAttacked' | 'onOpponentSummon' | 'manual' | 'onOpponentSpell' | 'onAnySummon' | 'onOpponentTrap' | 'onOppCardEffect' | 'onOpponentDraw';
 export type EffectTrigger= 'onSummon' | 'onDestroyByBattle' | 'onDestroyByOpponent' | 'passive' | 'onFlipSummon' | 'onFlip' | 'onDealBattleDamage' | 'onSentToGrave';
@@ -344,6 +344,7 @@ export interface GameState {
   log:          string[];
   firstTurnNoAttack?: boolean;
   skipNextDraw?: Owner;
+  oneMoveActionUsed?: boolean;
 }
 
 export interface DuelStats {

--- a/tests/engine.core.test.js
+++ b/tests/engine.core.test.js
@@ -384,19 +384,22 @@ describe('advancePhase', () => {
     expect(engine.state.phase).toBe('battle');
   });
 
-  it('battle → end', () => {
+  it('battle → endTurn (opponent draw phase)', () => {
     const { engine } = makeEngine();
     engine.state.phase = 'battle';
+    vi.useFakeTimers();
     engine.advancePhase();
-    expect(engine.state.phase).toBe('end');
+    expect(engine.state.activePlayer).toBe('opponent');
+    expect(engine.state.phase).toBe('draw');
+    vi.useRealTimers();
   });
 
-  it('end phase calls endTurn (turn increments)', () => {
+  it('advancePhase from battle increments turn', () => {
     const { engine } = makeEngine();
-    engine.state.phase = 'end';
+    engine.state.phase = 'battle';
     const turnBefore = engine.state.turn;
     vi.useFakeTimers();
-    engine.advancePhase();     // calls endTurn internally
+    engine.advancePhase();
     expect(engine.state.turn).toBe(turnBefore + 1);
     vi.useRealTimers();
   });

--- a/tests/engine.lifecycle.test.js
+++ b/tests/engine.lifecycle.test.js
@@ -327,20 +327,26 @@ describe('advancePhase', () => {
     expect(engine.state.phase).toBe('battle');
   });
 
-  it('advances from battle to end', () => {
+  it('advances from battle to endTurn (opponent draw phase)', () => {
     const { engine } = makeEngine();
     engine.state.phase = 'battle';
+    vi.useFakeTimers();
     engine.advancePhase();
-    expect(engine.state.phase).toBe('end');
+    expect(engine.state.activePlayer).toBe('opponent');
+    expect(engine.state.phase).toBe('draw');
+    vi.useRealTimers();
   });
 
   it('skips battle phase on first turn (FM-style)', () => {
     const { engine } = makeEngine();
     engine.state.phase = 'main';
     engine.state.firstTurnNoAttack = true;
+    vi.useFakeTimers();
     engine.advancePhase();
-    expect(engine.state.phase).toBe('end');
+    expect(engine.state.activePlayer).toBe('opponent');
+    expect(engine.state.phase).toBe('draw');
     expect(engine.state.firstTurnNoAttack).toBe(false);
+    vi.useRealTimers();
   });
 });
 


### PR DESCRIPTION
## Summary

- **OneMove Game Rule**: New optional rule (`oneMoveEnabled: false` by default). When enabled, any action (summon, fusion, spell activation, trap activation, equipment) automatically advances to Battle Phase
- **Remove End Phase**: Phase type simplified to `'draw' | 'main' | 'battle'`. Cleanup logic moved to end of Battle Phase
- **Spells from hand**: Spells can now be activated directly from hand in Main Phase (not just set)
- **Battle Phase spell/trap interaction**: Face-down spells/traps are now clickable during Battle Phase for activation

## Changes

| File | Change |
|------|--------|
| `src/rules.ts` | Added `oneMoveEnabled: false` |
| `src/types.ts` | Removed 'end' from Phase type, added `oneMoveActionUsed` state |
| `src/engine.ts` | Added `_hasPlayableCard()`, `_triggerOneMoveAdvance()`, updated phase logic |
| `src/ai-orchestrator.ts` | Removed End Phase handling |
| `src/react/modals/CardDetailModal.tsx` | Added spell activation from hand, spell activation in Battle Phase |
| `src/react/screens/game/PlayerField.tsx` | Made spells/traps clickable in Battle Phase |

## Test Plan

- All engine tests (334 tests) pass
- Phase transition tests updated for new phase flow