### PR TITLE
feat: add GitHub API authentication for TCG updates (#470)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# GitHub API Authentication (Optional)
+# Used for authenticated requests when checking for TCG updates
+# Increases rate limit from 60 to 5000 requests/hour
+#
+# To get a token: https://github.com/settings/tokens
+# Create a fine-grained token with no permissions (public repo read is automatic)
+#
+VITE_GITHUB_TOKEN=your_github_token_here

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,11 @@ package-lock.json
 dist/
 public/base.tcg
 
+# Environment variables (may contain secrets)
+.env
+.env.local
+.env.*.local
+
 # Android build outputs (keep project files, ignore generated outputs)
 android/.gradle/
 android/app/build/

--- a/README.md
+++ b/README.md
@@ -319,3 +319,26 @@ npm run cap:open         # Open Android Studio
 # cd /path/to/Echoes-of-Sanguo-TCG && npm ci && npm run build && npm link
 # cd <this-repo> && npm link @wynillo/tcg-format
 ```
+
+---
+
+## Optional GitHub API Authentication
+
+The engine checks for TCG updates from GitHub on startup. To avoid rate limiting (60 requests/hour for unauthenticated requests), you can provide a GitHub token:
+
+**1. Create `.env.local` file in project root:**
+```bash
+cp .env.example .env.local
+```
+
+**2. Add your token:**
+```env
+VITE_GITHUB_TOKEN=your_github_token_here
+```
+
+**3. Get a token:**
+- Go to https://github.com/settings/tokens
+- Create a fine-grained token with no special permissions (public repo read is automatic)
+- Authenticated requests get 5,000 requests/hour rate limit
+
+**Note:** The `VITE_` prefix is required for Vite to expose the variable to client-side code. The token is optional - the app works in unauthenticated mode if not provided.

--- a/src/tcg-update.ts
+++ b/src/tcg-update.ts
@@ -47,8 +47,16 @@ async function getLatestCommitSha(): Promise<string | null> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 5000);
   try {
+    const headers: HeadersInit = { Accept: 'application/vnd.github.sha' };
+    
+    // VITE_ prefix required for client-side exposure in Vite
+    const token = import.meta.env.VITE_GITHUB_TOKEN;
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+    }
+    
     const res = await fetch(COMMIT_URL, {
-      headers: { Accept: 'application/vnd.github.sha' },
+      headers,
       signal: controller.signal,
     });
     if (!res.ok) return null;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_GITHUB_TOKEN?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/tests/tcg-update-auth.test.js
+++ b/tests/tcg-update-auth.test.js
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const originalEnv = import.meta.env;
+
+describe('tcg-update authentication', () => {
+  beforeEach(() => {
+    Object.defineProperty(import.meta, 'env', {
+      value: {},
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(import.meta, 'env', {
+      value: originalEnv,
+      writable: true,
+    });
+  });
+
+  describe('getLatestCommitSha headers', () => {
+    it('should include Authorization header when VITE_GITHUB_TOKEN is set', async () => {
+      Object.defineProperty(import.meta, 'env', {
+        value: { VITE_GITHUB_TOKEN: 'test_token_123' },
+        writable: true,
+      });
+
+      const fetchMock = vi.fn();
+      fetchMock.mockResolvedValue({
+        ok: true,
+        text: async () => 'abc123',
+      });
+
+      const originalFetch = global.fetch;
+      global.fetch = fetchMock;
+
+      try {
+        const { loadCachedOrBundled } = await import('../src/tcg-update.js');
+        
+        await loadCachedOrBundled('data:application/octet-stream,test');
+        
+        expect(fetchMock).toHaveBeenCalled();
+        const callArgs = fetchMock.mock.calls[0];
+        const headers = callArgs[1]?.headers as Record<string, string>;
+        expect(headers['Authorization']).toBe('Bearer test_token_123');
+        expect(headers['Accept']).toBe('application/vnd.github.sha');
+      } finally {
+        global.fetch = originalFetch;
+      }
+    });
+
+    it('should not include Authorization header when token is not set', async () => {
+      Object.defineProperty(import.meta, 'env', {
+        value: {},
+        writable: true,
+      });
+
+      const fetchMock = vi.fn();
+      fetchMock.mockResolvedValue({
+        ok: true,
+        text: async () => 'abc123',
+      });
+
+      const originalFetch = global.fetch;
+      global.fetch = fetchMock;
+
+      try {
+        const { loadCachedOrBundled } = await import('../src/tcg-update.js');
+        await loadCachedOrBundled('data:application/octet-stream,test');
+        
+        const callArgs = fetchMock.mock.calls[0];
+        const headers = callArgs[1]?.headers as Record<string, string>;
+        expect(headers['Authorization']).toBeUndefined();
+        expect(headers['Accept']).toBe('application/vnd.github.sha');
+      } finally {
+        global.fetch = originalFetch;
+      }
+    });
+
+    it('should handle fetch errors gracefully', async () => {
+      Object.defineProperty(import.meta, 'env', {
+        value: { VITE_GITHUB_TOKEN: 'test_token' },
+        writable: true,
+      });
+
+      const fetchMock = vi.fn();
+      fetchMock.mockRejectedValue(new Error('Network error'));
+
+      const originalFetch = global.fetch;
+      global.fetch = fetchMock;
+
+      try {
+        const { loadCachedOrBundled } = await import('../src/tcg-update.js');
+        await expect(loadCachedOrBundled('data:application/octet-stream,test'))
+          .resolves.not.toThrow();
+      } finally {
+        global.fetch = originalFetch;
+      }
+    });
+
+    it('should handle non-OK responses gracefully', async () => {
+      const fetchMock = vi.fn();
+      fetchMock.mockResolvedValue({ ok: false, status: 403 });
+
+      const originalFetch = global.fetch;
+      global.fetch = fetchMock;
+
+      try {
+        const { loadCachedOrBundled } = await import('../src/tcg-update.js');
+        await expect(loadCachedOrBundled('data:application/octet-stream,test'))
+          .resolves.not.toThrow();
+      } finally {
+        global.fetch = originalFetch;
+      }
+    });
+  });
+});


### PR DESCRIPTION
Closes #470

Adds optional authentication for GitHub API calls when fetching TCG updates.