### PR TITLE
refactor: eliminate duplicate AI spell pattern matching (#373)

### DIFF
--- a/src/ai-orchestrator.ts
+++ b/src/ai-orchestrator.ts
@@ -24,6 +24,7 @@ import {
   aiEffectiveATK,
   aiEffectiveDEF,
 } from './ai-behaviors.js';
+import { classifySpell } from './ai/utils/spell-classifier.js';
 
 interface TurnContext {
   snap:       BoardSnapshot;
@@ -339,37 +340,27 @@ async function _activateSpells(deps: AIDependencies, ctx: TurnContext): Promise<
       if(card.type !== CardType.Spell) continue;
       let activated = false;
 
-        const actions = card.effect?.actions ?? [];
-        const dealsDamage = actions.some((a: import('./types.js').EffectDescriptor) => a.type === 'dealDamage');
-        const heals = actions.some((a: import('./types.js').EffectDescriptor) => a.type === 'gainLP');
-        const buffs = actions.some((a: import('./types.js').EffectDescriptor) => {
-          const t = a.type as string;
-          return t === 'buffAtkAll' || t === 'buffAtkRace' || t === 'buffAtk' || t === 'buffField';
-        });
-        const destroys = actions.some((a: import('./types.js').EffectDescriptor) => {
-          const t = a.type as string;
-          return t === 'destroyMonster' || t === 'destroyAll' || t === 'destroySpellTrap';
-        });
+      const classification = classifySpell(card);
 
-        let should = false;
-        if (dealsDamage) {
-          should = true;
-        } else if (heals) {
-          should = ai.lp < AI_LP_THRESHOLD.DEFENSIVE || ai.lp < plr.lp;
-        } else if (buffs) {
-          should = ai.field.monsters.some(fc => fc !== null);
-        } else if (destroys) {
-          should = plr.field.monsters.some(fc => fc !== null);
-          if (!should && bh.knowsPlayerHand) {
-            const plrHasMonsters = plr.hand.some(c => c.type === CardType.Monster || c.type === CardType.Fusion);
-            if (plrHasMonsters) {
-              EchoesOfSanguo.log('AI', `CHEAT-INSIGHT: Player hand has monsters — pre-emptively activating ${card.name}`);
-              should = true;
-            }
+      let should = false;
+      if (classification.dealsDamage) {
+        should = true;
+      } else if (classification.heals) {
+        should = ai.lp < AI_LP_THRESHOLD.DEFENSIVE || ai.lp < plr.lp;
+      } else if (classification.buffs) {
+        should = ai.field.monsters.some(fc => fc !== null);
+      } else if (classification.destroys) {
+        should = plr.field.monsters.some(fc => fc !== null);
+        if (!should && bh.knowsPlayerHand) {
+          const plrHasMonsters = plr.hand.some(c => c.type === CardType.Monster || c.type === CardType.Fusion);
+          if (plrHasMonsters) {
+            EchoesOfSanguo.log('AI', `CHEAT-INSIGHT: Player hand has monsters — pre-emptively activating ${card.name}`);
+            should = true;
           }
-        } else {
-          should = true;
         }
+      } else {
+        should = true;
+      }
 
         if(should){
           EchoesOfSanguo.log('SPELL', `Activating ${card.name} (normal)`);

--- a/src/ai/utils/spell-classifier.ts
+++ b/src/ai/utils/spell-classifier.ts
@@ -1,0 +1,43 @@
+import type { CardData } from '../../types.js';
+
+export interface SpellClassification {
+  dealsDamage: boolean;
+  heals: boolean;
+  buffs: boolean;
+  destroys: boolean;
+  buffsTargetCount: number;
+  destroysTargetCount: number;
+}
+
+const BUFF_TYPES = new Set(['buffAtkAll', 'buffAtkRace', 'buffAtk', 'buffField']);
+const DESTROY_TYPES = new Set(['destroyMonster', 'destroyAll', 'destroySpellTrap']);
+
+export function classifySpell(card: CardData): SpellClassification {
+  const actions = card.effect?.actions ?? [];
+  
+  const result: SpellClassification = {
+    dealsDamage: false,
+    heals: false,
+    buffs: false,
+    destroys: false,
+    buffsTargetCount: 0,
+    destroysTargetCount: 0,
+  };
+  
+  for (const action of actions) {
+    const t = action.type as string;
+    if (t === 'dealDamage') {
+      result.dealsDamage = true;
+    } else if (t === 'gainLP') {
+      result.heals = true;
+    } else if (BUFF_TYPES.has(t)) {
+      result.buffs = true;
+      result.buffsTargetCount++;
+    } else if (DESTROY_TYPES.has(t)) {
+      result.destroys = true;
+      result.destroysTargetCount++;
+    }
+  }
+  
+  return result;
+}


### PR DESCRIPTION
## Summary

Refactors duplicate AI spell activation logic into a reusable utility function, eliminating code duplication and improving maintainability.

## Changes

### New File: `src/ai/utils/spell-classifier.ts`
- Created `classifySpell()` function that analyzes card effect actions once
- Introduced `SpellClassification` interface for type-safe spell categorization
- Centralized effect type definitions using `BUFF_TYPES` and `DESTROY_TYPES` Sets
- Added support for target counting (`buffsTargetCount`, `destroysTargetCount`)

### Modified: `src/ai-orchestrator.ts`
- Replaced 4 separate `.some()` iterations with single `classifySpell()` call
- Simplified spell activation logic in `_activateSpells()` function
- Improved code readability and maintainability

## Benefits

- **Performance**: Single iteration through actions array instead of 4 separate iterations
- **Maintainability**: Centralized effect type definitions - adding new effect types requires updating only one location
- **Extensibility**: Easy to add new spell classifications without modifying core logic
- **Readability**: Cleaner, more self-documenting code

## Test Results

- **TypeScript**: ✅ No errors in modified files
- **Unit Tests**: ✅ 872 tests passing (pre-existing failures unrelated)
- **Build**: ⚠️ Pre-existing issue with @wynillo/tcg-format package (unrelated to changes)

## Code Quality

- Follows existing project conventions (ES modules, `.js` extensions)
- No decorative comments
- Type-safe with TypeScript
- Self-documenting code

Closes #373
