### PR TITLE
docs(types): add type/interface convention documentation (#398)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,33 @@
+/**
+ * Type Definition Conventions
+ * ===========================
+ *
+ * This file uses both `type` aliases and `interface` declarations following
+ * these conventions:
+ *
+ * **Use `type` for:**
+ * - Union types (e.g., `Owner`, `Phase`, `Position`)
+ * - Type aliases for primitives that come from external sources
+ *   (e.g., `Attribute`, `Race`, `Rarity` from TCG format)
+ * - Mapped types and type transformations (e.g., `EffectDescriptor`)
+ * - Re-exports of types from external libraries
+ *
+ * **Use `interface` for:**
+ * - Object shapes representing data structures (e.g., `CardData`, `GameState`)
+ * - When declaration merging or `extends` is needed
+ * - Context and configuration objects (e.g., `EffectContext`, `OpponentConfig`)
+ *
+ * **Special case: Attribute, Race, Rarity**
+ * These are defined as `type` aliases to `number` (not enums) because:
+ * 1. They originate from the TCG format library as numeric IDs
+ * 2. Type metadata (display names, colors, icons) is provided separately
+ *    via `type-metadata.ts` using the `TYPE_META` registry
+ * 3. This maintains compatibility with the external TCG format
+ *
+ * See: TypeScript Handbook - Interfaces vs Type Aliases
+ * https://www.typescriptlang.org/docs/handbook/2/everyday-types.html
+ */
+
 // Import effect types from TCG format library (single source of truth)
 import type {
   TcgTrapTrigger,
@@ -27,6 +57,11 @@ export enum CardType {
   Equipment = 5,
 }
 
+/**
+ * Primitive type aliases for TCG numeric IDs.
+ * These are not enums because they come from the external TCG format
+ * as plain numbers. Type metadata is provided via type-metadata.ts.
+ */
 export type Attribute = number;
 export type Race = number;
 export type Rarity = number;


### PR DESCRIPTION
## Summary

This PR addresses issue #398 by documenting the existing conventions for using `type` vs `interface` in the codebase, providing clear guidance for future development.

## Changes

- Added comprehensive documentation comment at the top of `src/types.ts` explaining:
  - When to use `type` aliases (union types, primitive aliases from external sources, mapped types)
  - When to use `interface` declarations (object shapes, data structures, configuration objects)
  - Why `Attribute`, `Race`, and `Rarity` remain as type aliases instead of enums (TCG format compatibility)

## Rationale

After analysis, I determined that **Option C** (document the convention) is the best approach because:

1. **Non-breaking**: Keeps compatibility with the external `@wynillo/tcg-format` package
2. **Minimal changes**: Only adds documentation, no refactoring required
3. **Follows existing patterns**: `CardType` is already an enum (locally defined), while `Attribute`/`Race`/`Rarity` come from TCG format as numbers
4. **Type metadata separation**: The `type-metadata.ts` system already provides enum-like behavior via the `TYPE_META` registry

Converting to branded types (Option A) or enums (Option B) would:
- Break compatibility with TCG format
- Require changes across 36+ files
- Add unnecessary complexity for a low-priority issue

## Testing

- ✅ TypeScript compilation: No new errors introduced
- ✅ Pre-existing test suite: 853 tests passing (49 failures are pre-existing, unrelated to this change)
- ✅ File-specific type check: `src/types.ts` compiles cleanly

## References

- TypeScript Handbook: [Interfaces vs Type Aliases](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#interfaces-and-type-aliases)
- Issue #398: [LOW] Inconsistent use of 'type' vs 'interface' for type definitions in types.ts

---

Closes #398
