### PR TITLE
fix: add YAML frontmatter to engine-state-reference agent file

### DIFF
--- a/.claude/agents/engine-state-reference.md
+++ b/.claude/agents/engine-state-reference.md
@@ -1,3 +1,17 @@
+---
+name: engine-state-reference
+description: >
+  Read-only reference for engine state management in src/engine/.
+  Provides documentation on GameState, PlayerState, FieldCard, and FieldSpellTrap
+  structures. Use for understanding state mutations, turn flow, and serialization.
+  Does not execute code — read-only consultation on engine architecture.
+tools:
+  - Read
+  - Grep
+  - Glob
+model: sonnet
+---
+
 # src/engine/ State Management
 
 Dieses Verzeichnis enthält die Engine-Schicht des Spiels. Die Engine ist reines TypeScript ohne React-Abhängigkeiten und verwaltet den kompletten Spielzustand.


### PR DESCRIPTION
Fixes deployment error - agent file was missing required YAML frontmatter.

## Changes
- Added YAML frontmatter to `.claude/agents/engine-state-reference.md` with:
  - name: engine-state-reference
  - description: Read-only reference for engine state management
  - tools: Read, Grep, Glob
  - model: sonnet

## Validation
```
agnix validate
# Found 0 errors, 9 warnings
```

Deployment should now succeed.