### PR TITLE
refactor: rename generic Props interfaces to component-specific names

### DIFF
--- a/src/react/components/Card.tsx
+++ b/src/react/components/Card.tsx
@@ -42,7 +42,7 @@ function attrCssKey(attr: number | undefined): string {
   return getAttrById(attr)?.key ?? 'spell';
 }
 
-interface Props {
+interface CardProps {
   card: CardData;
   fc?: FieldCard | null;
   dimmed?: boolean;
@@ -52,7 +52,7 @@ interface Props {
   extraClass?: string;
 }
 
-export function Card({ card, fc = null, dimmed = false, rotated = false, big = false, small = false, extraClass = '' }: Props) {
+export function Card({ card, fc = null, dimmed = false, rotated = false, big = false, small = false, extraClass = '' }: CardProps) {
   const isMonLevelC = card.type === CardType.Monster || card.type === CardType.Fusion;
   const isEquipment = card.type === CardType.Equipment;
   const levelStars = isMonLevelC && card.level ? '\u2605'.repeat(Math.min(card.level, 12)) : '';

--- a/src/react/components/ControllerFocusOverlay.tsx
+++ b/src/react/components/ControllerFocusOverlay.tsx
@@ -6,12 +6,12 @@ interface FocusZone {
   zone: number;
 }
 
-interface Props {
+interface ControllerFocusOverlayProps {
   connected: boolean;
   focusedZone: FocusZone | null;
 }
 
-export function ControllerFocusOverlay({ connected, focusedZone }: Props) {
+export function ControllerFocusOverlay({ connected, focusedZone }: ControllerFocusOverlayProps) {
   const { t } = useTranslation();
 
   if (!connected || !focusedZone) return null;

--- a/src/react/components/ErrorBoundary.tsx
+++ b/src/react/components/ErrorBoundary.tsx
@@ -2,7 +2,7 @@ import { Component } from 'react';
 import type { ReactNode, ErrorInfo } from 'react';
 import i18n from '../../i18n.js';
 
-interface Props {
+interface ErrorBoundaryProps {
   children: ReactNode;
   fallback?: ReactNode;
   onReset?: () => void;
@@ -12,7 +12,7 @@ interface State {
   error: Error | null;
 }
 
-export class ErrorBoundary extends Component<Props, State> {
+export class ErrorBoundary extends Component<ErrorBoundaryProps, State> {
   state: State = { error: null };
 
   static getDerivedStateFromError(error: Error): State {

--- a/src/react/components/FieldCardComponent.tsx
+++ b/src/react/components/FieldCardComponent.tsx
@@ -3,7 +3,7 @@ import { attachHover } from './hoverApi.js';
 import { Card, cardTypeCss, ATTR_CSS } from './Card.js';
 import type { FieldCard, CardData } from '../../types.js';
 
-interface Props {
+interface FieldCardComponentProps {
   fc: FieldCard;
   owner: 'player' | 'opponent';
   zone: number;
@@ -24,7 +24,7 @@ const IS_TOUCH = window.matchMedia('(pointer: coarse)').matches;
 export function FieldCardComponent({
   fc, owner, zone, selected, targetable, interactive, canAttack, viewable,
   onOwnClick, onAttackerSelect, onDefenderClick, onViewClick, onDetail,
-}: Props) {
+}: FieldCardComponentProps) {
   const { t } = useTranslation();
   const { card } = fc;
   const isPlayer = owner === 'player';

--- a/src/react/components/FieldSpellTrapComponent.tsx
+++ b/src/react/components/FieldSpellTrapComponent.tsx
@@ -4,7 +4,7 @@ import { Card, cardTypeCss } from './Card.js';
 import { CardType } from '../../types.js';
 import type { FieldSpellTrap } from '../../types.js';
 
-interface Props {
+interface FieldSpellTrapComponentProps {
   fst: FieldSpellTrap;
   owner: 'player' | 'opponent';
   zone: number;
@@ -15,7 +15,7 @@ interface Props {
 
 const IS_TOUCH = window.matchMedia('(pointer: coarse)').matches;
 
-export function FieldSpellTrapComponent({ fst, owner, zone, interactive, onClick, onDetail }: Props) {
+export function FieldSpellTrapComponent({ fst, owner, zone, interactive, onClick, onDetail }: FieldSpellTrapComponentProps) {
   const { t } = useTranslation();
   const { card } = fst;
   const isPlayer = owner === 'player';

--- a/src/react/components/HandCard.tsx
+++ b/src/react/components/HandCard.tsx
@@ -4,7 +4,7 @@ import { attachHover } from './hoverApi.js';
 import { useLongPress } from '../hooks/useLongPress.js';
 import type { CardData } from '../../types.js';
 
-interface Props {
+interface HandCardProps {
   card: CardData;
   index: number;
   playable: boolean;
@@ -21,7 +21,7 @@ interface Props {
   onLongPress?: () => void;
 }
 
-export function HandCard({ card, index, playable, dimmed, fusionable, targetable, chainSelected, chainIndex, fusionSelected, fusionIndex, newlyDrawn, drawDelay, onClick, onLongPress }: Props) {
+export function HandCard({ card, index, playable, dimmed, fusionable, targetable, chainSelected, chainIndex, fusionSelected, fusionIndex, newlyDrawn, drawDelay, onClick, onLongPress }: HandCardProps) {
   const ref = useRef<HTMLDivElement>(null);
 
   const isSelected = chainSelected || fusionSelected;

--- a/src/react/screens/game/LPPanel.tsx
+++ b/src/react/screens/game/LPPanel.tsx
@@ -1,7 +1,7 @@
 import { useAnimatedNumber } from '../../hooks/useAnimatedNumber.js';
 import RaceIcon from '../../components/RaceIcon.js';
 
-interface Props {
+interface LPPanelProps {
   playerLp:    number;
   oppLp:       number;
   playerDeck:  number;
@@ -11,7 +11,7 @@ interface Props {
 const START_LP = 8000;
 function lpPct(lp: number) { return `${Math.max(0, Math.min(100, lp / START_LP * 100))}%`; }
 
-export function LPPanel({ playerLp, oppLp, playerDeck, oppDeck }: Props) {
+export function LPPanel({ playerLp, oppLp, playerDeck, oppDeck }: LPPanelProps) {
   const playerLpDisplay = useAnimatedNumber(playerLp);
   const oppLpDisplay    = useAnimatedNumber(oppLp);
 

--- a/src/react/screens/game/PlayerField.tsx
+++ b/src/react/screens/game/PlayerField.tsx
@@ -12,12 +12,12 @@ import type { FieldSpellTrap } from '../../../field.js';
 
 const FIELD_ZONES = [0, 1, 2, 3, 4] as const;
 
-interface Props {
+interface PlayerFieldProps {
   showDirect:    boolean;
   setShowDirect: (v: boolean) => void;
 }
 
-export function PlayerField({ showDirect, setShowDirect }: Props) {
+export function PlayerField({ showDirect, setShowDirect }: PlayerFieldProps) {
   const { gameState, gameRef } = useGame();
   const { openModal }          = useModal();
   const { sel, setSel, resetSel } = useSelection();


### PR DESCRIPTION
## Summary

Fixes inconsistent React component Props interface naming by renaming all generic `Props` interfaces to descriptive, component-specific names following the `<ComponentName>Props` convention.

## Changes

Renamed Props interfaces in 8 files:

| File | Old Name | New Name |
|------|----------|----------|
| `ErrorBoundary.tsx` | `Props` | `ErrorBoundaryProps` |
| `HandCard.tsx` | `Props` | `HandCardProps` |
| `ControllerFocusOverlay.tsx` | `Props` | `ControllerFocusOverlayProps` |
| `Card.tsx` | `Props` | `CardProps` |
| `FieldSpellTrapComponent.tsx` | `Props` | `FieldSpellTrapComponentProps` |
| `FieldCardComponent.tsx` | `Props` | `FieldCardComponentProps` |
| `LPPanel.tsx` | `Props` | `LPPanelProps` |
| `PlayerField.tsx` | `Props` | `PlayerFieldProps` |

## Impact

- ✅ **Improved TypeScript error messages** - Errors now show "HandCardProps" instead of generic "Props"
- ✅ **Better IDE autocomplete** - Easier to distinguish between component props
- ✅ **Enhanced code navigation** - Can search for "HandCardProps" specifically
- ✅ **Consistent with existing patterns** - Matches already-renamed components (RaceIconProps, RaceFilterBarProps, etc.)

## Testing

- TypeScript type checking: ✅ No errors in modified files
- Build verification: ✅ Changes verified (pre-existing build issue unrelated to Props renames)

## References

- React TypeScript Cheatsheets: [Typing Component Props](https://react-typescript-cheatsheet.netlify.app/docs/basic/getting-started/basic_type_example#typing-component-props)
- Closes #399
