### PR TITLE
feat: introduce Option type for null-safe monster access (#337)

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -4,6 +4,7 @@ import { CardType } from './types.js';
 import { meetsEquipRequirement } from './types.js';
 import type { Owner, Phase, Position, CardData, CardEffectBlock, EffectContext, EffectSignal, GameState, UICallbacks, OpponentConfig, AIBehavior, DuelStats } from './types.js';
 import { TriggerBus } from './trigger-bus.js';
+import { Option } from './option.js';
 // Re-export for backwards compatibility
 export { meetsEquipRequirement } from './types.js';
 
@@ -83,6 +84,14 @@ export class GameEngine {
     this.ui = uiCallbacks;
     this._trapResolve = null;
     this._currentOpponentId = null;
+  }
+
+  /**
+   * Get a monster at the given zone, returning Option type to avoid null checks.
+   * Returns Some<FieldCard> if a monster is present, None if the zone is empty.
+   */
+  getMonsterAt(owner: Owner, zone: number): Option<FieldCard> {
+    return Option.fromNullable(this.state[owner].field.monsters[zone]);
   }
 
   _initStats(): void {
@@ -474,8 +483,14 @@ export class GameEngine {
   }
 
   async flipSummon(owner: Owner, zone: number){
-    const fc = this.state[owner].field.monsters[zone];
-    if(!fc || !fc.faceDown){ this.addLog('No face-down monster!'); return false; }
+    const fcResult = this.getMonsterAt(owner, zone);
+    if (fcResult.isNone()) {
+      this.addLog('No monster in that zone!');
+      return false;
+    }
+    const fc = fcResult.value;
+    
+    if(!fc.faceDown){ this.addLog('No face-down monster!'); return false; }
     if(fc.summonedThisTurn){ this.addLog('Cannot flip on the same turn!'); return false; }
     fc.faceDown = false;
     this.addLog(`${fc.card.name} is flipped face-up (Flip Summon)!`);
@@ -1023,12 +1038,14 @@ export class GameEngine {
 
   async attack(attackerOwner: Owner, attackerZone: number, defenderZone: number){
     if(this.hasPreventAttacks(attackerOwner)){ this.addLog('Attacks are prevented!'); return; }
-    const atkSt  = this.state[attackerOwner];
-    const defOwn = attackerOwner === 'player' ? 'opponent' : 'player';
-    const defSt  = this.state[defOwn];
-
-    const attFC = atkSt.field.monsters[attackerZone];
-    if(!attFC){ this.addLog('No attacking monster!'); return; }
+    
+    const attFCResult = this.getMonsterAt(attackerOwner, attackerZone);
+    if (attFCResult.isNone()) {
+      this.addLog('No attacking monster!');
+      return;
+    }
+    const attFC = attFCResult.value;
+    
     if(attFC.hasAttacked){ this.addLog(`${attFC.card.name} has already attacked!`); return; }
     if(attFC.faceDown){
       attFC.faceDown = false;
@@ -1039,7 +1056,7 @@ export class GameEngine {
     }
     if(attFC.position !== 'atk'){ this.addLog('Monster must be in attack position!'); return; }
 
-    const defFC = defSt.field.monsters[defenderZone];
+    const defFC = this.state[attackerOwner === 'player' ? 'opponent' : 'player'].field.monsters[defenderZone];
     if(defFC && defFC.cantBeAttacked){
       this.addLog(`${defFC.card.name} cannot be attacked!`); return;
     }
@@ -1230,9 +1247,11 @@ export class GameEngine {
   }
 
   async _destroyMonster(owner: Owner, zone: number, reason: string, byOwner: Owner){
-    const st  = this.state[owner];
-    const fc  = st.field.monsters[zone];
-    if(!fc) return;
+    const st = this.state[owner];
+    const fcResult = this.getMonsterAt(owner, zone);
+    if (fcResult.isNone()) return;
+    const fc = fcResult.value;
+    
     if(fc.indestructible && reason === 'battle'){
       this.addLog(`${fc.card.name} is indestructible!`);
       return;

--- a/src/option.ts
+++ b/src/option.ts
@@ -1,0 +1,88 @@
+/**
+ * Option/Maybe type for eliminating null checks in field monster access.
+ * 
+ * This type provides a functional alternative to null/undefined checks,
+ * making code more expressive and reducing repetitive null-checking boilerplate.
+ * 
+ * Example usage:
+ * ```typescript
+ * // Before
+ * const fc = this.state[owner].field.monsters[zone];
+ * if(!fc) return;
+ * if(fc.hasAttacked) return;
+ * 
+ * // After
+ * const result = this.getMonsterAt(owner, zone);
+ * if (result.isNone()) return;
+ * const fc = result.value;
+ * if(fc.hasAttacked) return;
+ * ```
+ */
+
+export type Option<T> = Some<T> | None;
+
+/**
+ * Represents a present value.
+ */
+export class Some<T> {
+  constructor(public readonly value: T) {}
+  
+  isSome(): this is Some<T> {
+    return true;
+  }
+  
+  isNone(): this is None {
+    return false;
+  }
+  
+  map<U>(fn: (v: T) => U): Option<U> {
+    return new Some(fn(this.value));
+  }
+  
+  andThen<U>(fn: (v: T) => Option<U>): Option<U> {
+    return fn(this.value);
+  }
+  
+  filter(predicate: (v: T) => boolean): Option<T> {
+    return predicate(this.value) ? this : new None();
+  }
+}
+
+/**
+ * Represents an absent value (replaces null).
+ */
+export class None {
+  isSome(): this is Some<any> {
+    return false;
+  }
+  
+  isNone(): this is None {
+    return true;
+  }
+  
+  map<U>(_fn: (v: any) => U): None {
+    return this;
+  }
+  
+  andThen<U>(_fn: (v: any) => Option<U>): None {
+    return this;
+  }
+  
+  filter(_predicate: (v: any) => boolean): None {
+    return this;
+  }
+}
+
+/**
+ * Helper to convert a nullable value to Option.
+ * ```typescript
+ * const fc = this.state[owner].field.monsters[zone];
+ * const optFC = Option.fromNullable(fc);
+ * ```
+ */
+export const Option = {
+  some: <T>(value: T): Some<T> => new Some(value),
+  none: <T>(): None => new None(),
+  fromNullable: <T>(value: T | null | undefined): Option<T> => 
+    value == null ? new None() : new Some(value),
+};


### PR DESCRIPTION
## Summary

Implements the Option/Maybe pattern to eliminate repetitive null checks when accessing field monster arrays. This addresses the boilerplate pattern `if(!fc) return;` that appears 40+ times across the codebase.

## Changes

### New File: src/option.ts
- Option<T> type union of Some<T> | None
- Some<T> class for present values with value, isSome(), isNone(), map(), andThen(), filter()
- None class for absent values (replaces null)
- Option.fromNullable() helper to convert nullable values to Option

### Modified: src/engine.ts
- Added getMonsterAt(owner, zone) helper method to GameEngine returning Option<FieldCard>
- Refactored 3 methods to demonstrate the pattern:
  - flipSummon() - null-safe monster retrieval before flip summon
  - attack() - null-safe attacker verification before combat  
  - _destroyMonster() - null-safe monster handling during destruction

## Impact

**Before:**
```typescript
const fc = this.state[owner].field.monsters[zone];
if(!fc) return;
if(fc.hasAttacked) return;
```

**After:**
```typescript
const fcResult = this.getMonsterAt(owner, zone);
if (fcResult.isNone()) return;
const fc = fcResult.value;
if(fc.hasAttacked) return;
```

## Testing & Quality

- No new test failures introduced by Option pattern changes
- Pre-existing test failures: 60 (unrelated to these changes)
- Pre-existing TypeScript errors: 15 (including missing vsAttrBonus property)

## Scope

This implementation follows the issue's recommended 1-hour scope:
1. ✅ Created Option<T> type in new src/option.ts
2. ✅ Added getMonsterAt() helper to GameEngine
3. ✅ Refactored 3-4 heavily nested null checks to use Option pattern

## Next Steps (Future Work)

This demonstrates the pattern for gradual rollout to remaining 40+ null check locations:
- Refactor remaining null checks in engine.ts (12+ occurrences)
- Apply pattern to effect-registry.ts (8+ occurrences)
- Apply pattern to ai-orchestrator.ts (10+ occurrences)
- Apply pattern to ai-behaviors.ts (6+ occurrences)

Closes #337
