### PR TITLE
refactor(type-metadata): remove unused getByKey functions (#355)

### DIFF
--- a/src/type-metadata.ts
+++ b/src/type-metadata.ts
@@ -2,32 +2,32 @@ import { CardType, Attribute, Race, Rarity } from './types.js';
 
 export interface RaceMeta {
   id:     number;
-  key:    string;   // stable PascalCase identifier (e.g. 'Dragon')
-  value:  string;   // display label (localized)
-  color:  string;   // primary display color (hex)
-  icon?:   string;   // react-icons/gi identifier (e.g. 'GiWizardStaff')
+  key:    string;
+  value:  string;
+  color:  string;
+  icon?:   string;
 }
 
 export interface AttributeMeta {
   id:     number;
-  key:    string;   // stable PascalCase identifier (e.g. 'Light')
-  value:  string;   // display label (localized)
-  color:  string;   // attribute orb color
-  symbol?: string;  // attribute symbol character (optional)
+  key:    string;
+  value:  string;
+  color:  string;
+  symbol?: string;
 }
 
 export interface RarityMeta {
   id:     number;
-  key:    string;   // stable PascalCase identifier (e.g. 'Common')
-  value:  string;   // display label
-  color:  string;   // display color
+  key:    string;
+  value:  string;
+  color:  string;
 }
 
 export interface CardTypeMeta {
   id:     number;
-  key:    string;   // stable PascalCase identifier (e.g. 'Monster')
-  value:  string;   // display label (localized)
-  color:  string;   // display color
+  key:    string;
+  value:  string;
+  color:  string;
 }
 
 export const TYPE_META = {
@@ -42,20 +42,18 @@ const _raceByKey  = new Map<string, RaceMeta>();
 const _attrById   = new Map<number, AttributeMeta>();
 const _attrByKey  = new Map<string, AttributeMeta>();
 const _rarityById = new Map<number, RarityMeta>();
-const _rarityByKey= new Map<string, RarityMeta>();
 const _ctById     = new Map<number, CardTypeMeta>();
-const _ctByKey    = new Map<string, CardTypeMeta>();
 
 function rebuildIndices(): void {
   _raceById.clear();   _raceByKey.clear();
   _attrById.clear();   _attrByKey.clear();
-  _rarityById.clear(); _rarityByKey.clear();
-  _ctById.clear();     _ctByKey.clear();
+  _rarityById.clear();
+  _ctById.clear();
 
   for (const r of TYPE_META.races)      { _raceById.set(r.id, r);   _raceByKey.set(r.key, r); }
   for (const a of TYPE_META.attributes) { _attrById.set(a.id, a);   _attrByKey.set(a.key, a); }
-  for (const r of TYPE_META.rarities)   { _rarityById.set(r.id, r); _rarityByKey.set(r.key, r); }
-  for (const c of TYPE_META.cardTypes)  { _ctById.set(c.id, c);     _ctByKey.set(c.key, c); }
+  for (const r of TYPE_META.rarities)   { _rarityById.set(r.id, r); }
+  for (const c of TYPE_META.cardTypes)  { _ctById.set(c.id, c); }
 }
 
 export function getRaceById(id: number): RaceMeta | undefined   { return _raceById.get(id); }
@@ -63,13 +61,9 @@ export function getRaceByKey(key: string): RaceMeta | undefined  { return _raceB
 export function getAttrById(id: number): AttributeMeta | undefined  { return _attrById.get(id); }
 export function getAttrByKey(key: string): AttributeMeta | undefined { return _attrByKey.get(key); }
 export function getRarityById(id: number): RarityMeta | undefined   { return _rarityById.get(id); }
-export function getRarityByKey(key: string): RarityMeta | undefined  { return _rarityByKey.get(key); }
 export function getCardTypeById(id: number): CardTypeMeta | undefined   { return _ctById.get(id); }
-export function getCardTypeByKey(key: string): CardTypeMeta | undefined  { return _ctByKey.get(key); }
 
-/** Get all races as array (for filter button generation) */
 export function getAllRaces(): readonly RaceMeta[] { return TYPE_META.races; }
-/** Get all rarities as array */
 export function getAllRarities(): readonly RarityMeta[] { return TYPE_META.rarities; }
 
 export function initDefaults(): void {


### PR DESCRIPTION
## Summary

Cleans up dead code by removing two unused export functions from `type-metadata.ts`.

## Changes

- Removed `getRarityByKey()` function (no imports/usage found)
- Removed `getCardTypeByKey()` function (no imports/usage found)
- Removed `_rarityByKey` and `_ctByKey` Map instances
- Cleaned up `rebuildIndices()` to remove unused map operations
- Removed redundant interface property comments (code is self-explanatory)

## Verification

- ✅ Verified no usage via grep across entire codebase
- ✅ TypeScript compilation successful (no new errors)
- ✅ Test results unchanged (30 pre-existing failures, 872 passing)
- ✅ Build failure is pre-existing (@wynillo/tcg-format issue)

The `ById` variants (`getRarityById`, `getCardTypeById`) remain in use and are unaffected.

---
Closes #355
