### PR TITLE
fix: Consistent FieldCard property naming in EffectContext (#396)

### DIFF
--- a/docs/effect-system.md
+++ b/docs/effect-system.md
@@ -146,11 +146,11 @@ type ValueExpr = number | {
 interface EffectContext {
   engine:       GameEngine;
   owner:        Owner;          // 'player' | 'opponent'
-  targetFC?:    FieldCard;      // Target FieldCard (targeted spells/traps)
+  target?:      FieldCard;      // Target FieldCard (targeted spells/traps)
   targetCard?:  CardData;       // Target CardData (fromGrave spells)
   attacker?:    FieldCard;      // Attacker (onAttack traps)
   defender?:    FieldCard;      // Defender
-  summonedFC?:  FieldCard;      // Just summoned monster
+  summoned?:    FieldCard;      // Just summoned monster
 }
 ```
 
@@ -394,7 +394,7 @@ function canPayCost(block: CardEffectBlock, ctx: PureEffectCtx): boolean {
   if (cost.lp && ctx.state[ctx.owner].lp < cost.lp) return false;
   if (cost.lpHalf && ctx.state[ctx.owner].lp <= 1) return false;
   if (cost.discard && ctx.state[ctx.owner].hand.length < cost.discard) return false;
-  if (cost.tributeSelf && !ctx.targetFC) return false;
+  if (cost.tributeSelf && !ctx.target) return false;
   
   return true;
 }
@@ -606,15 +606,15 @@ for (const block of blocks) {
 Effect handlers have access to:
 - `ctx.attacker` — attacking FieldCard
 - `ctx.defender` — defending FieldCard
-- `ctx.summonedFC` — just summoned FieldCard
-- `ctx.targetFC` — targeted FieldCard (for targeted Spells/Traps)
+- `ctx.summoned` — just summoned FieldCard
+- `ctx.target` — targeted FieldCard (for targeted Spells/Traps)
 - `ctx.targetCard` — targeted CardData (for fromGrave Spells)
 
 **Example **(Targeted Spell)
 ```typescript
 registerEffect('destroyMonster', (action, ctx) => {
-  if (!ctx.targetFC) return {};
-  return { destroySummoned: true }; // Engine destroys ctx.targetFC
+  if (!ctx.target) return {};
+  return { destroySummoned: true }; // Engine destroys ctx.target
 });
 ```
 

--- a/scripts/generate-engine-dts.js
+++ b/scripts/generate-engine-dts.js
@@ -196,11 +196,11 @@ declare global {
   interface EffectContext {
     engine:       any;
     owner:        Owner;
-    targetFC?:    any;
+    target?:      any;
     targetCard?:  CardData;
     attacker?:    any;
     defender?:    any;
-    summonedFC?:  any;
+    summoned?:    any;
   }
 
   // ── TriggerBus Context ────────────────────────────────────────

--- a/src/effect-registry.ts
+++ b/src/effect-registry.ts
@@ -63,8 +63,8 @@ function resolveValue(expr: ValueExpr, ctx: PureEffectCtx): number {
     const raw = ctx.attacker.effectiveATK() * expr.multiply;
     return expr.round === 'floor' ? Math.floor(raw) : Math.ceil(raw);
   }
-  if (expr.from === 'summoned.atk' && ctx.summonedFC) {
-    const raw = (ctx.summonedFC.card.atk ?? 0) * expr.multiply;
+  if (expr.from === 'summoned.atk' && ctx.summoned) {
+    const raw = (ctx.summoned.card.atk ?? 0) * expr.multiply;
     return expr.round === 'floor' ? Math.floor(raw) : Math.ceil(raw);
   }
   return 0;
@@ -78,9 +78,9 @@ function resolveTarget(target: 'opponent' | 'self', owner: Owner): Owner {
 function resolveStatTarget(target: StatTarget, ctx: PureEffectCtx): FieldCard | null {
   if (target === 'attacker')    return ctx.attacker ?? null;
   if (target === 'defender')    return ctx.defender ?? null;
-  if (target === 'summonedFC')  return ctx.summonedFC ?? null;
-  if (target === 'ownMonster')  return ctx.targetFC ?? null;
-  if (target === 'oppMonster')  return ctx.targetFC ?? null;
+  if (target === 'summonedFC')  return ctx.summoned ?? null;
+  if (target === 'ownMonster')  return ctx.target ?? null;
+  if (target === 'oppMonster')  return ctx.target ?? null;
   return null;
 }
 
@@ -523,8 +523,8 @@ const IMPL: Record<string, InternalImpl> = {
   },
 
   destroySummonedIf(desc: { minAtk: number }, ctx: PureEffectCtx) {
-    if (ctx.summonedFC && ctx.summonedFC.card.atk !== undefined && ctx.summonedFC.card.atk >= desc.minAtk) {
-      ctx.log(`Trap! ${ctx.summonedFC.card.name} is destroyed!`);
+    if (ctx.summoned && ctx.summoned.card.atk !== undefined && ctx.summoned.card.atk >= desc.minAtk) {
+      ctx.log(`Trap! ${ctx.summoned.card.name} is destroyed!`);
       return { destroySummoned: true };
     }
     return {};
@@ -748,11 +748,11 @@ const IMPL: Record<string, InternalImpl> = {
   },
 
   setFaceDown(_desc: unknown, ctx: PureEffectCtx) {
-    if (!ctx.targetFC) return {};
-    ctx.targetFC.faceDown = true;
-    ctx.targetFC.position = 'def';
-    ctx.targetFC.hasFlipSummoned = false;
-    ctx.log(`${ctx.targetFC.card.name} was set face-down!`);
+    if (!ctx.target) return {};
+    ctx.target.faceDown = true;
+    ctx.target.position = 'def';
+    ctx.target.hasFlipSummoned = false;
+    ctx.log(`${ctx.target.card.name} was set face-down!`);
     return {};
   },
 
@@ -883,11 +883,11 @@ export function makePureCtx(ctx: EffectContext): PureEffectCtx {
   return {
     state,
     owner:      ctx.owner,
-    targetFC:   ctx.targetFC,
+    target:     ctx.target,
     targetCard: ctx.targetCard,
     attacker:   ctx.attacker,
     defender:   ctx.defender,
-    summonedFC: ctx.summonedFC,
+    summoned:   ctx.summoned,
     log:               (msg) => engine.addLog(msg),
     damage:            (owner, amount) => engine.dealDamage(owner, amount),
     heal:              (owner, amount) => engine.gainLP(owner, amount),

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1281,7 +1281,7 @@ export class GameEngine {
         EchoesOfSanguo.log('EFFECT', `${targetInfo.card.name} cannot be targeted by effects – target ignored.`, '#fa0');
         this.addLog(`${targetInfo.card.name} cannot be targeted by effects!`);
       } else {
-        ctx.targetFC = targetInfo;
+        ctx.target = targetInfo;
       }
     } else if(targetInfo && typeof targetInfo === 'object' && 'id' in targetInfo){
       ctx.targetCard = targetInfo as CardData;
@@ -1297,7 +1297,7 @@ export class GameEngine {
       ctx.attacker = args[0];
       ctx.defender = args[1];
     } else if(trapTrigger === 'onOpponentSummon' || trapTrigger === 'onAnySummon'){
-      ctx.summonedFC = args[0];
+      ctx.summoned = args[0];
     } else if(trapTrigger === 'onOpponentTrap'){
       ctx.attacker = args[0];
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,22 +68,22 @@ export function isEquipmentType(type: CardType): boolean {
 export interface EffectContext {
   engine:       GameEngine;
   owner:        Owner;
-  targetFC?:    FieldCard;   // targeted FieldCard (targeted spells/traps)
+  target?:      FieldCard;   // targeted FieldCard (targeted spells/traps)
   targetCard?:  CardData;    // targeted CardData (fromGrave spells)
   attacker?:    FieldCard;   // attacking FieldCard (onAttack traps)
   defender?:    FieldCard;
-  summonedFC?:  FieldCard;   // FieldCard just summoned (onOpponentSummon traps)
+  summoned?:    FieldCard;   // FieldCard just summoned (onOpponentSummon traps)
   abortSignal?: AbortSignal; // for timeout/step-limit cancellation
 }
 
 export interface PureEffectCtx {
   state:        GameState;
   owner:        Owner;
-  targetFC?:    FieldCard;
+  target?:      FieldCard;
   targetCard?:  CardData;
   attacker?:    FieldCard;
   defender?:    FieldCard;
-  summonedFC?:  FieldCard;
+  summoned?:    FieldCard;
   log(msg: string): void;
   damage(owner: Owner, amount: number): void;
   heal(owner: Owner, amount: number): void;

--- a/tests/effect-registry-edges.test.js
+++ b/tests/effect-registry-edges.test.js
@@ -386,7 +386,7 @@ describe('permAtkBonus edge cases', () => {
     const e = mockEngine();
     await executeEffectBlock(
       { trigger: 'onSummon', actions: [{ type: 'permAtkBonus', target: 'ownMonster', value: 300 }] },
-      ctx(e, 'player', { targetFC: target }),
+      ctx(e, 'player', { target: target }),
     );
     expect(target.permATKBonus).toBe(300);
   });
@@ -396,7 +396,7 @@ describe('permAtkBonus edge cases', () => {
     const e = mockEngine();
     await executeEffectBlock(
       { trigger: 'onSummon', actions: [{ type: 'permAtkBonus', target: 'ownMonster', value: 300, filter: { attr: 'dark' } }] },
-      ctx(e, 'player', { targetFC: target }),
+      ctx(e, 'player', { target: target }),
     );
     expect(target.permATKBonus).toBe(500);
   });
@@ -784,7 +784,7 @@ describe('permAtkBonus — card without attribute and filter set', () => {
     const e = mockEngine();
     await executeEffectBlock(
       { trigger: 'onSummon', actions: [{ type: 'permAtkBonus', target: 'ownMonster', value: 400, filter: { attr: 'fire' } }] },
-      ctx(e, 'player', { targetFC: target }),
+      ctx(e, 'player', { target: target }),
     );
     expect(target.permATKBonus).toBe(0);
   });
@@ -804,7 +804,7 @@ describe('tempDefBonus — null target', () => {
   it('does nothing when target cannot be resolved', async () => {
     const e = mockEngine();
     await executeEffectBlock(
-      { trigger: 'onSummon', actions: [{ type: 'tempDefBonus', target: 'summoned', value: 200 }] },
+      { trigger: 'onSummon', actions: [{ type: 'tempDefBonus', target: 'summonedFC', value: 200 }] },
       ctx(e),
     );
   });
@@ -816,7 +816,7 @@ describe('resolveStatTarget — oppMonster via targetFC', () => {
     const e = mockEngine();
     await executeEffectBlock(
       { trigger: 'onSummon', actions: [{ type: 'permAtkBonus', target: 'oppMonster', value: -200 }] },
-      ctx(e, 'player', { targetFC: target }),
+      ctx(e, 'player', { target: target }),
     );
     expect(target.permATKBonus).toBe(-200);
   });

--- a/tests/effect-registry-edges.test.js
+++ b/tests/effect-registry-edges.test.js
@@ -62,7 +62,7 @@ describe('resolveValue edge cases', () => {
     expect(e.dealDamage).toHaveBeenCalledWith('opponent', 0);
   });
 
-  it('returns 0 when summoned.atk is used but summonedFC is missing', async () => {
+  it('returns 0 when summoned.atk is used but summoned is missing', async () => {
     const e = mockEngine();
     await executeEffectBlock(
       { trigger: 'onSummon', actions: [{ type: 'dealDamage', target: 'opponent', value: { from: 'summoned.atk', multiply: 1, round: 'floor' } }] },
@@ -84,10 +84,10 @@ describe('resolveValue edge cases', () => {
 
   it('handles summoned monster with undefined atk as 0', async () => {
     const e = mockEngine();
-    const summonedFC = { card: {} }; // atk is undefined
+    const summoned = { card: {} }; // atk is undefined
     await executeEffectBlock(
       { trigger: 'onSummon', actions: [{ type: 'dealDamage', target: 'opponent', value: { from: 'summoned.atk', multiply: 2, round: 'floor' } }] },
-      ctx(e, 'player', { summonedFC }),
+      ctx(e, 'player', { summoned }),
     );
     expect(e.dealDamage).toHaveBeenCalledWith('opponent', 0);
   });
@@ -350,7 +350,7 @@ describe('reviveFromGrave edge cases', () => {
 });
 
 describe('destroySummonedIf edge cases', () => {
-  it('does not destroy when summonedFC is missing', async () => {
+  it('does not destroy when summoned is missing', async () => {
     const e = mockEngine();
     const signal = await executeEffectBlock(
       { trigger: 'onOpponentSummon', actions: [{ type: 'destroySummonedIf', minAtk: 1000 }] },
@@ -360,21 +360,21 @@ describe('destroySummonedIf edge cases', () => {
   });
 
   it('does not destroy when atk is exactly at threshold', async () => {
-    const summonedFC = { card: { name: 'Exact', atk: 1000 } };
+    const summoned = { card: { name: 'Exact', atk: 1000 } };
     const e = mockEngine();
     const signal = await executeEffectBlock(
       { trigger: 'onOpponentSummon', actions: [{ type: 'destroySummonedIf', minAtk: 1000 }] },
-      ctx(e, 'player', { summonedFC }),
+      ctx(e, 'player', { summoned }),
     );
     expect(signal.destroySummoned).toBe(true);
   });
 
   it('does not destroy when atk is undefined', async () => {
-    const summonedFC = { card: { name: 'NoAtk' } };
+    const summoned = { card: { name: 'NoAtk' } };
     const e = mockEngine();
     const signal = await executeEffectBlock(
       { trigger: 'onOpponentSummon', actions: [{ type: 'destroySummonedIf', minAtk: 0 }] },
-      ctx(e, 'player', { summonedFC }),
+      ctx(e, 'player', { summoned }),
     );
     expect(signal.destroySummoned).toBeUndefined();
   });
@@ -804,7 +804,7 @@ describe('tempDefBonus — null target', () => {
   it('does nothing when target cannot be resolved', async () => {
     const e = mockEngine();
     await executeEffectBlock(
-      { trigger: 'onSummon', actions: [{ type: 'tempDefBonus', target: 'summonedFC', value: 200 }] },
+      { trigger: 'onSummon', actions: [{ type: 'tempDefBonus', target: 'summoned', value: 200 }] },
       ctx(e),
     );
   });
@@ -825,10 +825,10 @@ describe('resolveStatTarget — oppMonster via targetFC', () => {
 describe('summoned.atk — ceil rounding', () => {
   it('uses ceil rounding for summoned.atk value expression', async () => {
     const e = mockEngine();
-    const summonedFC = { card: { atk: 1001 } };
+    const summoned = { card: { atk: 1001 } };
     await executeEffectBlock(
       { trigger: 'onOpponentSummon', actions: [{ type: 'dealDamage', target: 'opponent', value: { from: 'summoned.atk', multiply: 0.5, round: 'ceil' } }] },
-      ctx(e, 'player', { summonedFC }),
+      ctx(e, 'player', { summoned }),
     );
     expect(e.dealDamage).toHaveBeenCalledWith('opponent', 501);
   });
@@ -894,11 +894,11 @@ describe('passive effect runtime execution', () => {
 
 describe('destroySummonedIf — atk is 0 with minAtk 0', () => {
   it('destroys when atk is 0 and minAtk is 0 (0 >= 0)', async () => {
-    const summonedFC = { card: { name: 'ZeroAtk', atk: 0 } };
+    const summoned = { card: { name: 'ZeroAtk', atk: 0 } };
     const e = mockEngine();
     const signal = await executeEffectBlock(
       { trigger: 'onOpponentSummon', actions: [{ type: 'destroySummonedIf', minAtk: 0 }] },
-      ctx(e, 'player', { summonedFC }),
+      ctx(e, 'player', { summoned }),
     );
     expect(signal.destroySummoned).toBe(true);
   });

--- a/tests/effect-registry-extended.test.js
+++ b/tests/effect-registry-extended.test.js
@@ -286,7 +286,7 @@ describe('setFaceDown', () => {
   it('sets targetFC face-down in def position', async () => {
     const fc = makeFC(1000, 500, { card: { name: 'Target', atk: 1000, def: 500, type: 1 }, position: 'atk', faceDown: false, hasFlipSummoned: true });
     const e = mockEngine();
-    await executeEffectBlock({ trigger: 'onActivate', actions: [{ type: 'setFaceDown' }] }, ctx(e, 'player', { targetFC: fc }));
+    await executeEffectBlock({ trigger: 'onActivate', actions: [{ type: 'setFaceDown' }] }, ctx(e, 'player', { target: fc }));
     expect(fc.faceDown).toBe(true);
     expect(fc.position).toBe('def');
     expect(fc.hasFlipSummoned).toBe(false);

--- a/tests/effect-registry.test.js
+++ b/tests/effect-registry.test.js
@@ -409,7 +409,7 @@ describe('tempAtkBonus', () => {
     const e = mockEngine();
     await executeEffectBlock(
       { trigger: 'onSummon', actions: [{ type: 'tempAtkBonus', target: 'ownMonster', value: 700 }] },
-      ctx(e, 'player', { targetFC: target }),
+      ctx(e, 'player', { target: target }),
     );
     expect(target.tempATKBonus).toBe(700);
   });
@@ -441,7 +441,7 @@ describe('permAtkBonus', () => {
     const e = mockEngine();
     await executeEffectBlock(
       { trigger: 'onSummon', actions: [{ type: 'permAtkBonus', target: 'ownMonster', value: 500, filter: { attr: 2 } }] },
-      ctx(e, 'player', { targetFC: target }),
+      ctx(e, 'player', { target: target }),
     );
     expect(target.permATKBonus).toBe(500);
   });
@@ -451,7 +451,7 @@ describe('permAtkBonus', () => {
     const e = mockEngine();
     await executeEffectBlock(
       { trigger: 'onSummon', actions: [{ type: 'permAtkBonus', target: 'ownMonster', value: 500, filter: { attr: 2 } }] },
-      ctx(e, 'player', { targetFC: target }),
+      ctx(e, 'player', { target: target }),
     );
     expect(target.permATKBonus).toBe(0);
   });
@@ -460,7 +460,7 @@ describe('permAtkBonus', () => {
     const summoned = { card: { name: 'Test' }, permATKBonus: 0 };
     const e = mockEngine();
     await executeEffectBlock(
-      { trigger: 'onOpponentSummon', actions: [{ type: 'permAtkBonus', target: 'summoned', value: -500 }] },
+      { trigger: 'onOpponentSummon', actions: [{ type: 'permAtkBonus', target: 'summonedFC', value: -500 }] },
       ctx(e, 'player', { summoned }),
     );
     expect(summoned.permATKBonus).toBe(-500);
@@ -472,7 +472,7 @@ describe('permDefBonus', () => {
     const summoned = { card: { name: 'Test' }, permDEFBonus: 0 };
     const e = mockEngine();
     await executeEffectBlock(
-      { trigger: 'onOpponentSummon', actions: [{ type: 'permDefBonus', target: 'summoned', value: -400 }] },
+      { trigger: 'onOpponentSummon', actions: [{ type: 'permDefBonus', target: 'summonedFC', value: -400 }] },
       ctx(e, 'player', { summoned }),
     );
     expect(summoned.permDEFBonus).toBe(-400);

--- a/tests/effect-registry.test.js
+++ b/tests/effect-registry.test.js
@@ -166,10 +166,10 @@ describe('dealDamage', () => {
 
   it('resolves summoned.atk value expression', async () => {
     const e = mockEngine();
-    const summonedFC = { card: { atk: 1500 } };
+    const summoned = { card: { atk: 1500 } };
     await executeEffectBlock(
       { trigger: 'onOpponentSummon', actions: [{ type: 'dealDamage', target: 'opponent', value: { from: 'summoned.atk', multiply: 0.5, round: 'floor' } }] },
-      ctx(e, 'player', { summonedFC }),
+      ctx(e, 'player', { summoned }),
     );
     expect(e.dealDamage).toHaveBeenCalledWith('opponent', 750);
   });
@@ -456,26 +456,26 @@ describe('permAtkBonus', () => {
     expect(target.permATKBonus).toBe(0);
   });
 
-  it('applies perm ATK debuff to summonedFC', async () => {
-    const summonedFC = { card: { name: 'Test' }, permATKBonus: 0 };
+  it('applies perm ATK debuff to summoned', async () => {
+    const summoned = { card: { name: 'Test' }, permATKBonus: 0 };
     const e = mockEngine();
     await executeEffectBlock(
-      { trigger: 'onOpponentSummon', actions: [{ type: 'permAtkBonus', target: 'summonedFC', value: -500 }] },
-      ctx(e, 'player', { summonedFC }),
+      { trigger: 'onOpponentSummon', actions: [{ type: 'permAtkBonus', target: 'summoned', value: -500 }] },
+      ctx(e, 'player', { summoned }),
     );
-    expect(summonedFC.permATKBonus).toBe(-500);
+    expect(summoned.permATKBonus).toBe(-500);
   });
 });
 
 describe('permDefBonus', () => {
-  it('applies permanent DEF debuff to summonedFC', async () => {
-    const summonedFC = { card: { name: 'Test' }, permDEFBonus: 0 };
+  it('applies permanent DEF debuff to summoned', async () => {
+    const summoned = { card: { name: 'Test' }, permDEFBonus: 0 };
     const e = mockEngine();
     await executeEffectBlock(
-      { trigger: 'onOpponentSummon', actions: [{ type: 'permDefBonus', target: 'summonedFC', value: -400 }] },
-      ctx(e, 'player', { summonedFC }),
+      { trigger: 'onOpponentSummon', actions: [{ type: 'permDefBonus', target: 'summoned', value: -400 }] },
+      ctx(e, 'player', { summoned }),
     );
-    expect(summonedFC.permDEFBonus).toBe(-400);
+    expect(summoned.permDEFBonus).toBe(-400);
   });
 });
 
@@ -528,21 +528,21 @@ describe('destroyAttacker', () => {
 
 describe('destroySummonedIf', () => {
   it('destroys summoned monster if ATK >= threshold', async () => {
-    const summonedFC = { card: { name: 'Big', atk: 2000 } };
+    const summoned = { card: { name: 'Big', atk: 2000 } };
     const e = mockEngine();
     const signal = await executeEffectBlock(
       { trigger: 'onOpponentSummon', actions: [{ type: 'destroySummonedIf', minAtk: 1000 }] },
-      ctx(e, 'player', { summonedFC }),
+      ctx(e, 'player', { summoned }),
     );
     expect(signal.destroySummoned).toBe(true);
   });
 
   it('does not destroy if ATK < threshold', async () => {
-    const summonedFC = { card: { name: 'Small', atk: 500 } };
+    const summoned = { card: { name: 'Small', atk: 500 } };
     const e = mockEngine();
     const signal = await executeEffectBlock(
       { trigger: 'onOpponentSummon', actions: [{ type: 'destroySummonedIf', minAtk: 1000 }] },
-      ctx(e, 'player', { summonedFC }),
+      ctx(e, 'player', { summoned }),
     );
     expect(signal.destroySummoned).toBeUndefined();
   });


### PR DESCRIPTION
## Summary

Fixes inconsistent FieldCard property naming in EffectContext and related interfaces.

## Changes

**Interfaces updated:**
- `EffectContext`: `targetFC` → `target`, `summonedFC` → `summoned`
- `PureEffectCtx`: `targetFC` → `target`, `summonedFC` → `summoned`
- `ChainEffectCtx`: Inherits from PureEffectCtx

**Files modified:**
- `src/types.ts` - Interface definitions
- `src/effect-registry.ts` - All effect handler implementations and context transformations
- `src/engine.ts` - Context building methods (`_buildSpellContext`, `_buildTrapContext`)
- `docs/effect-system.md` - Documentation
- `scripts/generate-engine-dts.js` - Type generation script
- Test files updated to use new property names

**Note on StatTarget type:**
The StatTarget type values remain unchanged (`'summonedFC'`, `'ownMonster'`, etc.) as they come from the external @wynillo/tcg-format package. The `resolveStatTarget` function maps these string values to the renamed context properties.

**Impact:**
- More consistent API - all FieldCard properties now follow the same naming convention (no FC suffix)
- The type is already `FieldCard`, so the suffix was redundant
- Improves code readability and reduces cognitive load

Closes #396
