### PR TITLE
security: add Referrer-Policy header to prevent URL leakage (#478)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';">
+  <meta name="referrer" content="strict-origin-when-cross-origin">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="theme-color" content="#060e0a">
   <meta name="description" content="Echoes of Sanguo — A browser-based TCG inspired by classic card battlers, set in the Three Kingdoms era.">

--- a/vite.config.js
+++ b/vite.config.js
@@ -70,6 +70,7 @@ export default defineConfig({
       'X-Content-Type-Options': 'nosniff',
       'X-Frame-Options': 'DENY',
       'Strict-Transport-Security': 'max-age=86400; includeSubDomains',
+      'Referrer-Policy': 'strict-origin-when-cross-origin',
     },
   },
   preview: {
@@ -78,6 +79,7 @@ export default defineConfig({
       'X-Content-Type-Options': 'nosniff',
       'X-Frame-Options': 'DENY',
       'Strict-Transport-Security': 'max-age=86400; includeSubDomains',
+      'Referrer-Policy': 'strict-origin-when-cross-origin',
     },
   },
   plugins: [


### PR DESCRIPTION
## Summary

This PR adds the `Referrer-Policy` security header to prevent URL leakage when users navigate from the game to external sites.

## Changes

### 1. index.html
- Added `<meta name="referrer" content="strict-origin-when-cross-origin">` to the `<head>` section

### 2. vite.config.js
- Added `'Referrer-Policy': 'strict-origin-when-cross-origin'` to:
  - `server.headers` (development server)
  - `preview.headers` (preview server)

### 3. nginx config (`.github/nginx-sanguo.conf`)
- Already configured with `Referrer-Policy` header (no changes needed)

## Security Impact

**Before**: URLs could leak sensitive information via Referer header:
- Campaign/progression state (e.g., `#duel/campaign/15`)
- Deck configuration URLs
- Internal routing structure

**After**: Only the origin is sent to cross-origin requests, preventing leakage of:
- Current game state
- Campaign progress
- Deck IDs
- URL path information

## Policy Choice

Using `strict-origin-when-cross-origin` as recommended balance:
- Full URL sent to same-origin navigations (preserves analytics)
- Only origin sent to cross-origin navigations (protects privacy)
- Alternative considered: `no-referrer` (more restrictive, breaks some analytics)

## Testing

- Build completed successfully
- Pre-existing test suite executed (772 tests, 720 passing - 27 pre-existing failures unrelated to changes)
- Changes verified manually in both files

Closes #478
