### PR TITLE
chore: add secret file patterns to .gitignore (#469)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,35 @@
+# Echoes of Sanguo Engine - Environment Variables
+# Copy this file to .env.local and fill in actual values
+# NEVER commit .env.local or any .env file except .env.example
+
+# ==========================================
+# Vite Configuration
+# ==========================================
+# Base URL for the application (optional, defaults to '/')
+# BASE_URL=/
+
+# ==========================================
+# Playwright E2E Testing
+# ==========================================
+# CI environment flag (auto-detected in most CI systems)
+# CI=true
+
+# Playwright test browser (optional)
+# PLAYWRIGHT_BROWSERS_PATH=0
+
+# ==========================================
+# Development (Optional)
+# ==========================================
+# Dev server port (Vite default: 5173)
+# PORT=5173
+
+# Enable debug logging
+# DEBUG=true
+
+# ==========================================
+# API Keys (if integrating external services)
+# ==========================================
+# Add placeholder entries for any future API integrations
+# Example:
+# ANALYTICS_API_KEY=your_analytics_key_here
+# SENTRY_DSN=your_sentry_dsn_here

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,45 @@ list.zip
 
 # OpenCode tool config (local only, not for repo)
 .opencode/
+
+# ==========================================
+# Environment and Secrets
+# ==========================================
+.env
+.env.*
+!.env.example
+!.env.template
+.env.local
+.env.development
+.env.test
+.env.production
+*.local
+
+# ==========================================
+# Cryptographic Keys and Certificates
+# ==========================================
+*.pem
+*.key
+*.p12
+*.pfx
+*.cer
+*.crt
+*.der
+*.csr
+
+# ==========================================
+# Credential Files
+# ==========================================
+*credentials*
+*secrets*
+!*credentials.test.*
+!*secrets.test.*
+service-account*.json
+*-service-account.json
+
+# ==========================================
+# SSH Keys
+# ==========================================
+*.pub
+!.gitignore
+.ssh/


### PR DESCRIPTION
## Summary

Add comprehensive secret and credential file patterns to `.gitignore` to prevent accidental commits of sensitive data.

## Changes

### `.gitignore` - Added security patterns:

**Environment and Secrets:**
- `.env`, `.env.*`, `.env.local`, `.env.development`, `.env.test`, `.env.production`
- Explicit keep-list for `.env.example` and `.env.template`

**Cryptographic Keys and Certificates:**
- `*.pem`, `*.key`, `*.p12`, `*.pfx`, `.cer`, `.crt`, `.der`, `.csr`

**Credential Files:**
- `*credentials*`, `*secrets*` (with exclusions for test files)
- Service account JSON patterns: `service-account*.json`, `*-service-account.json`

**SSH Keys:**
- `*.pub`, `.ssh/`

### `.env.example` - New file:

Created template file with placeholder documentation to guide developers on required environment variables without exposing real secrets.

## Impact

- Prevents accidental commits of API keys, tokens, and passwords
- Blocks cryptographic key files from being committed
- Protects service account credentials and SSH keys
- Reduces risk of secret exposure per OWASP guidelines

## Testing

No functional code changes - `.gitignore` updates only. Verified:
- Patterns follow standard gitignore syntax
- `.env.example` properly excluded from ignore rules
- Existing ignore patterns preserved

Closes #469
