### PR TITLE
fix: change CAMPAIGN_DATA from let to const (#394)

### DIFF
--- a/src/campaign.ts
+++ b/src/campaign.ts
@@ -1,9 +1,5 @@
 import type { CampaignData } from './campaign-types.js';
 
-export let CAMPAIGN_DATA: CampaignData | null = null;
+export const CAMPAIGN_DATA: CampaignData | null = null;
 export const CAMPAIGN_IMAGES = new Map<string, string>();  // path → blob URL
 export const CAMPAIGN_I18N   = new Map<string, Record<string, string>>(); // lang → KV
-
-export function setCampaignData(data: CampaignData): void {
-  CAMPAIGN_DATA = data;
-}


### PR DESCRIPTION
## Summary

Fix for issue #394 - Changes `CAMPAIGN_DATA` declaration from `let` to `const` in `src/campaign.ts` for consistency with other constants in the same file.

## Changes

- Changed `export let CAMPAIGN_DATA` to `export const CAMPAIGN_DATA` (line 3)
- Removed unused `setCampaignData()` function (lines 7-8) - this function was never called anywhere in the codebase
- File reduced from 9 lines to 5 lines

## Verification

- ✅ TypeScript compilation passes (`generate:engine-dts` succeeded)
- ✅ No new test failures introduced
- ✅ Only one file modified: `src/campaign.ts`

## Impact

- **Code consistency**: Now matches the pattern used by `CAMPAIGN_IMAGES` and `CAMPAIGN_I18N`
- **Safety**: Compile-time protection against accidental reassignment
- **No breaking changes**: The `setCampaignData` function was unused, so removing it has no impact

---

Closes #394
