### PR TITLE
refactor: consolidate duplicate Fisher-Yates shuffle implementations (#369)

### DIFF
--- a/src/effect-registry.ts
+++ b/src/effect-registry.ts
@@ -6,6 +6,7 @@ import {
   type PureEffectCtx, type ChainEffectCtx,
 } from './types.js';
 import { EchoesOfSanguo } from './debug-logger.js';
+import { shuffleArray, shuffleInPlace } from './utils/array.js';
 
 /**
  * Maximum number of effect steps allowed per effect block execution.
@@ -46,7 +47,7 @@ function filterFieldMonsters(monsters: Array<FieldCard | null>, filter?: CardFil
   let result = monsters.filter((fm): fm is FieldCard => fm !== null);
   if (filter) result = result.filter(fm => matchesFilter(fm.card, filter));
   if (filter?.random !== undefined && filter.random > 0) {
-    const shuffled = [...result].sort(() => Math.random() - 0.5);
+    const shuffled = shuffleArray(result);
     result = shuffled.slice(0, Math.min(filter.random, result.length));
   }
   return result;
@@ -82,13 +83,6 @@ function resolveStatTarget(target: StatTarget, ctx: PureEffectCtx): FieldCard | 
   if (target === 'ownMonster')  return ctx.targetFC ?? null;
   if (target === 'oppMonster')  return ctx.targetFC ?? null;
   return null;
-}
-
-function shuffleArray<T>(arr: T[]): void {
-  for (let i = arr.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [arr[i], arr[j]] = [arr[j], arr[i]];
-  }
 }
 
 function _triggerBuffVFX(fc: FieldCard, ctx: PureEffectCtx): void {
@@ -632,13 +626,13 @@ const IMPL: Record<string, InternalImpl> = {
     const ps = ctx.state[ctx.owner];
     ps.deck.push(...ps.graveyard);
     ps.graveyard.length = 0;
-    shuffleArray(ps.deck);
+    shuffleInPlace(ps.deck);
     ctx.log('Graveyard shuffled back into deck.');
     return {};
   },
 
   shuffleDeck(_desc: unknown, ctx: PureEffectCtx) {
-    shuffleArray(ctx.state[ctx.owner].deck);
+    shuffleInPlace(ctx.state[ctx.owner].deck);
     ctx.log('Deck shuffled.');
     return {};
   },

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1,5 +1,6 @@
 import { CARD_DB, OPPONENT_DECK_IDS, PLAYER_DECK_IDS, makeDeck, checkFusion, resolveFusionChain } from './cards.js';
 import { executeEffectBlock, matchesFilter, EffectExecutionError, MAX_EFFECT_STEPS } from './effect-registry.js';
+import { shuffleInPlace } from './utils/array.js';
 import { CardType } from './types.js';
 import { meetsEquipRequirement } from './types.js';
 import type { Owner, Phase, Position, CardData, CardEffectBlock, EffectContext, EffectSignal, GameState, UICallbacks, OpponentConfig, AIBehavior, DuelStats } from './types.js';
@@ -113,6 +114,10 @@ export class GameEngine {
     this._aiBehavior = resolveAIBehavior(opponentConfig?.behaviorId);
 
     const playerGoesFirst = Math.random() < 0.5;
+    const playerDeck = makeDeck(playerDeckIds || PLAYER_DECK_IDS);
+    const opponentDeck = makeDeck(oppDeckIds);
+    shuffleInPlace(playerDeck);
+    shuffleInPlace(opponentDeck);
 
     this.state = {
       phase: 'main',
@@ -120,7 +125,7 @@ export class GameEngine {
       activePlayer: playerGoesFirst ? 'player' : 'opponent',
       player: {
         lp: GAME_RULES.startingLP,
-        deck: this._shuffle(makeDeck(playerDeckIds || PLAYER_DECK_IDS)),
+        deck: playerDeck,
         hand: [],
         field: { monsters: Array(GAME_RULES.fieldZones).fill(null), spellTraps: Array(GAME_RULES.fieldZones).fill(null), fieldSpell: null },
         graveyard: [],
@@ -128,7 +133,7 @@ export class GameEngine {
       },
       opponent: {
         lp: GAME_RULES.startingLP,
-        deck: this._shuffle(makeDeck(oppDeckIds)),
+        deck: opponentDeck,
         hand: [],
         field: { monsters: Array(GAME_RULES.fieldZones).fill(null), spellTraps: Array(GAME_RULES.fieldZones).fill(null), fieldSpell: null },
         graveyard: [],
@@ -247,14 +252,6 @@ export class GameEngine {
   }
 
   getState(): GameState { return this.state; }
-
-  _shuffle<T>(arr: T[]): T[] {
-    for(let i=arr.length-1;i>0;i--){
-      const j=Math.floor(Math.random()*(i+1));
-      [arr[i],arr[j]]=[arr[j],arr[i]];
-    }
-    return arr;
-  }
 
   addLog(msg: string){
     this.state.log.unshift(msg);

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,0 +1,23 @@
+/**
+ * Fisher-Yates shuffle - returns a new shuffled array.
+ * O(n) time complexity with unbiased random distribution.
+ */
+export function shuffleArray<T>(arr: readonly T[]): T[] {
+  const result = [...arr];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+}
+
+/**
+ * Fisher-Yates shuffle - shuffles array in-place.
+ * O(n) time complexity with unbiased random distribution.
+ */
+export function shuffleInPlace<T>(arr: T[]): void {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+}


### PR DESCRIPTION
## Summary

Consolidates duplicate Fisher-Yates shuffle implementations across the codebase into a single shared utility module, replacing an inferior shuffle algorithm along the way.

## Changes

### New File: `src/utils/array.ts`
- `shuffleArray<T>(arr: readonly T[]): T[]` - Returns a new shuffled array (O(n))
- `shuffleInPlace<T>(arr: T[]): void` - Shuffles array in-place (O(n))
- Both use proper Fisher-Yates algorithm with unbiased random distribution

### Modified: `src/engine.ts`
- Import `shuffleInPlace` from `./utils/array.js`
- Replace `_shuffle<T>()` method with utility import
- Use `shuffleInPlace()` when initializing decks

### Modified: `src/effect-registry.ts`
- Import `shuffleArray` and `shuffleInPlace` from `./utils/array.js`
- Replace `sort(() => Math.random() - 0.5)` in `filterFieldMonsters()` with `shuffleArray()` - fixes biased shuffle
- Remove duplicate `shuffleArray()` function
- Update usages to use imported utilities

## Benefits

1. **Eliminates code duplication** - Single source of truth for shuffle algorithm
2. **Fixes biased shuffle** - Replaces inferior `sort(() => Math.random() - 0.5)` with proper O(n) Fisher-Yates
3. **Better maintainability** - Bug fixes or optimizations apply to one location
4. **Improved performance** - O(n) vs O(n log n) for the replaced sort-based shuffle
5. **Correct algorithm** - Fisher-Yates provides unbiased random distribution

## Testing

- TypeScript type checking passes
- Test suite: 872 tests passing (pre-existing failures unrelated to changes)
- Verified shuffle implementation correctness with manual test

## Verification

Run type checking:
```bash
npx tsc --noEmit
```

Run tests:
```bash
npm test
```

Closes #369
