### PR TITLE
refactor: extract duplicate trap check logic into _handleAttackTraps (#372)

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1044,35 +1044,17 @@ export class GameEngine {
       this.addLog(`${defFC.card.name} cannot be attacked!`); return;
     }
 
-    if(attackerOwner === 'opponent'){
-      const trapResult = await this._promptPlayerTraps('onAttack', attFC);
-      if(trapResult?.destroyAttacker){ this._destroyMonsterBySignal(attackerOwner, attackerZone, attFC); attFC.hasAttacked = true; this.ui.render(this.state); return; }
-      if(trapResult?.reflectDamage){ this.dealDamage(attackerOwner, attFC.effectiveATK()); attFC.hasAttacked = true; this.ui.render(this.state); return; }
-      if(trapResult && trapResult.cancelAttack){ attFC.hasAttacked = true; this.ui.render(this.state); return; }
-      if(this._duelEnded || !atkSt.field.monsters[attackerZone]){ this.ui.render(this.state); return; }
-      if(defFC){
-        const trapResult2 = await this._promptPlayerTraps('onOwnMonsterAttacked', attFC, defFC);
-        if(trapResult2?.destroyAttacker){ this._destroyMonsterBySignal(attackerOwner, attackerZone, attFC); attFC.hasAttacked = true; this.ui.render(this.state); return; }
-        if(trapResult2?.reflectDamage){ this.dealDamage(attackerOwner, attFC.effectiveATK()); attFC.hasAttacked = true; this.ui.render(this.state); return; }
-        if(trapResult2 && trapResult2.cancelAttack){ attFC.hasAttacked = true; this.ui.render(this.state); return; }
-        if(this._duelEnded || !atkSt.field.monsters[attackerZone]){ this.ui.render(this.state); return; }
-      }
-    }
-
-    if(attackerOwner === 'player'){
-      const oppTrap = await this._autoActivateOpponentTraps('onAttack', attFC);
-      if(oppTrap?.destroyAttacker){ this._destroyMonsterBySignal(attackerOwner, attackerZone, attFC); attFC.hasAttacked = true; this.ui.render(this.state); return; }
-      if(oppTrap?.reflectDamage){ this.dealDamage(attackerOwner, attFC.effectiveATK()); attFC.hasAttacked = true; this.ui.render(this.state); return; }
-      if(oppTrap?.cancelAttack){ attFC.hasAttacked = true; this.ui.render(this.state); return; }
-      if(this._duelEnded || !atkSt.field.monsters[attackerZone]){ this.ui.render(this.state); return; }
-      if(defFC){
-        const oppTrap2 = await this._autoActivateOpponentTraps('onOwnMonsterAttacked', attFC, defFC);
-        if(oppTrap2?.destroyAttacker){ this._destroyMonsterBySignal(attackerOwner, attackerZone, attFC); attFC.hasAttacked = true; this.ui.render(this.state); return; }
-        if(oppTrap2?.reflectDamage){ this.dealDamage(attackerOwner, attFC.effectiveATK()); attFC.hasAttacked = true; this.ui.render(this.state); return; }
-        if(oppTrap2?.cancelAttack){ attFC.hasAttacked = true; this.ui.render(this.state); return; }
-        if(this._duelEnded || !atkSt.field.monsters[attackerZone]){ this.ui.render(this.state); return; }
-      }
-    }
+    const trapHandled = await this._handleAttackTraps(
+      attackerOwner,
+      attackerZone,
+      attFC,
+      defFC,
+      attackerOwner === 'player'
+        ? (t, ...args) => this._autoActivateOpponentTraps(t, ...args)
+        : (t, ...args) => this._promptPlayerTraps(t, ...args)
+    );
+    if (trapHandled.cancelled) return;
+    if (!trapHandled.shouldContinue) return;
 
     if(!atkSt.field.monsters[attackerZone]){ this.ui.render(this.state); return; }
     attFC.hasAttacked = true;
@@ -1114,23 +1096,18 @@ export class GameEngine {
     }
     if(attFC.position !== 'atk') return;
 
-    if(attackerOwner === 'opponent'){
-      const trapResult = await this._promptPlayerTraps('onAttack', attFC);
-      if(trapResult?.destroyAttacker){ this._destroyMonsterBySignal(attackerOwner, attackerZone, attFC); attFC.hasAttacked = true; this.ui.render(this.state); return; }
-      if(trapResult?.reflectDamage){ this.dealDamage(attackerOwner, attFC.effectiveATK()); attFC.hasAttacked = true; this.ui.render(this.state); return; }
-      if(trapResult && trapResult.cancelAttack){ attFC.hasAttacked = true; this.ui.render(this.state); return; }
-      if(this._duelEnded || !this.state[attackerOwner].field.monsters[attackerZone]){ this.ui.render(this.state); return; }
-    }
+    const trapHandled = await this._handleAttackTraps(
+      attackerOwner,
+      attackerZone,
+      attFC,
+      null,
+      attackerOwner === 'player'
+        ? (t, ...args) => this._autoActivateOpponentTraps(t, ...args)
+        : (t, ...args) => this._promptPlayerTraps(t, ...args)
+    );
+    if (trapHandled.cancelled) return;
+    if (!trapHandled.shouldContinue) return;
 
-    if(attackerOwner === 'player'){
-      const oppTrap = await this._autoActivateOpponentTraps('onAttack', attFC);
-      if(oppTrap?.destroyAttacker){ this._destroyMonsterBySignal(attackerOwner, attackerZone, attFC); attFC.hasAttacked = true; this.ui.render(this.state); return; }
-      if(oppTrap?.reflectDamage){ this.dealDamage(attackerOwner, attFC.effectiveATK()); attFC.hasAttacked = true; this.ui.render(this.state); return; }
-      if(oppTrap?.cancelAttack){ attFC.hasAttacked = true; this.ui.render(this.state); return; }
-      if(this._duelEnded || !this.state[attackerOwner].field.monsters[attackerZone]){ this.ui.render(this.state); return; }
-    }
-
-    if(!this.state[attackerOwner].field.monsters[attackerZone]){ this.ui.render(this.state); return; }
     attFC.hasAttacked = true;
     this.addLog(`${attFC.card.name} greift direkt an!`);
     if(this.ui.playAttackAnimation) await this.ui.playAttackAnimation(attackerOwner, attackerZone, defOwn, null);
@@ -1366,6 +1343,68 @@ export class GameEngine {
     for (const block of blocks) {
       await this._safeExecuteEffect(block, ctx, card.id, 'flip effect');
     }
+  }
+
+  async _handleAttackTraps(
+    attackerOwner: Owner,
+    attackerZone: number,
+    attFC: FieldCard,
+    defFC: FieldCard | null,
+    activateTrapFn: (trigger: string, ...args: FieldCard[]) => Promise<EffectSignal | null>
+  ): Promise<{ cancelled: boolean; shouldContinue: boolean }> {
+    const atkSt = this.state[attackerOwner];
+
+    const trapResult = await activateTrapFn('onAttack', attFC);
+    if (trapResult?.destroyAttacker) {
+      this._destroyMonsterBySignal(attackerOwner, attackerZone, attFC);
+      attFC.hasAttacked = true;
+      this.ui.render(this.state);
+      return { cancelled: true, shouldContinue: false };
+    }
+    if (trapResult?.reflectDamage) {
+      this.dealDamage(attackerOwner, attFC.effectiveATK());
+      attFC.hasAttacked = true;
+      this.ui.render(this.state);
+      return { cancelled: true, shouldContinue: false };
+    }
+    if (trapResult?.cancelAttack) {
+      attFC.hasAttacked = true;
+      this.ui.render(this.state);
+      return { cancelled: true, shouldContinue: false };
+    }
+
+    if (this._duelEnded || !atkSt.field.monsters[attackerZone]) {
+      this.ui.render(this.state);
+      return { cancelled: false, shouldContinue: false };
+    }
+
+    if (defFC) {
+      const trapResult2 = await activateTrapFn('onOwnMonsterAttacked', attFC, defFC);
+      if (trapResult2?.destroyAttacker) {
+        this._destroyMonsterBySignal(attackerOwner, attackerZone, attFC);
+        attFC.hasAttacked = true;
+        this.ui.render(this.state);
+        return { cancelled: true, shouldContinue: false };
+      }
+      if (trapResult2?.reflectDamage) {
+        this.dealDamage(attackerOwner, attFC.effectiveATK());
+        attFC.hasAttacked = true;
+        this.ui.render(this.state);
+        return { cancelled: true, shouldContinue: false };
+      }
+      if (trapResult2?.cancelAttack) {
+        attFC.hasAttacked = true;
+        this.ui.render(this.state);
+        return { cancelled: true, shouldContinue: false };
+      }
+
+      if (this._duelEnded || !atkSt.field.monsters[attackerZone]) {
+        this.ui.render(this.state);
+        return { cancelled: false, shouldContinue: false };
+      }
+    }
+
+    return { cancelled: false, shouldContinue: true };
   }
 
   async _promptPlayerTraps(triggerType: string, ...args: FieldCard[]){


### PR DESCRIPTION
## Summary

Refactored duplicated trap activation logic in attack methods by extracting it into a parameterized helper method `_handleAttackTraps()`.

## Changes

- **New method**: `_handleAttackTraps()` - centralized trap handling for attack scenarios
- **Refactored**: `attack()` method - removed ~40 lines of duplicated code
- **Refactored**: `attackDirect()` method - removed ~15 lines of duplicated code

## Before

Two separate code blocks with identical logic:
- Lines 1047-1060: opponent attack trap handling
- Lines 1062-1075: player attack trap handling

Both blocks performed the same checks:
1. Check `onAttack` traps (destroy/reflect/cancel)
2. Check `onOwnMonsterAttacked` traps if defending monster exists
3. Same destruction/damage calls
4. Same duel-ended/zone-empty checks

## After

Single helper method with parameterized trap activation function:
```typescript
async _handleAttackTraps(
  attackerOwner: Owner,
  attackerZone: number,
  attFC: FieldCard,
  defFC: FieldCard | null,
  activateTrapFn: (trigger: string, ...args: FieldCard[]) => Promise<EffectSignal | null>
): Promise<{ cancelled: boolean; shouldContinue: boolean }>
```

Call sites pass different activation functions:
- Player attacks: `(t, ...args) => this._autoActivateOpponentTraps(t, ...args)`
- Opponent attacks: `(t, ...args) => this._promptPlayerTraps(t, ...args)`

## Benefits

1. **Reduced duplication**: 55 lines → 0 lines (centralized in one method)
2. **Easier maintenance**: Changes to trap flow need only one update
3. **Consistency**: Guaranteed identical behavior for both attack paths
4. **Testability**: Single method to test instead of two mirrored blocks

## Testing

- TypeScript type checking: ✅ No new errors introduced
- Unit tests: ✅ 872 tests passing (failures are pre-existing)
- Build verification: Pre-existing build issue with dependency (unrelated to changes)

Closes #372
