### PR TITLE
feat: export save system constants (#389)

### DIFF
--- a/src/progression.ts
+++ b/src/progression.ts
@@ -5,6 +5,38 @@ import { secureLogger } from './secure-logger.js';
 
 export type SlotId = 1 | 2 | 3;
 
+/**
+ * Current save file version for migration support.
+ * Increment when breaking changes are made to save structure.
+ * v2: Collection ID format change (old uppercase IDs → new format)
+ */
+export const SAVE_VERSION = 2;
+
+/**
+ * Number of save slots available to players.
+ * 3 slots - standard for single-player games (primary, secondary, backup).
+ */
+export const MAX_SAVE_SLOTS = 3;
+
+/**
+ * Total opponents in campaign mode.
+ * Fixed at 10 to match campaign chapter structure.
+ */
+export const CAMPAIGN_OPPONENT_COUNT = 10;
+
+/**
+ * localStorage key constants for debugging and development tools.
+ * All keys use 'tcg_' prefix to avoid conflicts with other applications.
+ */
+export const STORAGE_KEYS = Object.freeze({
+  /** User settings (language, volume, controller preferences) */
+  SETTINGS: 'tcg_settings',
+  /** Save slot metadata */
+  SLOT_META: 'tcg_slot_meta',
+  /** Currently active save slot */
+  ACTIVE_SLOT: 'tcg_active_slot',
+} as const);
+
 export interface SlotMeta {
   slot: SlotId;
   empty: boolean;
@@ -103,18 +135,15 @@ export const Progression = (() => {
     nextCraftedId:    'next_crafted_id',
   } as const;
 
-  /** Global keys (not per-slot) */
   const GLOBAL_KEYS = {
-    settings:   'tcg_settings',
-    slotMeta:   'tcg_slot_meta',
-    activeSlot: 'tcg_active_slot',
-  } as const;
+    settings: STORAGE_KEYS.SETTINGS,
+    slotMeta: STORAGE_KEYS.SLOT_META,
+    activeSlot: STORAGE_KEYS.ACTIVE_SLOT,
+  };
 
   const DUEL_CHECKPOINT_SUFFIX = 'duel_checkpoint';
 
-  const SAVE_VERSION   = 2;
-  const OPPONENT_COUNT = 10;
-  const SLOT_IDS: SlotId[] = [1, 2, 3];
+  const SLOT_IDS: SlotId[] = [1, 2, 3].slice(0, MAX_SAVE_SLOTS) as SlotId[];
 
   let activeSlot: SlotId | null = null;
 
@@ -201,7 +230,7 @@ export const Progression = (() => {
 
   function _defaultOpponents(): Record<number, OpponentRecord> {
     const ops: Record<number, OpponentRecord> = {};
-    for (let i = 1; i <= OPPONENT_COUNT; i++) {
+    for (let i = 1; i <= CAMPAIGN_OPPONENT_COUNT; i++) {
       ops[i] = { unlocked: i === 1, wins: 0, losses: 0 };
     }
     return ops;
@@ -597,7 +626,7 @@ function spendCoins(amount: number): boolean {
 
     if (won) {
       ops[id].wins++;
-      if (id < OPPONENT_COUNT && ops[id + 1] && !ops[id + 1].unlocked) {
+      if (id < CAMPAIGN_OPPONENT_COUNT && ops[id + 1] && !ops[id + 1].unlocked) {
         ops[id + 1].unlocked = true;
       }
     } else {
@@ -751,6 +780,10 @@ function spendCoins(amount: number): boolean {
   // ── Public API ───────────────────────────────────────────
 
   return {
+    SAVE_VERSION,
+    MAX_SAVE_SLOTS,
+    CAMPAIGN_OPPONENT_COUNT,
+    STORAGE_KEYS,
     // Quota Management (exported for external use)
     estimateStorageSize,
     checkQuotaBeforeSave,

--- a/tests/progression-constants.test.js
+++ b/tests/progression-constants.test.js
@@ -1,0 +1,71 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { Progression } from '../src/progression.js';
+
+describe('Progression Constants', () => {
+  describe('SAVE_VERSION', () => {
+    it('should be exported and accessible', () => {
+      expect(Progression.SAVE_VERSION).toBeDefined();
+      expect(typeof Progression.SAVE_VERSION).toBe('number');
+    });
+
+    it('should have expected value of 2', () => {
+      expect(Progression.SAVE_VERSION).toBe(2);
+    });
+  });
+
+  describe('MAX_SAVE_SLOTS', () => {
+    it('should be exported and accessible', () => {
+      expect(Progression.MAX_SAVE_SLOTS).toBeDefined();
+      expect(typeof Progression.MAX_SAVE_SLOTS).toBe('number');
+    });
+
+    it('should have expected value of 3', () => {
+      expect(Progression.MAX_SAVE_SLOTS).toBe(3);
+    });
+
+    it('should be positive integer', () => {
+      expect(Number.isInteger(Progression.MAX_SAVE_SLOTS)).toBe(true);
+      expect(Progression.MAX_SAVE_SLOTS).toBeGreaterThan(0);
+    });
+  });
+
+  describe('CAMPAIGN_OPPONENT_COUNT', () => {
+    it('should be exported and accessible', () => {
+      expect(Progression.CAMPAIGN_OPPONENT_COUNT).toBeDefined();
+      expect(typeof Progression.CAMPAIGN_OPPONENT_COUNT).toBe('number');
+    });
+
+    it('should have expected value of 10', () => {
+      expect(Progression.CAMPAIGN_OPPONENT_COUNT).toBe(10);
+    });
+
+    it('should be positive integer', () => {
+      expect(Number.isInteger(Progression.CAMPAIGN_OPPONENT_COUNT)).toBe(true);
+      expect(Progression.CAMPAIGN_OPPONENT_COUNT).toBeGreaterThan(0);
+    });
+  });
+
+  describe('STORAGE_KEYS', () => {
+    it('should be exported and accessible', () => {
+      expect(Progression.STORAGE_KEYS).toBeDefined();
+      expect(typeof Progression.STORAGE_KEYS).toBe('object');
+    });
+
+    it('should have SETTINGS key', () => {
+      expect(Progression.STORAGE_KEYS.SETTINGS).toBe('tcg_settings');
+    });
+
+    it('should have SLOT_META key', () => {
+      expect(Progression.STORAGE_KEYS.SLOT_META).toBe('tcg_slot_meta');
+    });
+
+    it('should have ACTIVE_SLOT key', () => {
+      expect(Progression.STORAGE_KEYS.ACTIVE_SLOT).toBe('tcg_active_slot');
+    });
+
+    it('should be frozen (immutable)', () => {
+      expect(Object.isFrozen(Progression.STORAGE_KEYS)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Exports save system constants from `progression.ts` to enable save version migrations, debugging tools, and modding support.

## Changes

**Exported Constants:**
- `SAVE_VERSION` - Current save file version (v2), documented with migration notes
- `MAX_SAVE_SLOTS` - Number of save slots (3) - standard for single-player games
- `CAMPAIGN_OPPONENT_COUNT` - Total campaign opponents (10) - matches chapter structure
- `STORAGE_KEYS` - localStorage key constants for debugging tools

**Internal Refactoring:**
- Renamed `OPPONENT_COUNT` → `CAMPAIGN_OPPONENT_COUNT` (more descriptive)
- Renamed `SLOT_IDS` array → `MAX_SAVE_SLOTS` count constant
- Replaced inline key object with exported `STORAGE_KEYS` constant
- All constants now have JSDoc documentation explaining design rationale

**Tests:**
- Added `tests/progression-constants.test.js` with 13 unit tests
- All existing progression tests continue to pass

## Why This Matters

Previously these values were module-private constants, making it impossible to:
- Build save migration tools that check version compatibility
- Create debugging tools that need to access localStorage keys
- Support modding scenarios requiring save system configuration
- Document design decisions (why 3 slots? why 10 opponents?)

## Test Results

```
✓ tests/progression-constants.test.js (13 tests)
✓ tests/progression.test.js (17 tests)
✓ tests/progression-edges.test.js (60 tests)
```

TypeScript type checking: ✓ No errors

Closes #389
