### PR TITLE
fix: replace Math.random() with crypto.getRandomValues() (#415)

### DIFF
--- a/src/effect-registry.ts
+++ b/src/effect-registry.ts
@@ -532,7 +532,7 @@ const IMPL: Record<string, InternalImpl> = {
     const hand = ctx.state[ctx.owner].hand;
     const toDiscard = Math.min(desc.discardCount, hand.length);
     for (let i = 0; i < toDiscard; i++) {
-      const idx = Math.floor(Math.random() * hand.length);
+      const idx = randomIndexSecure(hand);
       const [c] = hand.splice(idx, 1);
       ctx.state[ctx.owner].graveyard.push(c);
     }
@@ -545,7 +545,7 @@ const IMPL: Record<string, InternalImpl> = {
     const hand = ctx.state[opp].hand;
     const toReturn = Math.min(desc.count, hand.length);
     for (let i = 0; i < toReturn; i++) {
-      const idx = Math.floor(Math.random() * hand.length);
+      const idx = randomIndexSecure(hand);
       const [c] = hand.splice(idx, 1);
       ctx.state[opp].deck.push(c);
     }
@@ -788,7 +788,7 @@ const IMPL: Record<string, InternalImpl> = {
     const hand = ctx.state[ctx.owner].hand;
     const count = Math.min(desc.count, hand.length);
     for (let i = 0; i < count && hand.length > 0; i++) {
-      const idx = Math.floor(Math.random() * hand.length);
+      const idx = randomIndexSecure(hand);
       const [c] = hand.splice(idx, 1);
       ctx.state[ctx.owner].graveyard.push(c);
     }
@@ -801,7 +801,7 @@ const IMPL: Record<string, InternalImpl> = {
     const hand = ctx.state[opp].hand;
     const count = Math.min(desc.count, hand.length);
     for (let i = 0; i < count && hand.length > 0; i++) {
-      const idx = Math.floor(Math.random() * hand.length);
+      const idx = randomIndexSecure(hand);
       const [c] = hand.splice(idx, 1);
       ctx.state[opp].graveyard.push(c);
     }
@@ -1311,7 +1311,7 @@ async function payCost(block: CardEffectBlock, ctx: EffectContext): Promise<void
   }
   if (block.cost.discard) {
     for (let i = 0; i < block.cost.discard && st.hand.length > 0; i++) {
-      const idx = Math.floor(Math.random() * st.hand.length);
+      const idx = randomIndexSecure(st.hand);
       const [c] = st.hand.splice(idx, 1);
       st.graveyard.push(c);
     }

--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -1,23 +1,19 @@
+import { shuffleSecure, shuffleArraySecure } from './random.js';
+
 /**
  * Fisher-Yates shuffle - returns a new shuffled array.
  * O(n) time complexity with unbiased random distribution.
+ * Uses crypto.getRandomValues() for secure randomness.
  */
 export function shuffleArray<T>(arr: readonly T[]): T[] {
-  const result = [...arr];
-  for (let i = result.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [result[i], result[j]] = [result[j], result[i]];
-  }
-  return result;
+  return shuffleArraySecure(arr);
 }
 
 /**
  * Fisher-Yates shuffle - shuffles array in-place.
  * O(n) time complexity with unbiased random distribution.
+ * Uses crypto.getRandomValues() for secure randomness.
  */
 export function shuffleInPlace<T>(arr: T[]): void {
-  for (let i = arr.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [arr[i], arr[j]] = [arr[j], arr[i]];
-  }
+  shuffleSecure(arr);
 }

--- a/src/utils/random.ts
+++ b/src/utils/random.ts
@@ -1,0 +1,103 @@
+/**
+ * Cryptographically secure random number utilities using crypto.getRandomValues().
+ * 
+ * Math.random() is NOT cryptographically secure and can be predicted if enough
+ * samples are observed. For game-critical randomness (pack openings, badge drops,
+ * card shuffling, target selection), we MUST use crypto.getRandomValues().
+ * 
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues
+ * @see https://cwe.mitre.org/data/definitions/330.html
+ */
+
+/**
+ * Returns a cryptographically secure random floating-point number in [0, 1).
+ * Uses Uint32Array for full 32-bit randomness, normalized to [0, 1).
+ */
+export function secureRandom(): number {
+  const array = new Uint32Array(1);
+  crypto.getRandomValues(array);
+  // Divide by (2^32) to get [0, 1)
+  return array[0] / (0xFFFFFFFF + 1);
+}
+
+/**
+ * Returns a cryptographically secure random integer in [0, max).
+ * Uses rejection sampling to ensure uniform distribution.
+ * 
+ * @param max - Upper bound (exclusive). Must be positive.
+ * @returns Random integer in range [0, max)
+ */
+export function secureRandomInt(max: number): number {
+  if (max <= 0) throw new Error('max must be positive');
+  if (max === 1) return 0;
+  
+  const array = new Uint32Array(1);
+  // Reject values that would bias the distribution
+  const limit = Math.floor(0xFFFFFFFF / max) * max;
+  
+  do {
+    crypto.getRandomValues(array);
+  } while (array[0] >= limit);
+  
+  return array[0] % max;
+}
+
+/**
+ * Securely shuffles an array in-place using Fisher-Yates algorithm.
+ * 
+ * @param arr - Array to shuffle (modified in place)
+ * @returns The same array reference, shuffled
+ */
+export function shuffleSecure<T>(arr: T[]): T[] {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = secureRandomInt(i + 1);
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+/**
+ * Securely shuffles an array, returning a new shuffled array.
+ * 
+ * @param arr - Array to shuffle (not modified)
+ * @returns New shuffled array
+ */
+export function shuffleArraySecure<T>(arr: readonly T[]): T[] {
+  return shuffleSecure([...arr]);
+}
+
+/**
+ * Picks a random element from an array securely.
+ * 
+ * @param arr - Array to pick from
+ * @returns Random element, or undefined if array is empty
+ */
+export function pickRandomSecure<T>(arr: readonly T[]): T | undefined {
+  if (arr.length === 0) return undefined;
+  return arr[secureRandomInt(arr.length)];
+}
+
+/**
+ * Generates a cryptographically secure unique ID.
+ * Uses 16 random bytes (128 bits) converted to hex.
+ * 
+ * @param prefix - Optional prefix (e.g., "token", "sheep")
+ * @returns Unique ID string in format: "{prefix}_{timestamp}_{random_hex}"
+ */
+export function generateSecureId(prefix?: string): string {
+  const array = new Uint8Array(16);
+  crypto.getRandomValues(array);
+  const randomHex = Array.from(array, b => b.toString(16).padStart(2, '0')).join('');
+  const timestamp = Date.now().toString(36);
+  return prefix ? `${prefix}_${timestamp}_${randomHex}` : `${timestamp}_${randomHex}`;
+}
+
+/**
+ * Selects a random index from an array securely.
+ * 
+ * @param arr - Array or array-like object
+ * @returns Random index in range [0, arr.length)
+ */
+export function randomIndexSecure<T>(arr: readonly T[]): number {
+  return secureRandomInt(arr.length);
+}


### PR DESCRIPTION
## Summary

Replace all instances of `Math.random()` used for game-critical randomness with cryptographically secure alternatives using the Web Crypto API's `crypto.getRandomValues()`.

## Problem

The application used `Math.random()` for:
- Card pack opening rarity determination
- Battle badge drop calculations
- Going first/second decisions
- Card deck shuffling
- Random target/card selection in effects
- Token card ID generation

`Math.random()` is NOT cryptographically secure and can be predicted if enough samples are observed, potentially enabling:
- Manipulation of pack opening outcomes
- Prediction of card drops
- Exploitation of random draw/discard effects
- Token ID collisions

## Solution

Created `src/utils/random.ts` with secure RNG utilities:
- `secureRandom()` - Secure random float [0, 1)
- `secureRandomInt(max)` - Secure random integer [0, max) with rejection sampling for uniform distribution
- `shuffleSecure(arr)` - Secure Fisher-Yates shuffle (in-place)
- `shuffleArraySecure(arr)` - Secure Fisher-Yates shuffle (returns new array)
- `pickRandomSecure(arr)` - Securely pick random element from array
- `randomIndexSecure(arr)` - Securely generate random array index
- `generateSecureId(prefix)` - Generate cryptographically unique ID (128-bit)

## Changes

**Files Modified:**
1. `src/utils/random.ts` (NEW) - Secure RNG utilities
2. `src/utils/array.ts` - Now uses secure RNG for shuffle functions
3. `src/react/utils/pack-logic.ts` - Rarity rolls and card selection
4. `src/battle-badges.ts` - Badge drop calculations
5. `src/engine.ts` - First turn decision and deck shuffling
6. `src/effect-registry.ts` - Card selection effects and token ID generation

**Verification:**
```bash
grep -rn "Math\.random()" src/ --include="*.ts" --include="*.tsx"
# Only shows: VFX effects, animations, packReveal.ts (non-critical visual randomness)
```

All game-critical randomness now uses `crypto.getRandomValues()`.

## Testing

- No functional changes to game logic - only RNG source changed
- All existing tests should pass (pre-existing test failures unrelated to these changes)
- Build error `EFFECT_REGISTRY` duplicate declaration is pre-existing in main

## References

- Issue: #415 - [LOW] Weak Math.random() used for game-critical randomness
- CWE-330: Insufficiently Random Values - https://cwe.mitre.org/data/definitions/330.html
- MDN crypto.getRandomValues(): https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues

Closes #415
