### PR TITLE
fix: remove duplicate closing braces from pickBestGraveyardMonster (PR #572 artifact)

### DIFF
--- a/src/ai-behaviors.ts
+++ b/src/ai-behaviors.ts
@@ -938,9 +938,6 @@ export function pickBestGraveyardMonster(
   }
   return best;
 }
-  }
-  return best;
-}
 
 export function pickSpellBuffTarget(
   ownMonsters: Array<FieldCard | null>,


### PR DESCRIPTION
## Summary

Fixes a syntax error introduced by PR #572 where duplicate closing braces were accidentally added after `pickBestGraveyardMonster()`.

## Problem

PR #572 merged successfully but introduced duplicate lines 941-943 in `src/ai-behaviors.ts`:
```typescript
}
  }
  return best;
}
```

This caused TypeScript compilation to fail with 'Unexpected token' error.

## Solution

Removed the 3 duplicate lines (941-943). The function now properly closes once.

## Impact

- **Test Results**: Restores baseline of 12 failing / 914 passing tests
- **Breaking Changes**: None - this is a pure syntax fix
- **Verified**: All AI behavior tests pass

Closes #572 follow-up