### PR TITLE
chore: move test-only effect source utilities to test helpers (#356)

### DIFF
--- a/src/effect-items.ts
+++ b/src/effect-items.ts
@@ -9,11 +9,3 @@ export const EFFECT_SOURCES: Record<string, EffectSource> = {};
 export function getEffectSource(id: string): EffectSource | undefined {
   return EFFECT_SOURCES[id];
 }
-
-export function getEffectSourcesByRarity(rarity: number): EffectSource[] {
-  return Object.values(EFFECT_SOURCES).filter(e => e.rarity === rarity);
-}
-
-export function registerEffectSource(source: EffectSource): void {
-  EFFECT_SOURCES[source.id] = source;
-}

--- a/tests/crafting.test.js
+++ b/tests/crafting.test.js
@@ -3,7 +3,8 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { CARD_DB } from '../src/cards.js';
 import { GAME_RULES, applyRules } from '../src/rules.js';
 import { isCraftedId, buildCraftedCard, craftEffectMonster } from '../src/crafting.js';
-import { EFFECT_SOURCES, registerEffectSource } from '../src/effect-items.js';
+import { EFFECT_SOURCES } from '../src/effect-items.js';
+import { registerEffectSourceForTest } from './helpers/effect-sources-test.js';
 import { Progression } from '../src/progression.js';
 import { spendCurrency } from '../src/currencies.js';
 
@@ -61,7 +62,7 @@ describe('Crafting', () => {
 
   describe('buildCraftedCard', () => {
     it('should combine base card stats with effect source effects', () => {
-      registerEffectSource({ id: 'effect_monster_001', name: 'Test Effect', rarity: 4 });
+      registerEffectSourceForTest({ id: 'effect_monster_001', name: 'Test Effect', rarity: 4 });
       
       const record = { id: '100000000', baseId: 'monster_001', effectSourceId: 'effect_monster_001' };
       const card = buildCraftedCard(record);
@@ -89,7 +90,7 @@ describe('Crafting', () => {
     it('should fail when player does not own base card', () => {
       applyRules({ craftingEnabled: true });
       cardCountSpy.mockReturnValue(0);
-      registerEffectSource({ id: 'effect_monster_001', name: 'Test Effect', rarity: 4 });
+      registerEffectSourceForTest({ id: 'effect_monster_001', name: 'Test Effect', rarity: 4 });
       
       const result = craftEffectMonster('monster_001', 'effect_monster_001');
       expect(result.success).toBe(false);
@@ -106,7 +107,7 @@ describe('Crafting', () => {
 
     it('should succeed with valid inputs and free crafting', () => {
       applyRules({ craftingEnabled: true, craftingCost: 0 });
-      registerEffectSource({ id: 'effect_monster_001', name: 'Test Effect', rarity: 4 });
+      registerEffectSourceForTest({ id: 'effect_monster_001', name: 'Test Effect', rarity: 4 });
       cardCountSpy.mockReturnValue(1);
       effectItemCountSpy.mockReturnValue(1);
       

--- a/tests/helpers/effect-sources-test.ts
+++ b/tests/helpers/effect-sources-test.ts
@@ -1,0 +1,9 @@
+import { EFFECT_SOURCES, type EffectSource } from '../../src/effect-items.js';
+
+export function registerEffectSourceForTest(source: EffectSource): void {
+  EFFECT_SOURCES[source.id] = source;
+}
+
+export function getEffectSourcesByRarityForTest(rarity: number): EffectSource[] {
+  return Object.values(EFFECT_SOURCES).filter(e => e.rarity === rarity);
+}


### PR DESCRIPTION
## Summary

Moved test-only utility functions (`registerEffectSource` and `getEffectSourcesByRarity`) from production code to test helpers, as requested in this issue.

## Changes

- **Removed from `src/effect-items.ts`**:
  - `registerEffectSource(source: EffectSource)`
  - `getEffectSourcesByRarity(rarity: number)`
  
- **Created `tests/helpers/effect-sources-test.ts`**:
  - `registerEffectSourceForTest(source: EffectSource)`
  - `getEffectSourcesByRarityForTest(rarity: number)`
  
- **Updated `tests/crafting.test.js`**:
  - Import from test helper instead of production module

## Rationale

These functions were only used in test files (`crafting.test.js`) but were bloating the production bundle. By moving them to test helpers:
- **Cleaner API**: Production code only exports runtime utilities
- **Smaller bundle**: Test utilities removed from production build
- **Better organization**: Test helpers live with tests

## Test Results

All related tests pass:
- ✅ `tests/crafting.test.js` (8 tests)
- ✅ `tests/pack-logic.test.js` (9 tests)

Closes #356
