### PR TITLE
refactor: standardize LP naming conventions (#400)

### DIFF
--- a/src/ai-behaviors.ts
+++ b/src/ai-behaviors.ts
@@ -212,26 +212,26 @@ export function resolveAIBehavior(id?: string): Required<AIBehavior> {
 export function shouldActivateNormalSpell(
   cardId: string,
   behavior: Required<AIBehavior>,
-  playerLP: number,
-  aiLP: number,
+  playerLp: number,
+  aiLp: number,
 ): boolean {
   const rule = behavior.spellRules[cardId];
   if (rule) {
-    return evaluateSpellRule(rule, playerLP, aiLP);
+    return evaluateSpellRule(rule, playerLp, aiLp);
   }
   switch (behavior.defaultSpellActivation) {
     case 'always': return true;
     case 'never':  return false;
-    case 'smart':  return aiLP < playerLP || aiLP < AI_LP_THRESHOLD.DEFENSIVE;
+    case 'smart':  return aiLp < playerLp || aiLp < AI_LP_THRESHOLD.DEFENSIVE;
   }
 }
 
-function evaluateSpellRule(rule: AISpellRule, playerLP: number, aiLP: number): boolean {
+function evaluateSpellRule(rule: AISpellRule, playerLp: number, aiLp: number): boolean {
   const t = rule.threshold ?? 0;
   switch (rule.when) {
-    case 'always':   return true;
-    case 'opponentLP>N':  return playerLP > t;
-    case 'selfLP<N': return aiLP < t;
+    case 'always':      return true;
+    case 'opponentLp>$N': return playerLp > t;
+    case 'playerLp<$N':  return aiLp < t;
   }
 }
 
@@ -291,8 +291,8 @@ export function decideSummonPosition(
 export interface BoardContext {
   aiField: Array<FieldCard | null>;
   playerField: Array<FieldCard | null>;
-  playerLP: number;
-  aiLP: number;
+  playerLp: number;
+  aiLp: number;
 }
 
 /**
@@ -341,7 +341,7 @@ function calculateDefensiveScore(
   card: CardData,
   opponentMaxATK: number,
   opponentMaxThreat: number,
-  aiLP: number,
+  aiLp: number,
 ): number {
   const atk = card.atk ?? 0;
   const def = card.def ?? 0;
@@ -351,7 +351,7 @@ function calculateDefensiveScore(
     score += AI_SUMMON_SCORE.DEFENSIVE_BONUS;
   }
 
-  if (aiLP < AI_LP_THRESHOLD.LOW && def > opponentMaxThreat) {
+  if (aiLp < AI_LP_THRESHOLD.LOW && def > opponentMaxThreat) {
     score += AI_SCORE.LOW_LP_SURVIVAL;
   }
 
@@ -393,7 +393,7 @@ export function pickSmartSummonCandidate(hand: CardData[], ctx: BoardContext): n
     let score = 0;
 
     score += calculateOffensiveScore(card, playerMonsters, playerMaxATK);
-    score += calculateDefensiveScore(card, playerMaxATK, playerMaxThreat, ctx.aiLP);
+    score += calculateDefensiveScore(card, playerMaxATK, playerMaxThreat, ctx.aiLp);
     score += calculateDirectAttackBonus(card, playerMonsters.length > 0);
 
     if (card.effect) {
@@ -416,7 +416,7 @@ export interface AttackPlan {
 export function findLethal(
   aiMonsters: Array<FieldCard | null>,
   plrMonsters: Array<FieldCard | null>,
-  playerLP: number,
+  playerLp: number,
 ): AttackPlan[] | null {
   const attackers: { zone: number; atk: number; canDirect: boolean }[] = [];
   for (let z = 0; z < aiMonsters.length; z++) {
@@ -444,21 +444,21 @@ export function findLethal(
   const directAttackers = attackers.filter(a => a.canDirect);
   if (attackableDefenders.length === 0) {
     const totalDmg = attackers.reduce((s, a) => s + a.atk, 0);
-    if (totalDmg >= playerLP) {
+    if (totalDmg >= playerLp) {
       const sorted = [...attackers].sort((a, b) => b.atk - a.atk);
       return sorted.map(a => ({ attackerZone: a.zone, targetZone: -1 }));
     }
     return null;
   }
 
-  const plan = _simulateLethal(attackers, attackableDefenders, playerLP);
+  const plan = _simulateLethal(attackers, attackableDefenders, playerLp);
   return plan;
 }
 
 function _simulateLethal(
   attackers: { zone: number; atk: number; canDirect: boolean }[],
   defenders: { zone: number; val: number; inAtk: boolean }[],
-  playerLP: number,
+  playerLp: number,
 ): AttackPlan[] | null {
   const sorted = [...attackers].sort((a, b) => b.atk - a.atk);
   const remainingDefs = defenders.map(d => ({ ...d, alive: true }));
@@ -507,7 +507,7 @@ function _simulateLethal(
     }
   }
 
-  return dmgToLP >= playerLP ? plan : null;
+  return dmgToLP >= playerLp ? plan : null;
 }
 
 // ── Helper Functions for planAttacks ───────────────────────────────────────
@@ -817,10 +817,10 @@ function assignRemainingAttacks(
 export function planAttacks(
   aiMonsters: Array<FieldCard | null>,
   plrMonsters: Array<FieldCard | null>,
-  playerLP: number,
+  playerLp: number,
   behavior: Required<AIBehavior>,
 ): AttackPlan[] {
-  const lethal = findLethal(aiMonsters, plrMonsters, playerLP);
+  const lethal = findLethal(aiMonsters, plrMonsters, playerLp);
   if (lethal) return lethal;
 
   const strategy = getStrategy(behavior.battleStrategy);

--- a/src/ai-orchestrator.ts
+++ b/src/ai-orchestrator.ts
@@ -252,8 +252,8 @@ async function aiMainPhase(deps: AIDependencies): Promise<void> {
       ? pickSmartSummonCandidate(ai.hand, {
           aiField: ai.field.monsters,
           playerField: plr.field.monsters,
-          playerLP: plr.lp,
-          aiLP: ai.lp,
+          playerLp: plr.lp,
+          aiLp: ai.lp,
         })
       : pickSummonCandidate(ai.hand, bh.summonPriority);
 

--- a/src/ai-threat.ts
+++ b/src/ai-threat.ts
@@ -13,8 +13,8 @@ export function snapshotBoard(ai: PlayerState, plr: PlayerState): BoardSnapshot 
     if (fc) plrMonsterPower += fc.effectiveATK();
   }
   return {
-    aiLP:            ai.lp,
-    plrLP:           plr.lp,
+    opponentLp:      ai.lp,
+    playerLp:        plr.lp,
     aiMonsterPower,
     plrMonsterPower,
     aiHandSize:      ai.hand.length,
@@ -27,15 +27,15 @@ export function snapshotBoard(ai: PlayerState, plr: PlayerState): BoardSnapshot 
  * Positive = AI is ahead. Negative = AI is losing.
  *
  * Threat score combines three factors:
- * - LP ratio: scaled by GAME_RULES.STARTING_LP so the (aiLP/plrLP - 1) ratio lives in
+ * - LP ratio: scaled by GAME_RULES.STARTING_LP so the (opponentLp/playerLp - 1) ratio lives in
  *   the same ~8000-point range as board power (ATK totals typically 2000–6000), keeping
  *   LP relevant without dominating the score.
  * - Board differential: raw ATK difference weighted by THREAT_BOARD_WEIGHT
  * - Hand advantage: per-card value weighted by THREAT_HAND_WEIGHT
  */
 export function computeBoardThreat(snap: BoardSnapshot): number {
-  const plrLPSafe = snap.plrLP > 0 ? snap.plrLP : 1;
-  const lpRatio = (snap.aiLP / plrLPSafe - 1) * AI_SCORE.THREAT_LP_WEIGHT * GAME_RULES.STARTING_LP;
+  const playerLpSafe = snap.playerLp > 0 ? snap.playerLp : 1;
+  const lpRatio = (snap.opponentLp / playerLpSafe - 1) * AI_SCORE.THREAT_LP_WEIGHT * GAME_RULES.STARTING_LP;
   const boardDiff = (snap.aiMonsterPower - snap.plrMonsterPower) * AI_SCORE.THREAT_BOARD_WEIGHT;
   const handAdv = (snap.aiHandSize - snap.plrHandSize) * AI_SCORE.THREAT_HAND_WEIGHT;
   return lpRatio + boardDiff + handAdv;

--- a/src/types.ts
+++ b/src/types.ts
@@ -203,7 +203,7 @@ export type AIPositionStrategy = 'smart' | 'aggressive' | 'defensive';
 export type AIBattleStrategy   = 'smart' | 'aggressive' | 'conservative';
 
 export interface AISpellRule {
-  when: 'always' | 'opponentLP>N' | 'selfLP<N';
+  when: 'always' | 'opponentLp>$N' | 'playerLp<$N';
   threshold?: number;
 }
 
@@ -220,8 +220,8 @@ export interface AIGoal {
 }
 
 export interface BoardSnapshot {
-  aiLP:            number;
-  plrLP:           number;
+  opponentLp:      number;
+  playerLp:        number;
   aiMonsterPower:  number;
   plrMonsterPower: number;
   aiHandSize:      number;

--- a/tests/ai-behaviors.test.js
+++ b/tests/ai-behaviors.test.js
@@ -329,45 +329,71 @@ describe('decideSummonPosition', () => {
 
 // ── shouldActivateNormalSpell ─────────────────────────────
 
-describe('shouldActivateNormalSpell', () => {
-  describe('with matching spell rule', () => {
-    it('activates when rule condition "always" is met', () => {
+  describe('shouldActivateNormalSpell', () => {
+    it('activates (opponentLp>$N) when player LP exceeds threshold', () => {
       const behavior = {
         ...resolveAIBehavior('default'),
-        spellRules: { 'test-always': { when: 'always' } },
-      };
-      expect(shouldActivateNormalSpell('test-always', behavior, 8000, 8000)).toBe(true);
-    });
-
-    it('activates (opponentLP>N) when player LP exceeds threshold', () => {
-      const behavior = {
-        ...resolveAIBehavior('default'),
-        spellRules: { 'test-opp': { when: 'opponentLP>N', threshold: 800 } },
+        spellRules: { 'test-opp': { when: 'opponentLp>$N', threshold: 800 } },
       };
       expect(shouldActivateNormalSpell('test-opp', behavior, 1000, 8000)).toBe(true);
     });
 
-    it('does not activate (opponentLP>N) when player LP is at or below threshold', () => {
+    it('does not activate (opponentLp>$N) when player LP is at or below threshold', () => {
       const behavior = {
         ...resolveAIBehavior('default'),
-        spellRules: { 'test-opp': { when: 'opponentLP>N', threshold: 800 } },
+        spellRules: { 'test-opp': { when: 'opponentLp>$N', threshold: 800 } },
       };
       expect(shouldActivateNormalSpell('test-opp', behavior, 800, 8000)).toBe(false);
       expect(shouldActivateNormalSpell('test-opp', behavior, 500, 8000)).toBe(false);
     });
 
-    it('activates (selfLP<N) when AI LP is below threshold', () => {
+    it('activates (playerLp<$N) when AI LP is below threshold', () => {
       const behavior = {
         ...resolveAIBehavior('default'),
-        spellRules: { 'test-self': { when: 'selfLP<N', threshold: 5000 } },
+        spellRules: { 'test-self': { when: 'playerLp<$N', threshold: 5000 } },
       };
       expect(shouldActivateNormalSpell('test-self', behavior, 8000, 4000)).toBe(true);
     });
 
-    it('does not activate (selfLP<N) when AI LP is at or above threshold', () => {
+    it('does not activate (playerLp<$N) when AI LP is at or above threshold', () => {
       const behavior = {
         ...resolveAIBehavior('default'),
-        spellRules: { 'test-self': { when: 'selfLP<N', threshold: 5000 } },
+        spellRules: { 'test-self': { when: 'playerLp<$N', threshold: 5000 } },
+      };
+      expect(shouldActivateNormalSpell('test-self', behavior, 8000, 5000)).toBe(false);
+      expect(shouldActivateNormalSpell('test-self', behavior, 8000, 6000)).toBe(false);
+    });
+  });
+
+    it('activates (opponentLp>$N) when player LP exceeds threshold', () => {
+      const behavior = {
+        ...resolveAIBehavior('default'),
+        spellRules: { 'test-opp': { when: 'opponentLp>$N', threshold: 800 } },
+      };
+      expect(shouldActivateNormalSpell('test-opp', behavior, 1000, 8000)).toBe(true);
+    });
+
+    it('does not activate (opponentLp>$N) when player LP is at or below threshold', () => {
+      const behavior = {
+        ...resolveAIBehavior('default'),
+        spellRules: { 'test-opp': { when: 'opponentLp>$N', threshold: 800 } },
+      };
+      expect(shouldActivateNormalSpell('test-opp', behavior, 800, 8000)).toBe(false);
+      expect(shouldActivateNormalSpell('test-opp', behavior, 500, 8000)).toBe(false);
+    });
+
+    it('activates (playerLp<$N) when AI LP is below threshold', () => {
+      const behavior = {
+        ...resolveAIBehavior('default'),
+        spellRules: { 'test-self': { when: 'playerLp<$N', threshold: 5000 } },
+      };
+      expect(shouldActivateNormalSpell('test-self', behavior, 8000, 4000)).toBe(true);
+    });
+
+    it('does not activate (playerLp<$N) when AI LP is at or above threshold', () => {
+      const behavior = {
+        ...resolveAIBehavior('default'),
+        spellRules: { 'test-self': { when: 'playerLp<$N', threshold: 5000 } },
       };
       expect(shouldActivateNormalSpell('test-self', behavior, 8000, 5000)).toBe(false);
       expect(shouldActivateNormalSpell('test-self', behavior, 8000, 6000)).toBe(false);
@@ -409,7 +435,7 @@ describe('shouldActivateNormalSpell', () => {
     it('uses rule even when defaultSpellActivation is "always"', () => {
       const behavior = {
         ...resolveAIBehavior('aggressive'),
-        spellRules: { 'test-spell': { when: 'selfLP<N', threshold: 3000 } },
+        spellRules: { 'test-spell': { when: 'playerLp<$N', threshold: 3000 } },
       };
       // defaultSpellActivation is 'always' but test-spell has a specific rule
       // AI LP 8000 >= 3000, so rule returns false
@@ -449,42 +475,42 @@ describe('evaluateSpellRule (via shouldActivateNormalSpell)', () => {
     });
   });
 
-  describe('condition: opponentLP>N', () => {
-    it('returns true when playerLP > threshold', () => {
-      const b = behaviorWithRule({ when: 'opponentLP>N', threshold: 4000 });
+  describe('condition: opponentLp>$N', () => {
+    it('returns true when playerLp > threshold', () => {
+      const b = behaviorWithRule({ when: 'opponentLp>$N', threshold: 4000 });
       expect(shouldActivateNormalSpell('TEST', b, 4001, 8000)).toBe(true);
       expect(shouldActivateNormalSpell('TEST', b, 8000, 8000)).toBe(true);
     });
 
-    it('returns false when playerLP <= threshold', () => {
-      const b = behaviorWithRule({ when: 'opponentLP>N', threshold: 4000 });
+    it('returns false when playerLp <= threshold', () => {
+      const b = behaviorWithRule({ when: 'opponentLp>$N', threshold: 4000 });
       expect(shouldActivateNormalSpell('TEST', b, 4000, 8000)).toBe(false);
       expect(shouldActivateNormalSpell('TEST', b, 3000, 8000)).toBe(false);
     });
 
     it('uses 0 as default threshold when threshold is undefined', () => {
-      const b = behaviorWithRule({ when: 'opponentLP>N' });
-      // playerLP > 0
+      const b = behaviorWithRule({ when: 'opponentLp>$N' });
+      // playerLp > 0
       expect(shouldActivateNormalSpell('TEST', b, 1, 8000)).toBe(true);
       expect(shouldActivateNormalSpell('TEST', b, 0, 8000)).toBe(false);
     });
   });
 
-  describe('condition: selfLP<N', () => {
-    it('returns true when aiLP < threshold', () => {
-      const b = behaviorWithRule({ when: 'selfLP<N', threshold: 5000 });
+  describe('condition: playerLp<$N', () => {
+    it('returns true when aiLp < threshold', () => {
+      const b = behaviorWithRule({ when: 'playerLp<$N', threshold: 5000 });
       expect(shouldActivateNormalSpell('TEST', b, 8000, 4999)).toBe(true);
       expect(shouldActivateNormalSpell('TEST', b, 8000, 1)).toBe(true);
     });
 
-    it('returns false when aiLP >= threshold', () => {
-      const b = behaviorWithRule({ when: 'selfLP<N', threshold: 5000 });
+    it('returns false when aiLp >= threshold', () => {
+      const b = behaviorWithRule({ when: 'playerLp<$N', threshold: 5000 });
       expect(shouldActivateNormalSpell('TEST', b, 8000, 5000)).toBe(false);
       expect(shouldActivateNormalSpell('TEST', b, 8000, 8000)).toBe(false);
     });
 
     it('uses 0 as default threshold when threshold is undefined', () => {
-      const b = behaviorWithRule({ when: 'selfLP<N' });
+      const b = behaviorWithRule({ when: 'playerLp<$N' });
       // aiLP < 0 → never true for non-negative LP
       expect(shouldActivateNormalSpell('TEST', b, 8000, 0)).toBe(false);
       expect(shouldActivateNormalSpell('TEST', b, 8000, 1)).toBe(false);
@@ -524,8 +550,8 @@ describe('pickSmartSummonCandidate', () => {
     expect(pickSmartSummonCandidate([], {
       aiField: [null, null, null, null, null],
       playerField: [null, null, null, null, null],
-      playerLP: 8000,
-      aiLP: 8000,
+      playerLp: 8000,
+      aiLp: 8000,
     })).toBe(-1);
   });
 
@@ -538,8 +564,8 @@ describe('pickSmartSummonCandidate', () => {
     const result = pickSmartSummonCandidate(hand, {
       aiField: [null, null, null, null, null],
       playerField: [plrFC, null, null, null, null],
-      playerLP: 8000,
-      aiLP: 8000,
+      playerLp: 8000,
+      aiLp: 8000,
     });
     expect(result).toBe(1); // B can beat P1
   });
@@ -555,8 +581,8 @@ describe('pickSmartSummonCandidate', () => {
     const result = pickSmartSummonCandidate(hand, {
       aiField: [null, null, null, null, null],
       playerField: [null, null, null, null, null],
-      playerLP: 8000,
-      aiLP: 8000,
+      playerLp: 8000,
+      aiLp: 8000,
     });
     expect(result).toBe(1); // B has effect bonus
   });
@@ -566,8 +592,8 @@ describe('pickSmartSummonCandidate', () => {
     const result = pickSmartSummonCandidate(hand, {
       aiField: [null, null, null, null, null],
       playerField: [null, null, null, null, null],
-      playerLP: 8000,
-      aiLP: 8000,
+      playerLp: 8000,
+      aiLp: 8000,
     });
     expect(result).toBe(1);
   });

--- a/tests/ai-threat.test.js
+++ b/tests/ai-threat.test.js
@@ -30,10 +30,10 @@ describe('snapshotBoard', () => {
     const ai = makePlayerState();
     const plr = makePlayerState();
     const snap = snapshotBoard(ai, plr);
+    expect(snap.opponentLp).toBe(8000);
+    expect(snap.playerLp).toBe(8000);
     expect(snap.aiMonsterPower).toBe(0);
     expect(snap.plrMonsterPower).toBe(0);
-    expect(snap.aiLP).toBe(8000);
-    expect(snap.plrLP).toBe(8000);
     expect(snap.aiHandSize).toBe(0);
     expect(snap.plrHandSize).toBe(0);
   });


### PR DESCRIPTION
- BoardSnapshot: aiLP → opponentLp, plrLP → playerLp
- AISpellRule: 'opponentLP>N' → 'opponentLp>', 'selfLP<N' → 'playerLp<'
- Function parameters: aiLP, playerLP → aiLp, playerLp (consistent camelCase)
- Update all AI modules (ai-behaviors, ai-threat, ai-orchestrator)
- Update test files to match new naming

Fixes inconsistent abbreviations for Life Points across the codebase.