### PR TITLE
feat: centralize field dimension constants for format flexibility (#391)

### DIFF
--- a/src/ai-orchestrator.ts
+++ b/src/ai-orchestrator.ts
@@ -727,6 +727,9 @@ function _findSmartFusionChain(
   return { indices: bestChain, resultName: bestName, resultATK: bestATK, fieldZone: bestFieldZone };
 }
 
+// Minimum ATK advantage required to replace an existing monster on the field
+const MIN_ATK_ADVANTAGE = 500;
+
 function _findWeakestMonsterZone(monsters: Array<FieldCard | null>, replacementATK: number): number {
   let weakestZone = -1;
   let weakestATK = Infinity;
@@ -735,8 +738,7 @@ function _findWeakestMonsterZone(monsters: Array<FieldCard | null>, replacementA
     const fc = monsters[z];
     if (!fc) continue;
     const atk = fc.effectiveATK();
-    // Only replace if the new monster is significantly stronger (at least 500 ATK more)
-    if (atk < weakestATK && replacementATK >= atk + 500) {
+    if (atk < weakestATK && replacementATK >= atk + MIN_ATK_ADVANTAGE) {
       weakestATK = atk;
       weakestZone = z;
     }

--- a/src/react/components/ControllerFocusOverlay.tsx
+++ b/src/react/components/ControllerFocusOverlay.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'react-i18next';
+import { FIELD_RULES } from '../../rules.js';
 
 interface FocusZone {
   type: 'monster' | 'spell' | 'field-spell' | 'hand' | 'grave' | 'phase-btn' | 'direct-btn';
@@ -32,29 +33,49 @@ export function ControllerFocusOverlay({ connected, focusedZone }: Props) {
 }
 
 function getFocusPosition(focus: FocusZone): React.CSSProperties {
+  const monsterZones = FIELD_RULES.MONSTER_ZONES_PER_PLAYER as number;
+  const spellTrapZones = FIELD_RULES.SPELL_TRAP_ZONES_PER_PLAYER as number;
+  
+  // Monster zone positions: distributed from 25% to 50% of screen width
+  // Formula: leftPercent = 25 + (zoneIndex * (50 - 25) / (monsterZones - 1))
+  // For 5 zones: 25%, 31.25%, 37.5%, 43.75%, 50%
+  if (focus.type === 'monster') {
+    const leftPercent = monsterZones === 1 
+      ? 37.5 
+      : 25 + (focus.zone * (50 - 25) / (monsterZones - 1));
+    const topPercent = focus.owner === 'player' ? 52 : 28;
+    return { left: `${leftPercent}%`, top: `${topPercent}%` };
+  }
+  
+  // Spell/trap zone positions: vertical column on right side
+  // Player: top to bottom (45% to 73%), Opponent: top to bottom (10% to 38%)
+  if (focus.type === 'spell') {
+    const playerTopStart = 45;
+    const playerTopEnd = 73;
+    const opponentTopStart = 10;
+    const opponentTopEnd = 38;
+    
+    if (spellTrapZones === 1) {
+      const topPercent = focus.owner === 'player' ? 59 : 24;
+      return { left: '65%', top: `${topPercent}%` };
+    }
+    
+    const topPercent = focus.owner === 'player'
+      ? playerTopStart + (focus.zone * (playerTopEnd - playerTopStart) / (spellTrapZones - 1))
+      : opponentTopStart + (focus.zone * (opponentTopEnd - opponentTopStart) / (spellTrapZones - 1));
+    
+    return { left: '65%', top: `${topPercent}%` };
+  }
+  
+  // Hand positions: horizontal row at bottom
+  // 6 cards from 15% to 65% left
+  if (focus.type === 'hand' && focus.owner === 'player') {
+    const handLeftPercent = 15 + (focus.zone * (65 - 15) / 5);
+    return { left: `${handLeftPercent}%`, bottom: '8%' };
+  }
+  
+  // Fixed positions for other zones
   const positions: Record<string, React.CSSProperties> = {
-    'monster-player-0': { left: '25%', top: '52%' },
-    'monster-player-1': { left: '37.5%', top: '52%' },
-    'monster-player-2': { left: '50%', top: '52%' },
-    'monster-opponent-0': { left: '25%', top: '28%' },
-    'monster-opponent-1': { left: '37.5%', top: '28%' },
-    'monster-opponent-2': { left: '50%', top: '28%' },
-    'spell-player-0': { left: '65%', top: '45%' },
-    'spell-player-1': { left: '65%', top: '52%' },
-    'spell-player-2': { left: '65%', top: '59%' },
-    'spell-player-3': { left: '65%', top: '66%' },
-    'spell-player-4': { left: '65%', top: '73%' },
-    'spell-opponent-0': { left: '65%', top: '10%' },
-    'spell-opponent-1': { left: '65%', top: '17%' },
-    'spell-opponent-2': { left: '65%', top: '24%' },
-    'spell-opponent-3': { left: '65%', top: '31%' },
-    'spell-opponent-4': { left: '65%', top: '38%' },
-    'hand-player-0': { left: '15%', bottom: '8%' },
-    'hand-player-1': { left: '25%', bottom: '8%' },
-    'hand-player-2': { left: '35%', bottom: '8%' },
-    'hand-player-3': { left: '45%', bottom: '8%' },
-    'hand-player-4': { left: '55%', bottom: '8%' },
-    'hand-player-5': { left: '65%', bottom: '8%' },
     'phase-btn': { right: '12%', top: '50%' },
     'direct-btn-player-0': { left: '37.5%', top: '40%' },
     'grave-player': { left: '5%', top: '70%' },

--- a/src/react/screens/GameScreen.tsx
+++ b/src/react/screens/GameScreen.tsx
@@ -9,6 +9,7 @@ import { useHapticFeedback } from '../hooks/useHapticFeedback.js';
 import { cleanupAttackAnimations } from '../hooks/useAttackAnimation.js';
 import RaceIcon from '../components/RaceIcon.js';
 import { ControllerFocusOverlay } from '../components/ControllerFocusOverlay.js';
+import { FIELD_RULES } from '../../rules.js';
 
 import { OpponentField }   from './game/OpponentField.js';
 import { PlayerField }     from './game/PlayerField.js';
@@ -101,7 +102,7 @@ export default function GameScreen() {
       },
       onRB: () => {
         setControllerFocus(prev => {
-          if (prev && prev.type === 'hand' && prev.owner === 'player' && prev.zone < 5) {
+          if (prev && prev.type === 'hand' && prev.owner === 'player' && prev.zone < FIELD_RULES.HAND_CARDS_INITIAL) {
             return { ...prev, zone: prev.zone + 1 };
           }
           return prev;
@@ -113,31 +114,35 @@ export default function GameScreen() {
 
           const key = `${prev.type}-${prev.owner}`;
 
+          const maxMonsterZoneIndex = FIELD_RULES.MONSTER_ZONES_PER_PLAYER - 1;
+          
           if (prev.type === 'monster' && prev.owner === 'player') {
             if (direction === 'left' && prev.zone > 0) return { ...prev, zone: prev.zone - 1 };
-            if (direction === 'right' && prev.zone < 2) return { ...prev, zone: prev.zone + 1 };
+            if (direction === 'right' && prev.zone < maxMonsterZoneIndex) return { ...prev, zone: prev.zone + 1 };
             if (direction === 'up') return { type: 'monster', owner: 'opponent', zone: prev.zone };
             if (direction === 'down') return { type: 'spell', owner: 'player', zone: 0 };
           }
 
           if (prev.type === 'monster' && prev.owner === 'opponent') {
             if (direction === 'left' && prev.zone > 0) return { ...prev, zone: prev.zone - 1 };
-            if (direction === 'right' && prev.zone < 2) return { ...prev, zone: prev.zone + 1 };
+            if (direction === 'right' && prev.zone < maxMonsterZoneIndex) return { ...prev, zone: prev.zone + 1 };
             if (direction === 'up') return { type: 'spell', owner: 'opponent', zone: 0 };
             if (direction === 'down') return { type: 'monster', owner: 'player', zone: prev.zone };
           }
 
+          const maxSpellTrapZoneIndex = FIELD_RULES.SPELL_TRAP_ZONES_PER_PLAYER - 1;
+          
           if (prev.type === 'spell' && prev.owner === 'player') {
             if (direction === 'up' && prev.zone > 0) return { ...prev, zone: prev.zone - 1 };
             if (direction === 'up') return { type: 'monster', owner: 'player', zone: 0 };
-            if (direction === 'down' && prev.zone < 4) return { ...prev, zone: prev.zone + 1 };
+            if (direction === 'down' && prev.zone < maxSpellTrapZoneIndex) return { ...prev, zone: prev.zone + 1 };
             if (direction === 'down') return { type: 'grave', owner: 'player', zone: 0 };
             if (direction === 'left') return { type: 'grave', owner: 'player', zone: 0 };
             if (direction === 'right') return { type: 'field-spell', owner: 'player', zone: 0 };
           }
 
           if (prev.type === 'spell' && prev.owner === 'opponent') {
-            if (direction === 'up' && prev.zone < 4) return { ...prev, zone: prev.zone + 1 };
+            if (direction === 'up' && prev.zone < maxSpellTrapZoneIndex) return { ...prev, zone: prev.zone + 1 };
             if (direction === 'down' && prev.zone > 0) return { ...prev, zone: prev.zone - 1 };
             if (direction === 'up') return { type: 'field-spell', owner: 'opponent', zone: 0 };
             if (direction === 'down') return { type: 'monster', owner: 'opponent', zone: 0 };
@@ -145,10 +150,12 @@ export default function GameScreen() {
             if (direction === 'right') return { type: 'field-spell', owner: 'opponent', zone: 0 };
           }
 
+          const maxMonsterZoneIndexForHand = Math.min(2, FIELD_RULES.MONSTER_ZONES_PER_PLAYER - 1);
+          
           if (prev.type === 'hand' && prev.owner === 'player') {
             if (direction === 'left' && prev.zone > 0) return { ...prev, zone: prev.zone - 1 };
-            if (direction === 'right' && prev.zone < 5) return { ...prev, zone: prev.zone + 1 };
-            if (direction === 'up') return { type: 'monster', owner: 'player', zone: Math.min(prev.zone, 2) };
+            if (direction === 'right' && prev.zone < FIELD_RULES.HAND_CARDS_INITIAL) return { ...prev, zone: prev.zone + 1 };
+            if (direction === 'up') return { type: 'monster', owner: 'player', zone: Math.min(prev.zone, maxMonsterZoneIndexForHand) };
             if (direction === 'down') return { type: 'phase-btn', owner: 'player', zone: 0 };
           }
 

--- a/src/react/screens/game/OpponentField.tsx
+++ b/src/react/screens/game/OpponentField.tsx
@@ -5,10 +5,11 @@ import { useSelection } from '../../contexts/SelectionContext.js';
 import { FieldCardComponent }     from '../../components/FieldCardComponent.js';
 import { FieldSpellTrapComponent } from '../../components/FieldSpellTrapComponent.js';
 import { meetsEquipRequirement }  from '../../../types.js';
+import { FIELD_RULES } from '../../../rules.js';
 import type { FieldCard } from '../../../field.js';
 import type { FieldSpellTrap } from '../../../field.js';
 
-const FIELD_ZONES = [0, 1, 2, 3, 4] as const;
+const FIELD_ZONES = Array.from({ length: FIELD_RULES.MONSTER_ZONES_PER_PLAYER }, (_, i) => i);
 
 export function OpponentField() {
   const { gameState, gameRef } = useGame();

--- a/src/react/screens/game/PlayerField.tsx
+++ b/src/react/screens/game/PlayerField.tsx
@@ -7,10 +7,11 @@ import { FieldCardComponent }     from '../../components/FieldCardComponent.js';
 import { FieldSpellTrapComponent } from '../../components/FieldSpellTrapComponent.js';
 import { CardType, meetsEquipRequirement } from '../../../types.js';
 import { checkFusion, CARD_DB } from '../../../cards.js';
+import { FIELD_RULES } from '../../../rules.js';
 import type { FieldCard } from '../../../field.js';
 import type { FieldSpellTrap } from '../../../field.js';
 
-const FIELD_ZONES = [0, 1, 2, 3, 4] as const;
+const FIELD_ZONES = Array.from({ length: FIELD_RULES.MONSTER_ZONES_PER_PLAYER }, (_, i) => i);
 
 interface Props {
   showDirect:    boolean;

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -4,13 +4,27 @@
 // rules.json inside a .tcg archive.
 // ============================================================
 
+/**
+ * Field dimension constants defining the game board layout.
+ * Standard Yu-Gi-Oh TCG uses 5 monster zones and 5 spell/trap zones.
+ * Speed Duel format uses 3 monster zones.
+ */
+export const FIELD_RULES = {
+  MONSTER_ZONES_PER_PLAYER: 5,
+  SPELL_TRAP_ZONES_PER_PLAYER: 5,
+  HAND_CARDS_INITIAL: 5,
+  DECK_MIN_MAIN: 40,
+  DECK_MAX_MAIN: 60,
+  DECK_MAX_EXTRA: 15,
+} as const;
+
 export const GAME_RULES = {
   startingLP: 8000,
   maxLP: 99999,
   handLimitDraw: 10,
   handLimitEnd: 8,
-  fieldZones: 5,
-  maxDeckSize: 40,
+  fieldZones: FIELD_RULES.MONSTER_ZONES_PER_PLAYER as number,
+  maxDeckSize: FIELD_RULES.DECK_MIN_MAIN as number,
   maxCardCopies: 3,
   drawPerTurn: 1,
   handRefillSize: 5,


### PR DESCRIPTION
## Summary

Centralizes field dimension constants and removes hard-coded magic numbers for the 5-zone monster field layout. This enables support for alternate formats (e.g., Speed Duel with 3 zones) and improves code maintainability.

## Changes

### 1. New `FIELD_RULES` Constant (`src/rules.ts`)
- Moved field dimensions to a dedicated `FIELD_RULES` constant with documentation
- Includes: `MONSTER_ZONES_PER_PLAYER`, `SPELL_TRAP_ZONES_PER_PLAYER`, `HAND_CARDS_INITIAL`, deck size limits
- Documents standard TCG format (5 zones) and Speed Duel format (3 zones)
- `GAME_RULES.fieldZones` now references `FIELD_RULES.MONSTER_ZONES_PER_PLAYER`

### 2. Programmatic UI Positioning (`src/react/components/ControllerFocusOverlay.tsx`)
- Replaced hard-coded position percentages with dynamic calculations
- Monster zones: Formula `25 + (zoneIndex * 25 / (zones - 1))` distributes zones from 25% to 50%
- Spell/trap zones: Vertical distribution with configurable zone count
- Handles edge case of single-zone formats

### 3. Field Components Updated (`src/react/screens/game/PlayerField.tsx`, `OpponentField.tsx`)
- `FIELD_ZONES` array now generated from `FIELD_RULES.MONSTER_ZONES_PER_PLAYER`
- Zone rendering is now format-aware

### 4. Keyboard Navigation Updated (`src/react/screens/GameScreen.tsx`)
- Monster zone bounds use `FIELD_RULES.MONSTER_ZONES_PER_PLAYER`
- Spell/trap zone bounds use `FIELD_RULES.SPELL_TRAP_ZONES_PER_PLAYER`
- Hand zone bounds use `FIELD_RULES.HAND_CARDS_INITIAL`

### 5. AI ATK Threshold Documented (`src/ai-orchestrator.ts`)
- Extracted `500` magic number to `MIN_ATK_ADVANTAGE` constant
- Documents minimum ATK gain required for monster zone replacement

## Benefits

1. **Format flexibility**: Can support alternate formats (Speed Duel, custom rules) by changing `FIELD_RULES`
2. **Reduced coupling**: UI positioning no longer assumes 5 zones, calculates positions dynamically
3. **Better maintainability**: Single source of truth for field dimensions
4. **Documentation**: Constants explain the rationale behind field sizes

## Testing

- All modified files pass TypeScript type checking
- Pre-existing test failures are unrelated to these changes (jsdom, crypto tests)
- Build issue in vite config is pre-existing and unrelated

## Future Work

To fully support alternate formats, consider:
- Adding format selection in game setup
- TCG pack validation for zone count
- UI layout adjustments for non-5-zone formats

Closes #391
