### PR TITLE
feat(security): add Content-Security-Policy headers (#475)

### DIFF
--- a/.github/nginx-sanguo.conf
+++ b/.github/nginx-sanguo.conf
@@ -10,6 +10,7 @@ server {
     index index.html;
     
     # Security headers
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "DENY" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,12 +19,42 @@ Report security vulnerabilities by opening an issue on GitHub or contacting the 
 
 The application implements the following security headers to protect against common web vulnerabilities:
 
+### Content-Security-Policy (CSP)
+
+Content-Security-Policy is implemented in three layers for defense-in-depth:
+
+1. **Meta tag in `index.html`** — Applied for static file serving
+2. **Vite dev/preview server headers** — Applied during development and local preview
+3. **nginx production headers** — Applied in production deployments
+
+**Policy:**
+```
+default-src 'self'
+script-src 'self'
+style-src 'self' 'unsafe-inline'
+img-src 'self' data: blob:
+font-src 'self'
+connect-src 'self'
+frame-ancestors 'none'
+base-uri 'self'
+form-action 'self'
+```
+
+**Rationale:**
+- `'self'` for scripts, styles, and fonts ensures only same-origin resources load
+- `'unsafe-inline'` for styles required due to inline loading screen styles in index.html
+- `data:` and `blob:` for images needed for canvas operations and dynamic image generation
+- `frame-ancestors 'none'` prevents clickjacking (alternative to X-Frame-Options)
+- `base-uri 'self'` prevents base tag injection attacks
+- `form-action 'self'` prevents form data exfiltration
+
 ### Production Headers (Hetzner Deployment)
 
 The nginx server at `nightbeak.dev` is configured with:
 
 | Header | Value | Purpose |
 |--------|-------|---------|
+| `Content-Security-Policy` | (see above) | Prevents XSS and injection attacks |
 | `X-Content-Type-Options` | `nosniff` | Prevents MIME-type sniffing attacks |
 | `X-Frame-Options` | `DENY` | Prevents clickjacking attacks |
 | `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` | Enforces HTTPS |
@@ -38,6 +68,7 @@ The Vite dev server (`npm run dev`) sets these headers in `vite.config.js`:
 
 | Header | Value |
 |--------|-------|
+| `Content-Security-Policy` | (see above) |
 | `X-Content-Type-Options` | `nosniff` |
 | `X-Frame-Options` | `DENY` |
 | `Strict-Transport-Security` | `max-age=86400; includeSubDomains` |
@@ -46,13 +77,13 @@ For local preview builds (`npm run preview`), the same headers apply.
 
 ### GitHub Pages Deployment
 
-**Important:** GitHub Pages does NOT automatically set `X-Content-Type-Options` or most security headers. The deployment to GitHub Pages (`.github/workflows/deploy.yml`) relies on GitHub's default headers, which include:
+**Important:** GitHub Pages does NOT automatically set most security headers. The deployment to GitHub Pages (`.github/workflows/deploy.yml`) relies on GitHub's default headers, which include:
 
 - ✅ Automatic HTTPS
 - ✅ HSTS (for custom domains with HTTPS enforcement enabled)
+- ✅ CSP via meta tag in `index.html`
 - ❌ No X-Content-Type-Options
 - ❌ No X-Frame-Options
-- ❌ No Content-Security-Policy
 
 For production use, deploy to a server where you can configure headers (e.g., nginx, Apache, Cloudflare Workers).
 

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="theme-color" content="#060e0a">
   <meta name="description" content="Echoes of Sanguo — A browser-based TCG inspired by classic card battlers, set in the Three Kingdoms era.">

--- a/vite.config.js
+++ b/vite.config.js
@@ -66,6 +66,7 @@ export default defineConfig({
   },
   server: {
     headers: {
+      'Content-Security-Policy': "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';",
       'X-Content-Type-Options': 'nosniff',
       'X-Frame-Options': 'DENY',
       'Strict-Transport-Security': 'max-age=86400; includeSubDomains',
@@ -73,6 +74,7 @@ export default defineConfig({
   },
   preview: {
     headers: {
+      'Content-Security-Policy': "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';",
       'X-Content-Type-Options': 'nosniff',
       'X-Frame-Options': 'DENY',
       'Strict-Transport-Security': 'max-age=86400; includeSubDomains',


### PR DESCRIPTION
## Summary

Implements Content-Security-Policy (CSP) headers across all environments to protect against XSS attacks.

## Changes

- **index.html**: Added CSP meta tag for static file serving
- **vite.config.js**: Added CSP header to both dev and preview server configurations  
- **.github/nginx-sanguo.conf**: Added CSP header to nginx production configuration
- **SECURITY.md**: Updated documentation to describe CSP implementation and policy

## CSP Policy

```
default-src 'self'
script-src 'self'
style-src 'self' 'unsafe-inline'
img-src 'self' data: blob:
font-src 'self'
connect-src 'self'
frame-ancestors 'none'
base-uri 'self'
form-action 'self'
```

## Rationale

- `'self'` for scripts, styles, and fonts restricts loading to same-origin only
- `'unsafe-inline'` for styles required for inline loading screen styles in index.html
- `data:` and `blob:` for images needed for canvas operations
- `frame-ancestors 'none'` prevents clickjacking  
- `base-uri 'self'` prevents base tag injection attacks
- `form-action 'self'` prevents form data exfiltration

## Testing

- Build completes successfully
- No CSP violations in browser console
- All existing functionality preserved

## Related Issues

Closes #475
