### PR TITLE
security: add Permissions-Policy header (#479)

### DIFF
--- a/.github/nginx-sanguo.conf
+++ b/.github/nginx-sanguo.conf
@@ -11,6 +11,7 @@ server {
     
     # Security headers
     add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=(), fullscreen=(self)" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "DENY" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';">
+  <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=(), payment=(), usb=(), fullscreen=(self)">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="theme-color" content="#060e0a">
   <meta name="description" content="Echoes of Sanguo — A browser-based TCG inspired by classic card battlers, set in the Three Kingdoms era.">

--- a/vite.config.js
+++ b/vite.config.js
@@ -67,6 +67,7 @@ export default defineConfig({
   server: {
     headers: {
       'Content-Security-Policy': "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';",
+      'Permissions-Policy': 'camera=(), microphone=(), geolocation=(), payment=(), usb=(), fullscreen=(self)',
       'X-Content-Type-Options': 'nosniff',
       'X-Frame-Options': 'DENY',
       'Strict-Transport-Security': 'max-age=86400; includeSubDomains',
@@ -75,6 +76,7 @@ export default defineConfig({
   preview: {
     headers: {
       'Content-Security-Policy': "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';",
+      'Permissions-Policy': 'camera=(), microphone=(), geolocation=(), payment=(), usb=(), fullscreen=(self)',
       'X-Content-Type-Options': 'nosniff',
       'X-Frame-Options': 'DENY',
       'Strict-Transport-Security': 'max-age=86400; includeSubDomains',


### PR DESCRIPTION
## Summary

Adds `Permissions-Policy` HTTP header to restrict browser feature access for embedded content, addressing security issue #479.

## Changes

### 1. `index.html`
- Added meta tag in `<head>` section with Permissions-Policy directive

### 2. `vite.config.js`
- Added `Permissions-Policy` header to dev server configuration
- Added `Permissions-Policy` header to preview server configuration

### 3. `.github/nginx-sanguo.conf`
- Added `Permissions-Policy` header to nginx production configuration

## Policy Details

```
camera=(), microphone=(), geolocation=(), payment=(), usb=(), fullscreen=(self)
```

**Disabled for all origins:**
- `camera` - prevents webcam access
- `microphone` - prevents audio capture
- `geolocation` - prevents location access
- `payment` - prevents Payment API access
- `usb` - prevents USB device access

**Allowed for self origin:**
- `fullscreen` - required for game UX (game fullscreen mode)

## Impact

- **Security**: Prevents malicious embedded content (iframes) from requesting sensitive browser permissions
- **Future-proofing**: As the app adds features (e.g., webcam for AR, microphone for voice commands), they must be explicitly enabled
- **Game UX**: Fullscreen mode preserved for immersive gameplay

## Testing

- Build test not related to changes (pre-existing PWA plugin issue)
- Unit tests: 27 failures are pre-existing, unrelated to security headers
- No functional changes to game logic

## References

- [MDN: Permissions-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy)
- [OWASP: Permissions Policy](https://owasp.org/www-project-secure-headers/#permissions-policy)

Closes #479
