### PR TITLE
refactor: remove unused barrel export at src/react/screens/game/index.ts (#360)

### DIFF
--- a/src/react/screens/game/index.ts
+++ b/src/react/screens/game/index.ts
@@ -1,5 +1,0 @@
-export { OpponentField }                         from './OpponentField.js';
-export { PlayerField }                           from './PlayerField.js';
-export { HandArea }                              from './HandArea.js';
-export { LPPanel }                               from './LPPanel.js';
-export { PhaseDivider, DirectAttackButton, NextPhaseButton } from './PhaseControls.js';


### PR DESCRIPTION
## Summary

Removes unused barrel export file `src/react/screens/game/index.ts` that was not imported anywhere in the codebase.

## Changes

- Deleted `src/react/screens/game/index.ts` (5-line barrel export file)
- All components continue to be imported directly from their individual files as before

## Impact

- **No functional changes** - this file was orphaned and unused
- Improves codebase clarity by removing confusing unused export
- Aligns with existing import patterns in the codebase (direct imports)

## Verification

- ✅ No files import from this barrel export
- ✅ TypeScript compilation succeeds (pre-existing errors unrelated to this change)
- ✅ No test failures related to this change

---
**Closes #360**
