### PR TITLE
refactor: remove deprecated proxy exports from cards.ts (#357)

### DIFF
--- a/src/cards.ts
+++ b/src/cards.ts
@@ -8,48 +8,6 @@ import { isCraftedId, resolveCraftedCard } from './crafting.js';
 
 export const TYPE = CardType;
 
-/** @deprecated Use getRarityById() from type-metadata.ts instead */
-export const RARITY_COLOR: Record<number, string> = new Proxy({} as Record<number, string>, {
-  get(_t, prop) { const id = Number(prop); return getRarityById(id)?.color ?? '#aaa'; },
-  ownKeys() { return TYPE_META.rarities.map(r => String(r.id)); },
-  getOwnPropertyDescriptor() { return { configurable: true, enumerable: true }; },
-});
-
-/** @deprecated Use getRarityById() from type-metadata.ts instead */
-export const RARITY_NAME: Record<number, string> = new Proxy({} as Record<number, string>, {
-  get(_t, prop) { const id = Number(prop); return getRarityById(id)?.value ?? ''; },
-  ownKeys() { return TYPE_META.rarities.map(r => String(r.id)); },
-  getOwnPropertyDescriptor() { return { configurable: true, enumerable: true }; },
-});
-
-/** @deprecated Use getRaceByKey() from type-metadata.ts instead */
-export const RACE_ICON: Record<string, string> = new Proxy({} as Record<string, string>, {
-  get(_t, prop) { return getRaceByKey(String(prop))?.icon ?? ''; },
-  ownKeys() { return TYPE_META.races.map(r => r.key); },
-  getOwnPropertyDescriptor() { return { configurable: true, enumerable: true }; },
-});
-
-/** @deprecated Use getRaceByKey() from type-metadata.ts instead */
-export const RACE_NAME: Record<string, string> = new Proxy({} as Record<string, string>, {
-  get(_t, prop) { return getRaceByKey(String(prop))?.value ?? ''; },
-  ownKeys() { return TYPE_META.races.map(r => r.key); },
-  getOwnPropertyDescriptor() { return { configurable: true, enumerable: true }; },
-});
-
-/** @deprecated Use getAttrByKey() from type-metadata.ts instead */
-export const ATTR_SYMBOL: Record<string, string> = new Proxy({} as Record<string, string>, {
-  get(_t, prop) { return getAttrByKey(String(prop))?.symbol ?? '✦'; },
-  ownKeys() { return TYPE_META.attributes.map(a => a.key); },
-  getOwnPropertyDescriptor() { return { configurable: true, enumerable: true }; },
-});
-
-/** @deprecated Use getAttrByKey() from type-metadata.ts instead */
-export const ATTR_NAME: Record<string, string> = new Proxy({} as Record<string, string>, {
-  get(_t, prop) { return getAttrByKey(String(prop))?.value ?? ''; },
-  ownKeys() { return TYPE_META.attributes.map(a => a.key); },
-  getOwnPropertyDescriptor() { return { configurable: true, enumerable: true }; },
-});
-
 export const CARD_DB: Record<string, CardData> = {};
 export const FUSION_RECIPES: FusionRecipe[] = [];
 export const FUSION_FORMULAS: FusionFormula[] = [];


### PR DESCRIPTION
## Summary

Removes 6 deprecated Proxy exports from `cards.ts` that are no longer used anywhere in the codebase.

## Changes

Removed the following deprecated exports (lines 11-52):
- `RARITY_COLOR` - replaced by `getRarityById().color`
- `RARITY_NAME` - replaced by `getRarityById().value`
- `RACE_ICON` - replaced by `getRaceByKey().icon`
- `RACE_NAME` - replaced by `getRaceByKey().value`
- `ATTR_SYMBOL` - replaced by `getAttrByKey().symbol`
- `ATTR_NAME` - replaced by `getAttrByKey().value`

All replacement functions in `type-metadata.ts` are already actively used:
- `getRarityById()` - used in 5+ files
- `getRaceByKey()` - used in `highlightCardText.tsx`
- `getAttrByKey()` - used in `highlightCardText.tsx`
- `getAttrById()` - used in `Card.tsx`, `HoverPreview.tsx`, `CardDetailModal.tsx`

## Benefits

- **Dead code elimination**: 42 lines removed, reduces bundle size
- **Performance**: Removes runtime Proxy overhead
- **API clarity**: Eliminates confusion between deprecated and current exports
- **Maintainability**: Cleaner codebase with single source of truth for type metadata

## Testing

- Verified zero usage of deprecated exports in codebase
- No functional changes - removal only
- Pre-existing test failures unrelated to this change

Closes #357
