### PR TITLE
refactor: Extract initGame() helper methods (#349)

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -97,11 +97,11 @@ export class GameEngine {
     };
   }
 
-  async initGame(playerDeckIds: string[], opponentConfig: OpponentConfig | null){
-    EchoesOfSanguo.startSession();
-    this._initStats();
-    this._duelEnded = false;
-    let oppDeckIds = (opponentConfig && opponentConfig.deckIds) ? opponentConfig.deckIds : OPPONENT_DECK_IDS;
+  private _resolveOpponentConfig(
+    config: OpponentConfig | null
+  ): { deckIds: string[]; behaviorId: string; id: number | null } {
+    let oppDeckIds = (config && config.deckIds) ? config.deckIds : OPPONENT_DECK_IDS;
+    
     if (oppDeckIds.length > 0 && oppDeckIds.length < GAME_RULES.maxDeckSize) {
       const padded = [...oppDeckIds];
       while (padded.length < GAME_RULES.maxDeckSize) {
@@ -109,12 +109,20 @@ export class GameEngine {
       }
       oppDeckIds = padded;
     }
-    this._currentOpponentId = (opponentConfig && opponentConfig.id) ? opponentConfig.id : null;
-    this._aiBehavior = resolveAIBehavior(opponentConfig?.behaviorId);
+    
+    return {
+      deckIds: oppDeckIds,
+      behaviorId: config?.behaviorId ?? 'default',
+      id: (config && config.id) ? config.id : null,
+    };
+  }
 
-    const playerGoesFirst = Math.random() < 0.5;
-
-    this.state = {
+  private _initializeGameState(
+    playerDeckIds: string[],
+    opponentDeckIds: string[],
+    playerGoesFirst: boolean
+  ): GameState {
+    return {
       phase: 'main',
       turn: 1,
       activePlayer: playerGoesFirst ? 'player' : 'opponent',
@@ -128,7 +136,7 @@ export class GameEngine {
       },
       opponent: {
         lp: GAME_RULES.startingLP,
-        deck: this._shuffle(makeDeck(oppDeckIds)),
+        deck: this._shuffle(makeDeck(opponentDeckIds)),
         hand: [],
         field: { monsters: Array(GAME_RULES.fieldZones).fill(null), spellTraps: Array(GAME_RULES.fieldZones).fill(null), fieldSpell: null },
         graveyard: [],
@@ -138,9 +146,42 @@ export class GameEngine {
       firstTurnNoAttack: true,
       oneMoveActionUsed: false,
     } as GameState;
-    this.drawCard('player',   5);
+  }
+
+  private _performInitialDraws(): void {
+    this.drawCard('player', 5);
     this.drawCard('opponent', 5);
     this.addLog('=== Duel begins! ===');
+  }
+
+  private _handleAICrash(err: unknown): void {
+    EchoesOfSanguo.log('ERROR', 'AI turn crashed:', err);
+    this.state.activePlayer = 'player';
+    this.state.phase = 'main';
+    this.state.turn++;
+    this.addLog(`[ERROR] Opponent AI crashed. Your turn (Round ${this.state.turn}).`);
+    this.refillHand('player');
+    this.ui.render(this.state);
+  }
+
+  private _scheduleOpponentTurn(delayMs: number = 600): void {
+    setTimeout(() => {
+      aiTurn(createEngineDependencies(this)).catch(err => this._handleAICrash(err));
+    }, delayMs);
+  }
+
+  async initGame(playerDeckIds: string[], opponentConfig: OpponentConfig | null){
+    EchoesOfSanguo.startSession();
+    this._initStats();
+    this._duelEnded = false;
+
+    const resolved = this._resolveOpponentConfig(opponentConfig);
+    this._currentOpponentId = resolved.id;
+    this._aiBehavior = resolveAIBehavior(resolved.behaviorId);
+
+    const playerGoesFirst = Math.random() < 0.5;
+    this.state = this._initializeGameState(playerDeckIds, resolved.deckIds, playerGoesFirst);
+    this._performInitialDraws();
 
     if(this.ui.showCoinToss) await this.ui.showCoinToss(playerGoesFirst);
 
@@ -152,17 +193,7 @@ export class GameEngine {
       this.addLog('Opponent goes first!');
       this.state.phase = 'draw';
       this.ui.render(this.state);
-      setTimeout(() => {
-        aiTurn(createEngineDependencies(this)).catch(err => {
-          EchoesOfSanguo.log('ERROR', 'AI turn crashed:', err);
-          this.state.activePlayer = 'player';
-          this.state.phase = 'main';
-          this.state.turn++;
-          this.addLog(`[ERROR] Opponent AI crashed. Your turn (Round ${this.state.turn}).`);
-          this.refillHand('player');
-          this.ui.render(this.state);
-        });
-      }, 600);
+      this._scheduleOpponentTurn();
     }
   }
 
@@ -232,17 +263,7 @@ export class GameEngine {
     this.ui.render(this.state);
 
     if (this.state.activePlayer === 'opponent') {
-      setTimeout(() => {
-        aiTurn(createEngineDependencies(this)).catch(err => {
-          EchoesOfSanguo.log('ERROR', 'AI turn crashed:', err);
-          this.state.activePlayer = 'player';
-          this.state.phase = 'main';
-          this.state.turn++;
-          this.addLog(`[ERROR] Opponent AI crashed. Your turn (Round ${this.state.turn}).`);
-          this.refillHand('player');
-          this.ui.render(this.state);
-        });
-      }, 600);
+      this._scheduleOpponentTurn();
     }
   }
 


### PR DESCRIPTION
## Summary

Refactors the `initGame()` method in `src/engine.ts` to reduce complexity and improve maintainability by extracting helper methods.

## Changes

### Extracted Private Methods

1. **`_resolveOpponentConfig(config)`** - Handles opponent configuration resolution including:
   - Null-coalescing for deck IDs, behavior ID, and opponent ID
   - Deck padding logic for undersized decks

2. **`_initializeGameState(playerDeckIds, opponentDeckIds, playerGoesFirst)`** - Creates the GameState object with:
   - Player and opponent state initialization
   - Turn order logic
   - Field zone setup

3. **`_performInitialDraws()`** - Performs initial 5-card draws for both players and logs duel start

4. **`_handleAICrash(err)`** - Centralized error recovery for AI turn crashes:
   - Error logging
   - State reset to player turn
   - Hand refill

5. **`_scheduleOpponentTurn(delayMs)`** - Schedules opponent AI turn with setTimeout

### Benefits

- **Reduced complexity**: `initGame()` reduced from 69 lines to ~20 lines
- **Improved readability**: Clear separation of concerns
- **Code reuse**: `_scheduleOpponentTurn()` and `_handleAICrash()` are now used by both `initGame()` and `restoreGame()`
- **Better testability**: Each helper method can be tested independently
- **Easier maintenance**: Changes to opponent config logic, state initialization, or AI crash handling are now isolated

### Testing

- All existing tests pass
- No new type errors introduced
- Build successful

Closes #349
