### PR TITLE
refactor: remove unused CAMPAIGN_DATA export from campaign.ts (#354)

### DIFF
--- a/src/campaign.ts
+++ b/src/campaign.ts
@@ -1,9 +1,2 @@
-import type { CampaignData } from './campaign-types.js';
-
-export let CAMPAIGN_DATA: CampaignData | null = null;
 export const CAMPAIGN_IMAGES = new Map<string, string>();  // path → blob URL
 export const CAMPAIGN_I18N   = new Map<string, Record<string, string>>(); // lang → KV
-
-export function setCampaignData(data: CampaignData): void {
-  CAMPAIGN_DATA = data;
-}


### PR DESCRIPTION
## Summary

Removes the unused `CAMPAIGN_DATA` export from `src/campaign.ts` to eliminate confusion and potential duplicate state issues.

## Changes

- Removed `export let CAMPAIGN_DATA: CampaignData | null = null;` from `src/campaign.ts`
- Removed the now-unused `setCampaignData()` function
- Kept `CAMPAIGN_IMAGES` and `CAMPAIGN_I18N` exports as they are actively used by `DialogueScreen.tsx`

## Rationale

The `CAMPAIGN_DATA` variable in `campaign.ts` was never imported or used anywhere in the codebase. Campaign data is properly managed by `campaign-store.ts`, which is the actual source of truth and is correctly imported by `CampaignContext.tsx`.

This cleanup:
- Eliminates developer confusion about which module is the source of truth
- Removes potential for duplicate state bugs
- Reduces maintenance overhead

## Testing

- Verified no files import `CAMPAIGN_DATA` from `campaign.ts`
- Confirmed `CAMPAIGN_IMAGES` and `CAMPAIGN_I18N` are still used correctly in `DialogueScreen.tsx`
- No tests reference `CAMPAIGN_DATA` from `campaign.ts`

Closes #354
