### PR TITLE
refactor: remove unused RewardMode type and mode field (#366)

### DIFF
--- a/src/react/contexts/GameContext.tsx
+++ b/src/react/contexts/GameContext.tsx
@@ -175,7 +175,6 @@ export function GameProvider({ children }: { children: React.ReactNode }) {
       const rewardCfg = resolveRewardConfig(
         pending?.rewardConfig,
         opponentCfg?.rewardConfig,
-        pending ? 'campaign' : 'free',
       );
 
       const badges: BattleBadges | null = result === 'victory' && stats

--- a/src/reward-config.ts
+++ b/src/reward-config.ts
@@ -1,7 +1,6 @@
 import { Rarity } from './types.js';
 
 export type BadgeRank = 'S' | 'A' | 'B';
-export type RewardMode = 'campaign' | 'free' | 'both';
 
 export interface DropPoolEntry {
   cardId: string;
@@ -16,13 +15,11 @@ export interface RankRewardEffect {
 }
 
 export interface DuelRewardConfig {
-  mode?: RewardMode;
   ranks: Record<BadgeRank, RankRewardEffect>;
   dropPool?: DropPoolEntry[];
 }
 
 export const DEFAULT_REWARD_CONFIG: DuelRewardConfig = {
-  mode: 'both',
   ranks: {
     S: { coinMultiplier: 2.5, cardDropCount: 3 },
     A: { coinMultiplier: 1.0, cardDropCount: 0 },
@@ -33,12 +30,11 @@ export const DEFAULT_REWARD_CONFIG: DuelRewardConfig = {
 export function resolveRewardConfig(
   nodeConfig?: DuelRewardConfig,
   opponentConfig?: DuelRewardConfig,
-  mode?: 'campaign' | 'free',
 ): DuelRewardConfig {
   const candidates = [nodeConfig, opponentConfig];
   for (const cfg of candidates) {
     if (!cfg) continue;
-    if (!mode || !cfg.mode || cfg.mode === 'both' || cfg.mode === mode) return cfg;
+    return cfg;
   }
   return DEFAULT_REWARD_CONFIG;
 }


### PR DESCRIPTION
## Summary

Removes unused `RewardMode` type and `mode` field from the reward configuration system.

## Changes

- **src/reward-config.ts**: 
  - Removed unused `RewardMode` type definition
  - Removed `mode?: RewardMode` field from `DuelRewardConfig` interface
  - Removed `mode: 'both'` from `DEFAULT_REWARD_CONFIG`
  - Simplified `resolveRewardConfig()` to remove unused third parameter and mode-checking logic

- **src/react/contexts/GameContext.tsx**: 
  - Updated `resolveRewardConfig` call to remove third parameter

## Rationale

The `RewardMode` type and `mode` field represented an incomplete feature to differentiate between campaign and free duel rewards. However, this functionality was never actually implemented:

- No opponent configs in the codebase set the `mode` field (only `DEFAULT_REWARD_CONFIG` had it)
- The mode-checking logic in `resolveRewardConfig` was never exercised in practice
- The third parameter was always passed but never affected the outcome

Removing this dead code simplifies the API and eliminates confusion about how reward modes work.

## Testing

- ✅ `npm test -- tests/reward-config.test.js` - All 9 tests pass
- ✅ TypeScript type checking passes for modified files
- ✅ No new type errors introduced

## Related

Closes #366
