### PR TITLE
refactor: centralize STARTING_LP constant in rules.ts (#387)

### DIFF
--- a/src/ai-threat.ts
+++ b/src/ai-threat.ts
@@ -1,5 +1,6 @@
 import type { AIGoal, BoardSnapshot, PlayerState } from './types.js';
 import { AI_SCORE } from './ai-behaviors.js';
+import { GAME_RULES } from './rules.js';
 
 /** Create a lightweight board snapshot from live player states. */
 export function snapshotBoard(ai: PlayerState, plr: PlayerState): BoardSnapshot {
@@ -27,7 +28,7 @@ export function snapshotBoard(ai: PlayerState, plr: PlayerState): BoardSnapshot 
  */
 export function computeBoardThreat(snap: BoardSnapshot): number {
   const plrLPSafe = snap.plrLP > 0 ? snap.plrLP : 1;
-  const lpRatio = (snap.aiLP / plrLPSafe - 1) * AI_SCORE.THREAT_LP_WEIGHT * 8000;
+  const lpRatio = (snap.aiLP / plrLPSafe - 1) * AI_SCORE.THREAT_LP_WEIGHT * GAME_RULES.STARTING_LP;
   const boardDiff = (snap.aiMonsterPower - snap.plrMonsterPower) * AI_SCORE.THREAT_BOARD_WEIGHT;
   const handAdv = (snap.aiHandSize - snap.plrHandSize) * AI_SCORE.THREAT_HAND_WEIGHT;
   return lpRatio + boardDiff + handAdv;

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -119,7 +119,7 @@ export class GameEngine {
       turn: 1,
       activePlayer: playerGoesFirst ? 'player' : 'opponent',
       player: {
-        lp: GAME_RULES.startingLP,
+        lp: GAME_RULES.STARTING_LP,
         deck: this._shuffle(makeDeck(playerDeckIds || PLAYER_DECK_IDS)),
         hand: [],
         field: { monsters: Array(GAME_RULES.fieldZones).fill(null), spellTraps: Array(GAME_RULES.fieldZones).fill(null), fieldSpell: null },
@@ -127,7 +127,7 @@ export class GameEngine {
         normalSummonUsed: false
       },
       opponent: {
-        lp: GAME_RULES.startingLP,
+        lp: GAME_RULES.STARTING_LP,
         deck: this._shuffle(makeDeck(oppDeckIds)),
         hand: [],
         field: { monsters: Array(GAME_RULES.fieldZones).fill(null), spellTraps: Array(GAME_RULES.fieldZones).fill(null), fieldSpell: null },

--- a/src/react/screens/game/LPPanel.tsx
+++ b/src/react/screens/game/LPPanel.tsx
@@ -1,5 +1,6 @@
 import { useAnimatedNumber } from '../../hooks/useAnimatedNumber.js';
 import RaceIcon from '../../components/RaceIcon.js';
+import { GAME_RULES } from '../../../rules.js';
 
 interface Props {
   playerLp:    number;
@@ -8,8 +9,7 @@ interface Props {
   oppDeck:     number;
 }
 
-const START_LP = 8000;
-function lpPct(lp: number) { return `${Math.max(0, Math.min(100, lp / START_LP * 100))}%`; }
+function lpPct(lp: number) { return `${Math.max(0, Math.min(100, lp / GAME_RULES.STARTING_LP * 100))}%`; }
 
 export function LPPanel({ playerLp, oppLp, playerDeck, oppDeck }: Props) {
   const playerLpDisplay = useAnimatedNumber(playerLp);

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -5,7 +5,8 @@
 // ============================================================
 
 export const GAME_RULES = {
-  startingLP: 8000,
+  /** Standard TCG format starting LP (8000 = traditional, 4000 = speed duel) */
+  STARTING_LP: 8000,
   maxLP: 99999,
   handLimitDraw: 10,
   handLimitEnd: 8,


### PR DESCRIPTION
## Summary

Centralizes the starting LP constant (8000) into a single source of truth in `rules.ts` to prevent drift and enable easier rule variants.

## Changes

- **src/rules.ts**: Renamed `startingLP` → `STARTING_LP` with documentation comment explaining format choice (8000 = traditional TCG, 4000 = speed duel)
- **src/react/screens/game/LPPanel.tsx**: Removed duplicate constant, now imports from `GAME_RULES.STARTING_LP`
- **src/ai-threat.ts**: Replaced magic number 8000 with `GAME_RULES.STARTING_LP` in threat calculation normalization

## Testing

**Unit tests related to modified files:**
- ✅ `tests/rules.test.js` - 5/5 tests passed
- ✅ `tests/ai-threat.test.js` - 37/37 tests passed
- ✅ `tests/engine.lifecycle.test.js` - 40/42 tests passed (2 pre-existing failures unrelated to this PR)

**Pre-existing test failures:** The 2 failing tests and 36 other failures across the test suite are unrelated to these changes (affect different modules).

## Impact

- Eliminates duplication risk for LP constant
- Enables future format variants (e.g., Speed Duel 4000 LP) via single configuration point
- Improves code maintainability with single source of truth
- Zero runtime behavior changes

Closes #387
