### PR TITLE
fix: remove unused getChapter export (#365)

### DIFF
--- a/src/campaign-store.ts
+++ b/src/campaign-store.ts
@@ -4,7 +4,7 @@
 // ============================================================
 
 import type { DialogueScene } from '@wynillo/tcg-format';
-import type { CampaignData, CampaignNode, CampaignProgress, Chapter } from './campaign-types.js';
+import type { CampaignData, CampaignNode, CampaignProgress } from './campaign-types.js';
 import { Progression } from './progression.js';
 
 export const CAMPAIGN_DATA: CampaignData = { chapters: [] };
@@ -60,13 +60,6 @@ export function isNodeUnlocked(nodeId: string, progress: CampaignProgress): bool
     default:
       return false;
   }
-}
-
-/**
- * Get a chapter by ID.
- */
-export function getChapter(chapterId: string): Chapter | undefined {
-  return CAMPAIGN_DATA.chapters.find(ch => ch.id === chapterId);
 }
 
 /**


### PR DESCRIPTION
## Summary
Removed unused `getChapter()` function from campaign-store.ts that was exported but never used anywhere in the codebase.

## Changes
- Deleted `getChapter(chapterId: string)` function (lines 65-70)
- Removed unused `Chapter` type import

## Rationale
- **Dead code**: Function added to module API without value
- **Unused export**: grep shows zero imports/usage outside definition
- **Reduced API surface**: Cleaner module exports
- **No breaking changes**: Function was never called

## Quality Gates
- ✅ TypeScript: No errors in campaign-store.ts
- ✅ Tests: No campaign-store tests exist; overall test suite has pre-existing failures
- ✅ Build: Pre-existing build issues unrelated to this change

Closes #365
