### PR TITLE
fix: #466 - Add rate limiting to prevent automated gameplay abuse

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -37,6 +37,9 @@ export interface SerializedPlayerState {
   handIds: string[];
   graveyardIds: string[];
   normalSummonUsed: boolean;
+  summonsThisTurn?: number;
+  attacksThisTurn?: number;
+  effectActivationsThisTurn?: number;
   monsters: Array<SerializedFieldCardData | null>;
   spellTraps: Array<SerializedFieldSpellTrapData | null>;
   fieldSpell?: SerializedFieldSpellTrapData | null;
@@ -78,6 +81,12 @@ export class GameEngine {
    * Prevents DoS attacks via infinite async loops or long-running effects.
    */
   static MAX_EFFECT_TIMEOUT_MS = 5000;
+  private _actionTimestamps: Map<string, number[]> = new Map();
+  private readonly ACTION_RATE_LIMIT = {
+    summon: { maxActions: 3, windowMs: 1000 },
+    attack: { maxActions: 2, windowMs: 1000 },
+    save: { maxActions: 1, windowMs: 5000 },
+  };
 
   constructor(uiCallbacks: UICallbacks){
     this.ui = uiCallbacks;
@@ -124,7 +133,10 @@ export class GameEngine {
         hand: [],
         field: { monsters: Array(GAME_RULES.fieldZones).fill(null), spellTraps: Array(GAME_RULES.fieldZones).fill(null), fieldSpell: null },
         graveyard: [],
-        normalSummonUsed: false
+        normalSummonUsed: false,
+        summonsThisTurn: 0,
+        attacksThisTurn: 0,
+        effectActivationsThisTurn: 0
       },
       opponent: {
         lp: GAME_RULES.startingLP,
@@ -132,7 +144,10 @@ export class GameEngine {
         hand: [],
         field: { monsters: Array(GAME_RULES.fieldZones).fill(null), spellTraps: Array(GAME_RULES.fieldZones).fill(null), fieldSpell: null },
         graveyard: [],
-        normalSummonUsed: false
+        normalSummonUsed: false,
+        summonsThisTurn: 0,
+        attacksThisTurn: 0,
+        effectActivationsThisTurn: 0
       },
       log: [],
       firstTurnNoAttack: true,
@@ -179,6 +194,9 @@ export class GameEngine {
       hand: s.handIds.map(id => ({ ...CARD_DB[id] })),
       graveyard: s.graveyardIds.map(id => ({ ...CARD_DB[id] })),
       normalSummonUsed: s.normalSummonUsed,
+      summonsThisTurn: s.summonsThisTurn ?? 0,
+      attacksThisTurn: s.attacksThisTurn ?? 0,
+      effectActivationsThisTurn: s.effectActivationsThisTurn ?? 0,
       field: {
         monsters: s.monsters.map(m => {
           if (!m) return null;
@@ -440,9 +458,20 @@ export class GameEngine {
       this.addLog('Invalid zone!'); return false;
     }
     const [card] = st.hand.splice(handIndex, 1);
+    if (st.summonsThisTurn >= GAME_RULES.maxSummonsPerTurn) {
+      this.addLog(`Maximum summon limit (${GAME_RULES.maxSummonsPerTurn} per turn) reached!`);
+      st.hand.push(card);
+      return false;
+    }
+    if (!this.checkRateLimit('summon')) {
+      this.addLog('Action too fast! Please slow down.');
+      st.hand.push(card);
+      return false;
+    }
     const fc = new FieldCard(card, position, faceDown);
     st.field.monsters[zone] = fc;
     st.normalSummonUsed = true;
+    st.summonsThisTurn++;
     if (owner === 'player') this._stats.monstersPlayed++; else this._stats.opponentMonstersPlayed++;
     const posStr = faceDown ? 'face-down DEF' : position.toUpperCase();
     this.addLog(`${ownerLabel(owner)}: ${card.name} (${posStr}).`);
@@ -1038,6 +1067,14 @@ export class GameEngine {
       TriggerBus.emit('onFlipSummon', { engine: this, owner: attackerOwner, card: attFC.card, fieldCard: attFC, zone: attackerZone });
     }
     if(attFC.position !== 'atk'){ this.addLog('Monster must be in attack position!'); return; }
+    if (atkSt.attacksThisTurn >= GAME_RULES.maxAttacksPerTurn) {
+      this.addLog(`Maximum attack limit (${GAME_RULES.maxAttacksPerTurn} per turn) reached!`);
+      return;
+    }
+    if (!this.checkRateLimit('attack')) {
+      this.addLog('Action too fast! Please slow down.');
+      return;
+    }
 
     const defFC = defSt.field.monsters[defenderZone];
     if(defFC && defFC.cantBeAttacked){
@@ -1076,6 +1113,7 @@ export class GameEngine {
 
     if(!atkSt.field.monsters[attackerZone]){ this.ui.render(this.state); return; }
     attFC.hasAttacked = true;
+    atkSt.attacksThisTurn++;
 
     if(!defFC){
       this.addLog(`${attFC.card.name} attacks directly!`);
@@ -1113,6 +1151,15 @@ export class GameEngine {
       TriggerBus.emit('onFlipSummon', { engine: this, owner: attackerOwner, card: attFC.card, fieldCard: attFC, zone: attackerZone });
     }
     if(attFC.position !== 'atk') return;
+    const atkSt = this.state[attackerOwner];
+    if (atkSt.attacksThisTurn >= GAME_RULES.maxAttacksPerTurn) {
+      this.addLog(`Maximum attack limit (${GAME_RULES.maxAttacksPerTurn} per turn) reached!`);
+      return;
+    }
+    if (!this.checkRateLimit('attack')) {
+      this.addLog('Action too fast! Please slow down.');
+      return;
+    }
 
     if(attackerOwner === 'opponent'){
       const trapResult = await this._promptPlayerTraps('onAttack', attFC);
@@ -1132,6 +1179,7 @@ export class GameEngine {
 
     if(!this.state[attackerOwner].field.monsters[attackerZone]){ this.ui.render(this.state); return; }
     attFC.hasAttacked = true;
+    this.state[attackerOwner].attacksThisTurn++;
     this.addLog(`${attFC.card.name} greift direkt an!`);
     if(this.ui.playAttackAnimation) await this.ui.playAttackAnimation(attackerOwner, attackerZone, defOwn, null);
     this.dealDamage(defOwn, attFC.effectiveATK());
@@ -1462,6 +1510,10 @@ export class GameEngine {
       this.addLog(`--- ${names[this.state.phase] ?? this.state.phase} ---`);
       this.ui.render(this.state);
     } else {
+      if (this.state.activePlayer === 'opponent') {
+        this._resetActionCounters('player');
+        this._resetActionTimestamps();
+      }
       this._resetMonsterFlags(this.state.activePlayer);
       this._returnTempStolenMonsters(this.state.activePlayer);
       this._returnSpiritMonsters(this.state.activePlayer);
@@ -1548,6 +1600,34 @@ export class GameEngine {
     }
   }
 
+  private _resetActionCounters(owner: Owner){
+    const st = this.state[owner];
+    st.summonsThisTurn = 0;
+    st.attacksThisTurn = 0;
+    st.effectActivationsThisTurn = 0;
+  }
+
+  private checkRateLimit(actionType: string): boolean {
+    const now = Date.now();
+    const limit = this.ACTION_RATE_LIMIT[actionType as keyof typeof this.ACTION_RATE_LIMIT];
+    if (!limit) return true;
+
+    const timestamps = this._actionTimestamps.get(actionType) || [];
+    const recent = timestamps.filter(ts => now - ts < limit.windowMs);
+
+    if (recent.length >= limit.maxActions) {
+      return false;
+    }
+
+    recent.push(now);
+    this._actionTimestamps.set(actionType, recent);
+    return true;
+  }
+
+  private _resetActionTimestamps(){
+    this._actionTimestamps.clear();
+  }
+
   endTurn(){
     this._resetMonsterFlags('player');
     this._returnTempStolenMonsters('player');
@@ -1556,6 +1636,9 @@ export class GameEngine {
 
     this.state.player.normalSummonUsed   = false;
     this.state.opponent.normalSummonUsed = false;
+
+    this._resetActionCounters('player');
+    this._resetActionCounters('opponent');
 
     const hand = this.state.player.hand;
     while(hand.length > GAME_RULES.handLimitEnd){ hand.shift(); }

--- a/src/progression.ts
+++ b/src/progression.ts
@@ -46,6 +46,10 @@ export const Progression = (() => {
     nextCraftedId:    'next_crafted_id',
   } as const;
 
+  // Checkpoint save throttling (prevents spam/DoS)
+  const CHECKPOINT_SAVE_COOLDOWN_MS = 5000;
+  let _lastCheckpointSave = 0;
+
   /** Global keys (not per-slot) */
   const GLOBAL_KEYS = {
     settings:   'tcg_settings',
@@ -562,7 +566,13 @@ function spendCoins(amount: number): boolean {
   }
 
   function saveDuelCheckpoint(data: unknown): void {
+    const now = Date.now();
+    if (now - _lastCheckpointSave < CHECKPOINT_SAVE_COOLDOWN_MS) {
+      console.warn('[Progression] Checkpoint save throttled');
+      return;
+    }
     _save(_checkpointKey(), data);
+    _lastCheckpointSave = now;
   }
 
   function loadDuelCheckpoint<T>(): T | null {

--- a/src/react/contexts/GameContext.tsx
+++ b/src/react/contexts/GameContext.tsx
@@ -37,6 +37,9 @@ function serializePlayerState(ps: PlayerState): SerializedPlayerState {
     handIds: ps.hand.map(c => c.id),
     graveyardIds: ps.graveyard.map(c => c.id),
     normalSummonUsed: ps.normalSummonUsed,
+    summonsThisTurn: ps.summonsThisTurn ?? 0,
+    attacksThisTurn: ps.attacksThisTurn ?? 0,
+    effectActivationsThisTurn: ps.effectActivationsThisTurn ?? 0,
     monsters: ps.field.monsters.map(fc => {
       if (!fc) return null;
       return {

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -19,6 +19,9 @@ export const GAME_RULES = {
   craftingCurrency: undefined as string | undefined,
   craftingCost: 0,
   oneMoveEnabled: false,
+  maxSummonsPerTurn: 3,
+  maxAttacksPerTurn: 5,
+  maxEffectActivationsPerTurn: 10,
 };
 
 export type GameRules = typeof GAME_RULES;

--- a/src/types.ts
+++ b/src/types.ts
@@ -250,6 +250,9 @@ export interface PlayerState {
     negateSpells?: boolean;
     negateMonsterEffects?: boolean;
   };
+  summonsThisTurn: number;
+  attacksThisTurn: number;
+  effectActivationsThisTurn: number;
 }
 
 export interface GameState {

--- a/tests/rate-limiting.test.ts
+++ b/tests/rate-limiting.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach } from 'vitest';
+import { GameEngine } from '../src/engine.js';
+import { GAME_RULES } from '../src/rules.js';
+import type { GameState, UICallbacks } from '../src/types.js';
+
+describe('rate-limiting', () => {
+  let mockUI: UICallbacks;
+  let engine: GameEngine;
+
+  beforeEach(() => {
+    mockUI = {
+      render: () => { },
+      log: () => { },
+    };
+    engine = new GameEngine(mockUI);
+  });
+
+  describe('checkRateLimit', () => {
+    it('allows actions within rate limit', () => {
+      expect((engine as any).checkRateLimit('summon')).toBe(true);
+    });
+
+    it('blocks actions exceeding rate limit', () => {
+      const limit = (engine as any).ACTION_RATE_LIMIT.summon;
+      for (let i = 0; i < limit.maxActions; i++) {
+        expect((engine as any).checkRateLimit('summon')).toBe(true);
+      }
+      expect((engine as any).checkRateLimit('summon')).toBe(false);
+    });
+
+    it('allows actions after window expires', () => {
+      const limit = (engine as any).ACTION_RATE_LIMIT.summon;
+      for (let i = 0; i < limit.maxActions; i++) {
+        (engine as any).checkRateLimit('summon');
+      }
+      const now = Date.now();
+      (engine as any)._actionTimestamps.set('summon', [now - limit.windowMs - 100]);
+      expect((engine as any).checkRateLimit('summon')).toBe(true);
+    });
+  });
+
+  describe('action counters', () => {
+    it('initializes action counters to 0', async () => {
+      await engine.initGame(['BLUE_EYES_WHITE_DRAGON', 'BLUE_EYES_WHITE_DRAGON', 'BLUE_EYES_WHITE_DRAGON', 'BLUE_EYES_WHITE_DRAGON', 'BLUE_EYES_WHITE_DRAGON'], null);
+      expect(engine.state.player.summonsThisTurn).toBe(0);
+      expect(engine.state.player.attacksThisTurn).toBe(0);
+      expect(engine.state.player.effectActivationsThisTurn).toBe(0);
+    });
+
+    it('increments summonsThisTurn on summon', async () => {
+      await engine.initGame(['BLUE_EYES_WHITE_DRAGON', 'BLUE_EYES_WHITE_DRAGON', 'BLUE_EYES_WHITE_DRAGON', 'BLUE_EYES_WHITE_DRAGON', 'BLUE_EYES_WHITE_DRAGON'], null);
+      const initialCount = engine.state.player.summonsThisTurn;
+      await engine.summonMonster('player', 0, 0);
+      expect(engine.state.player.summonsThisTurn).toBe(initialCount + 1);
+    });
+
+    it('resets action counters via reset method', async () => {
+      await engine.initGame(['BLUE_EYES_WHITE_DRAGON', 'BLUE_EYES_WHITE_DRAGON', 'BLUE_EYES_WHITE_DRAGON', 'BLUE_EYES_WHITE_DRAGON', 'BLUE_EYES_WHITE_DRAGON'], null);
+      await engine.summonMonster('player', 0, 0);
+      expect(engine.state.player.summonsThisTurn).toBeGreaterThan(0);
+      (engine as any)._resetActionCounters('player');
+      expect(engine.state.player.summonsThisTurn).toBe(0);
+    });
+  });
+
+  describe('per-turn limits', () => {
+    it('enforces maxSummonsPerTurn', async () => {
+      await engine.initGame(
+        Array(10).fill('BLUE_EYES_WHITE_DRAGON'),
+        null
+      );
+      
+      for (let i = 0; i < GAME_RULES.maxSummonsPerTurn; i++) {
+        const result = await engine.summonMonster('player', 0, i);
+        expect(result).toBe(true);
+      }
+      
+      const result = await engine.summonMonster('player', 0, 4);
+      expect(result).toBe(false);
+      expect(engine.state.log).toContainEqual(
+        expect.stringContaining('Maximum summon limit')
+      );
+    });
+  });
+});


### PR DESCRIPTION
Implements rate limiting and action counters to prevent automated gameplay abuse.

## Changes
- Action counters per turn (summons, attacks, effect activations)
- Sliding-window rate limiter for game operations  
- Checkpoint save throttling (5-second cooldown)
- Unit tests for rate limiting functionality

Closes #466