### PR TITLE
test(setup): restore fixture loader and effect-string parsing

### DIFF
--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,7 +1,11 @@
 import { afterEach } from 'vitest';
 
-// Mock window for node environment tests
-if (typeof window === 'undefined') {
+// Capture node-env detection before we mutate window below — the fixture loader
+// further down guards on `typeof window === 'undefined'` and must see the original
+// value, not the mock we assign here.
+const isNodeEnv = typeof window === 'undefined';
+
+if (isNodeEnv) {
   global.window = {
     confirm: () => false,
     location: { search: '' },
@@ -25,7 +29,7 @@ global.sessionStorage = {
   clear:      ()     => { Object.keys(sessionStore).forEach(k => delete sessionStore[k]); },
 };
 
-if (typeof window === 'undefined') {
+if (isNodeEnv) {
   URL.createObjectURL ??= () => 'blob:mock';
 
   const { readFileSync } = await import('fs');
@@ -37,6 +41,7 @@ if (typeof window === 'undefined') {
     CARD_DB, FUSION_RECIPES, FUSION_FORMULAS, OPPONENT_CONFIGS,
     STARTER_DECKS, PLAYER_DECK_IDS, OPPONENT_DECK_IDS,
   } = await import('../src/cards.js');
+  const { parseEffectString } = await import('../src/effect-serializer.js');
   const { applyShopData } = await import('../src/shop-data.js');
 
   const fixture = JSON.parse(
@@ -45,6 +50,11 @@ if (typeof window === 'undefined') {
 
   for (const raw of fixture.cards) {
     const card = { ...raw, id: String(raw.id) };
+    if (card.effect && typeof card.effect === 'string') {
+      const parsed = {};
+      parseEffectString(card.effect, parsed);
+      Object.assign(card, parsed);
+    }
     CARD_DB[card.id] = card;
   }
 


### PR DESCRIPTION
Commit 6dc626bb (security: PR #461) silently broke the test fixture
loader by adding a `global.window = {...}` assignment at the top of
tests/setup.js, which made the later `if (typeof window === 'undefined')`
guard always false — so CARD_DB, FUSION_FORMULAS, OPPONENT_CONFIGS, and
STARTER_DECKS never got populated. The same commit also removed the
`parseEffectString` step that converts fixture string-effects into the
`{ actions: [...] }` object shape the engine expects.

Fix: capture the node-env detection before mutating `window`, and
restore the effect-string parsing.

Impact: 886 -> 914 passing tests on main, 34 -> 12 failing. Remaining
failures are genuine test/mock issues unrelated to fixture loading.

https://claude.ai/code/session_01X31KBmAzhUytxGy6obvdQm