### PR TITLE
Fix cards.ts duplicate import blocking tests

### DIFF
--- a/src/cards.ts
+++ b/src/cards.ts
@@ -1,5 +1,5 @@
 import type { CardData, FusionRecipe, FusionFormula, FusionComboType, OpponentConfig } from './types.js';
-import { CardType, isMonsterType, getCardAtk, getCardAtk } from './types.js';
+import { CardType, isMonsterType, getCardAtk } from './types.js';
 import {
   getRaceByKey, getAttrByKey, getRarityById, getRaceById, getAttrById,
   TYPE_META,


### PR DESCRIPTION
Fixes syntax error in src/cards.ts where  was imported twice on line 2, causing vitest transform to fail.

This was introduced after PR #624 was merged (the duplicate wasn't in my original PR branch when it merged).

Error: 