### PR TITLE
fix(slot-select): resolve race translation fallback showing raw key

### DIFF
--- a/src/react/screens/SaveSlotScreen.tsx
+++ b/src/react/screens/SaveSlotScreen.tsx
@@ -5,6 +5,7 @@ import { useProgression } from '../contexts/ProgressionContext';
 import { useCampaign }    from '../contexts/CampaignContext';
 import { useModal }       from '../contexts/ModalContext';
 import { Progression }    from '../../progression';
+import { getRaceById }    from '../../type-metadata';
 import type { SlotId, SlotMeta } from '../../progression';
 import styles from './SaveSlotScreen.module.css';
 
@@ -108,7 +109,7 @@ export default function SaveSlotScreen() {
                 <div className={styles.slotInfo}>
                   {meta.starterRace && (
                     <div className={styles.infoRow}>
-                      <span>{t('slots.race_label', { race: t(`cards.race_${meta.starterRace}`) })}</span>
+                      <span>{t('slots.race_label', { race: getRaceById(Number(meta.starterRace))?.value ?? meta.starterRace })}</span>
                     </div>
                   )}
                   <div className={styles.infoRow}>


### PR DESCRIPTION
﻿## Summary
Fixes the slot selection screen showing cards.race_8 instead of the translated race name.

## Root Cause
meta.starterRace stores the numeric race ID (e.g. "8"), but the translation keys use race keys (e.g. cards.race_Dragon). Calling 	(cards.race_) produced a nonexistent key and fell back to the raw string.

## Fix
Switched to getRaceById(Number(meta.starterRace))?.value, which reads the live-translated name from RaceMeta — the same pattern already used by the "Choose your starter deck" screen. A fallback (?? meta.starterRace) preserves graceful behavior if the race metadata is unavailable.

## Verification
- All 46 test suites (1043 tests) pass.