### PR TITLE
refactor: remove unused isEquipmentType and isEffectMonster type guards (#359)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -53,16 +53,8 @@ export type {
   TcgCardEffectBlock,
 };
 
-export function isEffectMonster(card: CardData): boolean {
-  return card.type === CardType.Monster && !!card.effect;
-}
-
 export function isMonsterType(type: CardType): boolean {
   return type === CardType.Monster || type === CardType.Fusion;
-}
-
-export function isEquipmentType(type: CardType): boolean {
-  return type === CardType.Equipment;
 }
 
 export interface EffectContext {


### PR DESCRIPTION
## Summary

Remove two unused type guard functions from `types.ts` to clean up dead code and reduce API surface.

## Changes

- **Removed** `isEffectMonster(card: CardData)` - unused function, inline checks used throughout codebase instead
- **Removed** `isEquipmentType(type: CardType)` - unused function, inline checks used throughout codebase instead
- **Kept** `isMonsterType(type: CardType)` - actively used in cards.ts, HandArea.tsx, CardDetailModal.tsx, and ai-orchestrator.ts

## Rationale

These functions were defined but never called anywhere in the codebase. The checks are performed inline where needed:
- Equipment checks: `card.type === CardType.Equipment`
- Effect monster checks: `card.type === CardType.Monster && card.effect`

Removing these unused functions:
- Reduces API surface
- Eliminates dead code
- Maintains consistency with inline checking patterns

## Testing

- ✅ TypeScript compilation: no new errors introduced
- ✅ Tests: no test failures related to these changes (pre-existing failures unrelated)
- ✅ Verified functions were unused via grep across entire codebase

Closes #359