### PR TITLE
fix: remove unused getCard export from crafting.ts (#358)

### DIFF
--- a/src/crafting.ts
+++ b/src/crafting.ts
@@ -91,13 +91,3 @@ export function craftEffectMonster(
   
   return { success: true, card: card ?? undefined };
 }
-
-export function getCard(id: string | number): CardData | null {
-  const strId = String(id);
-  
-  if (isCraftedId(strId)) {
-    return resolveCraftedCard(strId);
-  }
-  
-  return CARD_DB[strId] ?? null;
-}


### PR DESCRIPTION
## Summary

Removes the unused `getCard()` function export from `crafting.ts`.

## Changes

- Removed `getCard()` function (lines 95-101 in `src/crafting.ts`)
- This function was never imported or used anywhere in the production codebase
- `CARD_DB` already provides direct card lookup functionality

## Testing

- Crafting tests pass: `tests/crafting.test.js (8 tests) ✓`
- No TypeScript errors introduced
- No test regressions

Closes #358
