### PR TITLE
fix(security): Restrict Android FileProvider to app-specific paths (#416)

### DIFF
--- a/android/app/src/main/res/xml/file_paths.xml
+++ b/android/app/src/main/res/xml/file_paths.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <paths xmlns:android="http://schemas.android.com/apk/res/android">
-    <external-path name="my_images" path="." />
-    <cache-path name="my_cache_images" path="." />
+    <external-files-path 
+        name="game_exports" 
+        path="." />
+    <cache-path 
+        name="game_cache" 
+        path="images" />
 </paths>


### PR DESCRIPTION
## Summary

Fix Android FileProvider security vulnerability by restricting file access to app-specific directories only.

## Changes

- **android/app/src/main/res/xml/file_paths.xml**:
  - Replaced `<external-path path="." />` with `<external-files-path path="." />` (app-specific sandboxed directory)
  - Changed `<cache-path path="." />` to `<cache-path path="images" />` (specific subdirectory only)

## Security Impact

**Before:** FileProvider granted access to entire external storage and cache directories
- Path traversal risk: Could potentially access any file in external storage
- Inter-app data leakage: Other apps could potentially access game files
- Sensitive data exposure: Any files in external paths were accessible

**After:** FileProvider only grants access to:
- App-specific external files directory (`/Android/data/com.wynillo.echoesofsanguo/files/`)
- Images subdirectory in cache only

These directories are:
- Sandboxed to the app
- Automatically deleted on uninstall
- Not accessible by other apps without explicit permission

## Testing

- XML configuration validated against Android schema
- No existing functionality affected (FileProvider not currently used by app code)
- Build compatible with Capacitor Android project structure

## References

- Android FileProvider Security: https://developer.android.com/reference/androidx/core/content/FileProvider
- OWASP Mobile Top 10 - M2: Insecure Data Storage

Closes #416
