### PR TITLE
fix(ai): skip trap prompt on face-down summon from AI

### DIFF
--- a/src/ai-orchestrator.ts
+++ b/src/ai-orchestrator.ts
@@ -299,16 +299,6 @@ async function aiMainPhase(deps: AIDependencies): Promise<void> {
         } else {
           await deps.summonMonster('opponent', bestIdx, zone, summonPos);
         }
-        const summonedFC = ai.field.monsters[zone];
-        if(summonedFC){
-          const trapResult = await deps.promptPlayerTraps('onOpponentSummon', summonedFC);
-          if(trapResult && trapResult.destroySummoned){
-            EchoesOfSanguo.log('TRAP', `Trap hole destroyed ${summonedFC.card.name}`);
-            ai.graveyard.push(summonedFC.card);
-            ai.field.monsters[zone] = null;
-            deps.render(state);
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- Remove redundant summon trap prompt from AI orchestrator that fires even for face-down monsters
- **fixes bug**: AI setting a face-down monster was triggering \onOpponentSummon\ trap prompts, incorrectly revealing the enemy's hidden card

## What Changed
- AI \sumMonster\ (face-down) called \promptPlayerTraps('onOpponentSummon')\, bypassing the \if (!faceDown)\ guard in \engine.ts:summonMonster\
- \engine.ts\ already handles summon trap prompts correctly — it only fires for face-up summons
- Delete the 10-line duplicate prompt block from \i-orchestrator.ts\

## Verification
- All 1043 tests pass (no test depended on the removed code)
- Manual test: AI sets face-down → no trap prompt; AI summons face-up → trap prompt works