### PR TITLE
Fix shop-data.ts duplicate import blocking tests

### DIFF
--- a/src/shop-data.ts
+++ b/src/shop-data.ts
@@ -66,7 +66,6 @@ export interface ShopData {
   backgrounds: Record<string, string>;
 }
 
-import { CURRENCY_IDS } from './economy-config.js';
 
 export const SHOP_DATA: ShopData = {
   backgrounds: {},


### PR DESCRIPTION
Fixes duplicate CURRENCY_IDS import on line 69 that causes:\n```\nError: Identifier CURRENCY_IDS has already been declared\n```\n\nThis has been blocking all vitest tests from running, preventing the deploy pipeline from succeeding.