### PR TITLE
refactor: remove duplicate summon logic from performFusionChain (#375)

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -913,21 +913,14 @@ export class GameEngine {
   }
 
   /**
-   * FM-style multi-card fusion chain.
-   * If 1 card: normal summon in ATK position.
-   * If 2+ cards: resolve chain, place final result on field.
+   * FM-style multi-card fusion chain (2+ cards only).
+   * For single-card summon, use summonMonster() directly.
    */
   async performFusionChain(owner: Owner, handIndices: number[]): Promise<boolean> {
     const st = this.state[owner];
     const hand = st.hand;
 
-    if (handIndices.length === 0) return false;
-
-    if (handIndices.length === 1) {
-      const zone = st.field.monsters.findIndex(z => z === null);
-      if (zone === -1) { this.addLog('No free zone!'); return false; }
-      return this.summonMonster(owner, handIndices[0], zone, 'atk');
-    }
+    if (handIndices.length < 2) return false;
 
     const zone = st.field.monsters.findIndex(z => z === null);
     if (zone === -1) { this.addLog('No free zone for fusion monster!'); return false; }


### PR DESCRIPTION
## Summary

Refactors `performFusionChain` to remove duplicated summon logic for the single-card special case.

## Changes

### `src/engine.ts`

**Removed duplicate code** (lines 926-930):
- Deleted special case that handled single-card fusion by calling `summonMonster`
- This logic duplicated zone-finding that already exists in `summonMonster`
- The code path was unreachable - no caller invokes this method with 1 card

**Updated guard clause**:
- Changed from `if (handIndices.length === 0)` to `if (handIndices.length < 2)`
- Method now correctly enforces that fusion chains require 2+ cards

**Updated documentation**:
- Clarified method signature: "FM-style multi-card fusion chain (2+ cards only)"
- Added guidance: "For single-card summon, use `summonMonster()` directly"

## Why this is safe

1. **UI caller** (`src/react/screens/game/HandArea.tsx:93-98`): Has explicit guard preventing calls with < 2 cards
2. **AI caller** (`src/ai-orchestrator.ts:237`): Only calls with results from fusion chain finder (always 2+ cards)
3. **Method semantics**: "Fusion chain" implies multiple cards - single-card case was a confusing legacy feature

Closes #375
