### PR TITLE
fix: standardize 'Opponent' naming (#395)

### DIFF
--- a/docs/ai-system.md
+++ b/docs/ai-system.md
@@ -288,13 +288,13 @@ function _activateSpells(deps, ctx) {
 
 ```typescript
 interface AISpellRule {
-  when: 'always' | 'oppLP>N' | 'selfLP<N';
+  when: 'always' | 'opponentLP>N' | 'selfLP<N';
   threshold?: number;
 }
 
 // Example: Activate only if opponent LP > 3000
 spellRules: {
-  'strong_nuke': { when: 'oppLP>N', threshold: 3000 }
+  'strong_nuke': { when: 'opponentLP>N', threshold: 3000 }
 }
 ```
 

--- a/docs/engine-core.md
+++ b/docs/engine-core.md
@@ -483,7 +483,7 @@ interface UICallbacks {
   playSfx?:                   (sfxId: string) => void;
   showDamageNumber?:          (amount: number, owner: Owner) => void;
   onDraw?:                    (owner: Owner, count: number) => void;
-  onDuelEnd?:                 (result, oppId, stats: DuelStats) => void;
+  onDuelEnd?:                 (result, opponentId, stats: DuelStats) => void;
   showCoinToss?:              (playerGoesFirst: boolean) => Promise<void>;
   selectFromDeck?:            (cards: CardData[]) => Promise<CardData>;
 }

--- a/docs/ui-architecture.md
+++ b/docs/ui-architecture.md
@@ -691,7 +691,7 @@ interface UICallbacks {
   // Duel lifecycle
   onDuelEnd?: (
     result: 'victory' | 'defeat',
-    oppId: number | null,
+    opponentId: number | null,
     stats: DuelStats,
   ) => void;
 }

--- a/src/ai-behaviors.ts
+++ b/src/ai-behaviors.ts
@@ -158,7 +158,7 @@ function evaluateSpellRule(rule: AISpellRule, playerLP: number, aiLP: number): b
   const t = rule.threshold ?? 0;
   switch (rule.when) {
     case 'always':   return true;
-    case 'oppLP>N':  return playerLP > t;
+    case 'opponentLP>N':  return playerLP > t;
     case 'selfLP<N': return aiLP < t;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -176,7 +176,7 @@ export type AIPositionStrategy = 'smart' | 'aggressive' | 'defensive';
 export type AIBattleStrategy   = 'smart' | 'aggressive' | 'conservative';
 
 export interface AISpellRule {
-  when: 'always' | 'oppLP>N' | 'selfLP<N';
+  when: 'always' | 'opponentLP>N' | 'selfLP<N';
   threshold?: number;
 }
 
@@ -318,7 +318,7 @@ export interface UICallbacks {
   playSfx?:             (sfxId: string) => void;
   showDamageNumber?:    (amount: number, owner: Owner) => void;
   onDraw?:              (owner: Owner, count: number) => void;
-  onDuelEnd?:           (result: 'victory' | 'defeat', oppId: number | null, stats: DuelStats) => void;
+  onDuelEnd?:           (result: 'victory' | 'defeat', opponentId: number | null, stats: DuelStats) => void;
   showCoinToss?:        (playerGoesFirst: boolean) => Promise<void>;
   selectFromDeck?:      (cards: CardData[]) => Promise<CardData>;
 }

--- a/tests/ai-behaviors.test.js
+++ b/tests/ai-behaviors.test.js
@@ -339,18 +339,18 @@ describe('shouldActivateNormalSpell', () => {
       expect(shouldActivateNormalSpell('test-always', behavior, 8000, 8000)).toBe(true);
     });
 
-    it('activates (oppLP>N) when player LP exceeds threshold', () => {
+    it('activates (opponentLP>N) when player LP exceeds threshold', () => {
       const behavior = {
         ...resolveAIBehavior('default'),
-        spellRules: { 'test-opp': { when: 'oppLP>N', threshold: 800 } },
+        spellRules: { 'test-opp': { when: 'opponentLP>N', threshold: 800 } },
       };
       expect(shouldActivateNormalSpell('test-opp', behavior, 1000, 8000)).toBe(true);
     });
 
-    it('does not activate (oppLP>N) when player LP is at or below threshold', () => {
+    it('does not activate (opponentLP>N) when player LP is at or below threshold', () => {
       const behavior = {
         ...resolveAIBehavior('default'),
-        spellRules: { 'test-opp': { when: 'oppLP>N', threshold: 800 } },
+        spellRules: { 'test-opp': { when: 'opponentLP>N', threshold: 800 } },
       };
       expect(shouldActivateNormalSpell('test-opp', behavior, 800, 8000)).toBe(false);
       expect(shouldActivateNormalSpell('test-opp', behavior, 500, 8000)).toBe(false);
@@ -449,21 +449,21 @@ describe('evaluateSpellRule (via shouldActivateNormalSpell)', () => {
     });
   });
 
-  describe('condition: oppLP>N', () => {
+  describe('condition: opponentLP>N', () => {
     it('returns true when playerLP > threshold', () => {
-      const b = behaviorWithRule({ when: 'oppLP>N', threshold: 4000 });
+      const b = behaviorWithRule({ when: 'opponentLP>N', threshold: 4000 });
       expect(shouldActivateNormalSpell('TEST', b, 4001, 8000)).toBe(true);
       expect(shouldActivateNormalSpell('TEST', b, 8000, 8000)).toBe(true);
     });
 
     it('returns false when playerLP <= threshold', () => {
-      const b = behaviorWithRule({ when: 'oppLP>N', threshold: 4000 });
+      const b = behaviorWithRule({ when: 'opponentLP>N', threshold: 4000 });
       expect(shouldActivateNormalSpell('TEST', b, 4000, 8000)).toBe(false);
       expect(shouldActivateNormalSpell('TEST', b, 3000, 8000)).toBe(false);
     });
 
     it('uses 0 as default threshold when threshold is undefined', () => {
-      const b = behaviorWithRule({ when: 'oppLP>N' });
+      const b = behaviorWithRule({ when: 'opponentLP>N' });
       // playerLP > 0
       expect(shouldActivateNormalSpell('TEST', b, 1, 8000)).toBe(true);
       expect(shouldActivateNormalSpell('TEST', b, 0, 8000)).toBe(false);


### PR DESCRIPTION
## Summary

Fixes inconsistent abbreviation of "Opponent" vs "Opp" throughout the codebase by standardizing on the full word "Opponent" for better clarity and discoverability.

## Changes

### Code Changes
- **UICallbacks.onDuelEnd parameter**: `oppId` → `opponentId` (src/types.ts)
- **AISpellRule.when**: `'oppLP>N'` → `'opponentLP>N'` (src/types.ts, src/ai-behaviors.ts)

### Test Updates
- Updated test cases in tests/ai-behaviors.test.js
- All 80 AI behavior tests pass ✅

### Documentation Updates
- docs/ai-system.md
- docs/engine-core.md  
- docs/ui-architecture.md

## Test Results
- ✅ AI behavior tests: 80/80 passing
- ✅ No TypeScript errors for renamed identifiers
- ℹ️ Pre-existing build issues exist but are unrelated to these changes

## Note on External Package

The `TcgTrapTrigger` type (which includes `'onOppCardEffect'`) is defined in the external `@wynillo/tcg-format` package and is not modified here. A companion PR in that repository would be needed for complete standardization.

Closes #395
