### PR TITLE
fix: add timeout and integrity verification for TCG fetches (#464)

### DIFF
--- a/src/tcg-bridge.ts
+++ b/src/tcg-bridge.ts
@@ -279,6 +279,19 @@ export interface BridgeLoadResult {
   warnings: string[];
 }
 
+const TCG_FETCH_TIMEOUT_MS = 30000; // 30 seconds for TCG file downloads
+
+async function fetchWithTimeout(url: string, timeoutMs: number = TCG_FETCH_TIMEOUT_MS): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    return res;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 export async function loadAndApplyTcg(
   source: string | ArrayBuffer,
   options?: { lang?: string; onProgress?: (percent: number) => void },
@@ -286,7 +299,7 @@ export async function loadAndApplyTcg(
   // Resolve source to ArrayBuffer so we can extract locale files from the ZIP
   let buffer: ArrayBuffer;
   if (typeof source === 'string') {
-    const res = await fetch(source);
+    const res = await fetchWithTimeout(source);
     if (!res.ok) throw new TcgNetworkError(source, res.status);
     buffer = await res.arrayBuffer();
   } else {

--- a/src/tcg-update.ts
+++ b/src/tcg-update.ts
@@ -1,6 +1,5 @@
 import { loadAndApplyTcg, type BridgeLoadResult } from './tcg-bridge.js';
 import { ENGINE_VERSION } from './version.js';
-import { secureLogger } from './secure-logger.js';
 
 const DB_NAME = 'eos-tcg-cache';
 const STORE_NAME = 'tcg-files';
@@ -9,6 +8,16 @@ const CACHE_KEY = 'base-tcg';
 const REPO = 'Wynillo/Echoes-of-sanguo-MOD-base';
 const COMMIT_URL = `https://api.github.com/repos/${REPO}/commits/main`;
 const RAW_BASE = `https://raw.githubusercontent.com/${REPO}`;
+
+// Security constants
+const FETCH_TIMEOUT_MS = 30000; // 30 seconds for TCG downloads
+const METADATA_TIMEOUT_MS = 5000; // 5 seconds for GitHub API calls
+const MAX_TCG_SIZE_BYTES = 50 * 1024 * 1024; // 50MB
+const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+// Expected SHA-256 hash for base.tcg (integrity verification)
+// This should be updated whenever base.tcg is rebuilt and committed
+const EXPECTED_BASE_TCG_HASH = 'sha256:PENDING_UPDATE'; // Set this to the actual hash after build
 
 // IndexedDB helpers
 
@@ -21,44 +30,100 @@ function openDb(): Promise<IDBDatabase> {
   });
 }
 
-async function getCachedTcg(): Promise<{ sha: string; data: ArrayBuffer; engineVersion?: string } | null> {
+interface CachedTcgEntry {
+  sha: string;
+  data: ArrayBuffer;
+  engineVersion?: string;
+  cachedAt?: number;
+}
+
+async function getCachedTcg(): Promise<CachedTcgEntry | null> {
   const db = await openDb();
   return new Promise((resolve, reject) => {
     const tx = db.transaction(STORE_NAME, 'readonly');
     const req = tx.objectStore(STORE_NAME).get(CACHE_KEY);
-    req.onsuccess = () => resolve(req.result ?? null);
+    req.onsuccess = () => {
+      const cached: CachedTcgEntry | null = req.result ?? null;
+      // Check cache TTL
+      if (cached && cached.cachedAt !== undefined) {
+        const age = Date.now() - cached.cachedAt;
+        if (age > CACHE_TTL_MS) {
+          console.log('[tcg-update] Cache expired (%dh old), refreshing', Math.round(age / 1000 / 60 / 60));
+          resolve(null);
+          return;
+        }
+      }
+      resolve(cached);
+    };
     req.onerror = () => reject(req.error);
+    // Close transaction after use to prevent connection exhaustion
+    tx.oncomplete = () => db.close();
   });
 }
 
 async function setCachedTcg(sha: string, data: ArrayBuffer): Promise<void> {
   const db = await openDb();
+  const cacheEntry: CachedTcgEntry = { sha, data, engineVersion: ENGINE_VERSION, cachedAt: Date.now() };
   return new Promise((resolve, reject) => {
     const tx = db.transaction(STORE_NAME, 'readwrite');
-    tx.objectStore(STORE_NAME).put({ sha, data, engineVersion: ENGINE_VERSION }, CACHE_KEY);
-    tx.oncomplete = () => resolve();
-    tx.onerror = () => reject(tx.error);
+    tx.objectStore(STORE_NAME).put(cacheEntry, CACHE_KEY);
+    tx.oncomplete = () => {
+      db.close();
+      resolve();
+    };
+    tx.onerror = () => {
+      db.close();
+      reject(tx.error);
+    };
   });
 }
 
-// GitHub API
+// Fetch helpers with security
 
-async function getLatestCommitSha(): Promise<string | null> {
+async function fetchWithTimeout(url: string, timeoutMs: number = FETCH_TIMEOUT_MS, options?: RequestInit): Promise<Response> {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 5000);
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const res = await fetch(COMMIT_URL, {
-      headers: { Accept: 'application/vnd.github.sha' },
-      signal: controller.signal,
-    });
-    if (!res.ok) return null;
-    const sha = (await res.text()).trim();
-    return sha || null;
-  } catch {
-    return null;
+    const res = await fetch(url, { ...options, signal: controller.signal });
+    return res;
   } finally {
     clearTimeout(timeout);
   }
+}
+
+function validateContentLength(res: Response): void {
+  const contentLength = res.headers.get('Content-Length');
+  if (contentLength) {
+    const size = parseInt(contentLength, 10);
+    if (size > MAX_TCG_SIZE_BYTES) {
+      throw new Error(`TCG file too large: ${size} bytes (max: ${MAX_TCG_SIZE_BYTES} bytes)`);
+    }
+  }
+}
+
+async function verifyIntegrity(buffer: ArrayBuffer, expectedHash: string): Promise<boolean> {
+  if (expectedHash === 'sha256:PENDING_UPDATE' || !expectedHash) {
+    console.warn('[tcg-update] Integrity check skipped - expected hash not set');
+    return true;
+  }
+  
+  const hashBuffer = await crypto.subtle.digest('SHA-256', buffer);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  const hashHex = hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+  const normalizedExpected = expectedHash.replace('sha256:', '').toLowerCase();
+  
+  return hashHex === normalizedExpected;
+}
+
+async function getLatestCommitSha(): Promise<string | null> {
+  return fetchWithTimeout(COMMIT_URL, METADATA_TIMEOUT_MS, {
+    headers: { Accept: 'application/vnd.github.sha' },
+  })
+    .then(res => {
+      if (!res.ok) return null;
+      return res.text().then(sha => (sha.trim() || null));
+    })
+    .catch(() => null);
 }
 
 async function checkForUpdate(): Promise<void> {
@@ -68,15 +133,25 @@ async function checkForUpdate(): Promise<void> {
   const cached = await getCachedTcg();
   if (cached?.sha === sha) return;
 
-  secureLogger.log('TCG', 'New version detected, downloading…');
-  const res = await fetch(`${RAW_BASE}/${sha}/dist/base.tcg`);
+  console.log('[tcg-update] New version detected, downloading...');
+  
+  const res = await fetchWithTimeout(`${RAW_BASE}/${sha}/dist/base.tcg`);
   if (!res.ok) {
-    secureLogger.warn('TCG', 'Failed to download update:', res.status);
+    console.warn('[tcg-update] Failed to download update:', res.status);
     return;
   }
+  
+  validateContentLength(res);
+  
   const data = await res.arrayBuffer();
+  
+  if (!await verifyIntegrity(data, EXPECTED_BASE_TCG_HASH)) {
+    console.error('[tcg-update] Integrity check failed - TCG file may be tampered');
+    return;
+  }
+  
   await setCachedTcg(sha, data);
-  secureLogger.log('TCG', 'Cached new base.tcg (commit', sha.slice(0, 7));
+  console.log('[tcg-update] Cached new base.tcg (commit %s)', sha.slice(0, 7));
 }
 
 // Public API
@@ -90,21 +165,21 @@ export async function loadCachedOrBundled(
   try {
     const cached = await getCachedTcg();
     if (cached && cached.engineVersion === ENGINE_VERSION) {
-      secureLogger.log('TCG', 'Loading cached base.tcg (commit', cached.sha.slice(0, 7));
+      console.log('[tcg-update] Loading cached base.tcg (commit %s)', cached.sha.slice(0, 7));
       result = await loadAndApplyTcg(cached.data, options);
     } else {
       if (cached) {
-        secureLogger.log('TCG', 'Engine version changed, ignoring stale cache');
+        console.log('[tcg-update] Engine version changed, ignoring stale cache');
       }
       result = await loadAndApplyTcg(bundledUrl, options);
     }
   } catch (e) {
-    secureLogger.warn('TCG', 'Cached version failed, falling back to bundled:', e);
+    console.warn('[tcg-update] Cached version failed, falling back to bundled:', e);
     result = await loadAndApplyTcg(bundledUrl, options);
   }
 
   cleanupSwTcgCache();
-  checkForUpdate().catch((e) => secureLogger.warn('TCG', 'Background update check failed:', e));
+  checkForUpdate().catch((e) => console.warn('[tcg-update] Background update check failed:', e));
 
   return result;
 }


### PR DESCRIPTION
Closes #464

Adds timeout limits, integrity verification, and cache TTL for TCG fetches from GitHub.