### PR TITLE
security: add TCG size validation (#460)

### DIFF
--- a/src/secure-logger.ts
+++ b/src/secure-logger.ts
@@ -1,0 +1,22 @@
+/**
+ * Secure logging utilities for security-sensitive operations.
+ * Provides structured logging with appropriate severity levels.
+ */
+
+export const secureLogger = {
+  log(context: string, ...args: unknown[]): void {
+    console.log(`[SECURE:${context}]`, ...args);
+  },
+
+  info(context: string, ...args: unknown[]): void {
+    console.info(`[SECURE:${context}]`, ...args);
+  },
+
+  warn(context: string, ...args: unknown[]): void {
+    console.warn(`[SECURE:${context}]`, ...args);
+  },
+
+  error(context: string, ...args: unknown[]): void {
+    console.error(`[SECURE:${context}]`, ...args);
+  },
+};

--- a/src/tcg-bridge.ts
+++ b/src/tcg-bridge.ts
@@ -14,6 +14,7 @@ import { applyShopData, SHOP_DATA, type ShopData } from './shop-data.js';
 import { applyCampaignData } from './campaign-store.js';
 import type { CampaignData } from './campaign-types.js';
 import { TYPE_META } from './type-metadata.js';
+import { MAX_TCG_SIZE_BYTES, formatBytes } from './tcg-config.js';
 
 // Re-export error classes for consumers
 export { TcgNetworkError, TcgFormatError };
@@ -291,6 +292,16 @@ export async function loadAndApplyTcg(
     buffer = await res.arrayBuffer();
   } else {
     buffer = source;
+  }
+
+  // SECURITY: Validate TCG archive size to prevent resource exhaustion attacks
+  // Oversized .tcg files could consume excessive memory or cause DoS
+  const bufferSize = buffer.byteLength;
+  if (bufferSize > MAX_TCG_SIZE_BYTES) {
+    throw new TcgFormatError(
+      `TCG archive exceeds maximum allowed size of ${formatBytes(MAX_TCG_SIZE_BYTES)} (actual: ${formatBytes(bufferSize)}). ` +
+      `This security measure prevents resource exhaustion attacks via oversized mod files.`
+    );
   }
 
   await Promise.all([

--- a/src/tcg-config.ts
+++ b/src/tcg-config.ts
@@ -1,0 +1,19 @@
+/**
+ * Maximum allowed size for TCG archive files.
+ * Prevents resource exhaustion attacks via oversized .tcg files.
+ * 50MB is sufficient for legitimate card packs with high-quality images.
+ */
+export const MAX_TCG_SIZE_BYTES = 50 * 1024 * 1024; // 50MB
+
+/**
+ * Formats a byte size into a human-readable string.
+ * @param bytes - Size in bytes
+ * @returns Formatted string (e.g., "50.0 MB")
+ */
+export function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B';
+  const k = 1024;
+  const sizes = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${(bytes / Math.pow(k, i)).toFixed(1)} ${sizes[i]}`;
+}

--- a/src/tcg-update.ts
+++ b/src/tcg-update.ts
@@ -1,6 +1,7 @@
 import { loadAndApplyTcg, type BridgeLoadResult } from './tcg-bridge.js';
 import { ENGINE_VERSION } from './version.js';
 import { secureLogger } from './secure-logger.js';
+import { MAX_TCG_SIZE_BYTES, formatBytes } from './tcg-config.js';
 
 const DB_NAME = 'eos-tcg-cache';
 const STORE_NAME = 'tcg-files';
@@ -74,9 +75,48 @@ async function checkForUpdate(): Promise<void> {
     secureLogger.warn('TCG', 'Failed to download update:', res.status);
     return;
   }
+
+  // SECURITY: Check Content-Length header before downloading to prevent resource exhaustion
+  const contentLength = res.headers.get('content-length');
+  if (contentLength) {
+    const fileSize = parseInt(contentLength, 10);
+    if (fileSize > MAX_TCG_SIZE_BYTES) {
+      secureLogger.warn(
+        'TCG',
+        `Rejected oversized TCG update: ${formatBytes(fileSize)} exceeds limit of ${formatBytes(MAX_TCG_SIZE_BYTES)}`
+      );
+      return;
+    }
+  }
+
   const data = await res.arrayBuffer();
-  await setCachedTcg(sha, data);
-  secureLogger.log('TCG', 'Cached new base.tcg (commit', sha.slice(0, 7));
+
+  // SECURITY: Double-check actual size after download (Content-Length can be spoofed)
+  if (data.byteLength > MAX_TCG_SIZE_BYTES) {
+    secureLogger.warn(
+      'TCG',
+      `Rejected oversized TCG update: actual size ${formatBytes(data.byteLength)} exceeds limit of ${formatBytes(MAX_TCG_SIZE_BYTES)}`
+    );
+    return;
+  }
+
+  // SECURITY: Check IndexedDB storage quota before caching
+  try {
+    const estimatedUsage = await navigator.storage.estimate();
+    const projectedUsage = (estimatedUsage.usage || 0) + data.byteLength;
+    if (estimatedUsage.quota && projectedUsage > estimatedUsage.quota * 0.9) {
+      secureLogger.warn(
+        'TCG',
+        `Skipping cache: IndexedDB quota nearly exceeded (${formatBytes(estimatedUsage.usage || 0)} / ${formatBytes(estimatedUsage.quota)})`
+      );
+    } else {
+      await setCachedTcg(sha, data);
+      secureLogger.log('TCG', 'Cached new base.tcg (commit', sha.slice(0, 7));
+    }
+  } catch (quotaError) {
+    secureLogger.warn('TCG', 'IndexedDB quota check failed, skipping cache:', quotaError);
+    // Continue without caching - the data is already in memory and will be used
+  }
 }
 
 // Public API

--- a/tests/security-attacks.test.js
+++ b/tests/security-attacks.test.js
@@ -640,3 +640,39 @@ describe('verifyModIntegrity', () => {
     }
   });
 });
+
+// ============================================================================
+// TCG Size Validation Tests (Issue #460)
+// ============================================================================
+
+import { MAX_TCG_SIZE_BYTES } from '../src/tcg-config.js';
+
+describe('TCG size validation (issue #460)', () => {
+  it('should reject TCG archives exceeding 50MB limit', async () => {
+    const { loadAndApplyTcg } = await import('../src/tcg-bridge.js');
+    const { TcgFormatError } = await import('../src/tcg-bridge.js');
+    const oversizedBuffer = new ArrayBuffer(51 * 1024 * 1024); // 51MB
+    
+    await expect(loadAndApplyTcg(oversizedBuffer))
+      .rejects
+      .toThrow(TcgFormatError);
+  });
+
+  it('should include max size in error message', async () => {
+    const { loadAndApplyTcg } = await import('../src/tcg-bridge.js');
+    const oversizedBuffer = new ArrayBuffer(60 * 1024 * 1024); // 60MB
+    
+    await expect(loadAndApplyTcg(oversizedBuffer))
+      .rejects
+      .toThrow(/50\.0 MB/);
+  });
+
+  it('should include security context in error message', async () => {
+    const { loadAndApplyTcg } = await import('../src/tcg-bridge.js');
+    const oversizedBuffer = new ArrayBuffer(100 * 1024 * 1024); // 100MB
+    
+    await expect(loadAndApplyTcg(oversizedBuffer))
+      .rejects
+      .toThrow(/security measure/i);
+  });
+});

--- a/tests/tcg-size-validation.test.js
+++ b/tests/tcg-size-validation.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { MAX_TCG_SIZE_BYTES, formatBytes } from '../src/tcg-config.js';
+
+describe('tcg-config', () => {
+  describe('MAX_TCG_SIZE_BYTES', () => {
+    it('should be 50MB in bytes', () => {
+      const expected = 50 * 1024 * 1024;
+      expect(MAX_TCG_SIZE_BYTES).toBe(expected);
+    });
+
+    it('should be a positive integer', () => {
+      expect(MAX_TCG_SIZE_BYTES).toBeGreaterThan(0);
+      expect(Number.isInteger(MAX_TCG_SIZE_BYTES)).toBe(true);
+    });
+  });
+
+  describe('formatBytes', () => {
+    it('should format 0 bytes correctly', () => {
+      expect(formatBytes(0)).toBe('0 B');
+    });
+
+    it('should format the max TCG size correctly', () => {
+      expect(formatBytes(MAX_TCG_SIZE_BYTES)).toBe('50.0 MB');
+    });
+
+    it('should format 1KB correctly', () => {
+      expect(formatBytes(1024)).toBe('1.0 KB');
+    });
+
+    it('should format 1MB correctly', () => {
+      expect(formatBytes(1024 * 1024)).toBe('1.0 MB');
+    });
+  });
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -123,6 +123,9 @@ export default defineConfig({
   },
   build: {
     outDir: 'dist',
+    // SECURITY: Limit inline asset size to prevent bundle bloat attacks
+    assetsInlineLimit: 4096, // 4KB - small assets only
+    // SECURITY: Warn on chunks exceeding 600KB to catch optimization issues early
     chunkSizeWarningLimit: 600,
     rollupOptions: {
       output: {


### PR DESCRIPTION
Closes #460

Adds maximum request body size validation to prevent resource exhaustion attacks.