### PR TITLE
chore: remove unused raceToInt and intToRace functions (#363)

### DIFF
--- a/src/enums.ts
+++ b/src/enums.ts
@@ -36,14 +36,6 @@ export function intToCardType(n: number, hasEffect: boolean): CardType {
   return ct;
 }
 
-export function raceToInt(r: Race): number {
-  return r;
-}
-
-export function intToRace(n: number): Race {
-  return n;
-}
-
 const TRIGGER_STRINGS: ReadonlySet<string> = new Set([
   'onSummon', 'onDestroyByBattle', 'onDestroyByOpponent', 'passive', 'onFlipSummon', 'onFlip',
   'onDealBattleDamage', 'onSentToGrave',


### PR DESCRIPTION
## Summary

Removes two unused utility functions from `enums.ts` that were never called anywhere in the codebase.

## Changes

- **Removed** `raceToInt(r: Race): number` - identity function (Race is already typed as `number`)
- **Removed** `intToRace(n: number): Race` - identity function (Race is already typed as `number`)

## Verification

- Searched entire codebase - no usages of these functions found
- File reduced from 76 lines to 68 lines
- No type errors or build issues introduced
- Contrasts with `cardTypeToInt`/`intToCardType` and `trapTriggerToInt`/`intToTrapTrigger` which ARE used

## Impact

- **Breaking Change**: No - these functions were never used
- **Dead Code Elimination**: Yes - reduces API surface confusion
- **Type Safety**: No impact - Race remains typed as `number`

Closes #363
