### PR TITLE
fix: display 'On Activation' instead of 'On Summon' for spell/trap cards

### DIFF
--- a/locales/de.json
+++ b/locales/de.json
@@ -538,6 +538,7 @@
   },
   "effectText": {
     "trigger_onSummon": "Bei Beschwörung",
+    "trigger_onSummon_spell": "Bei Aktivierung",
     "trigger_onDestroyByBattle": "Bei Zerstörung im Kampf",
     "trigger_onDestroyByOpponent": "Bei Zerstörung durch Gegner",
     "trigger_passive": "Passiv",
@@ -554,6 +555,7 @@
     "trigger_onOpponentTrap": "Wenn Gegner eine Falle aktiviert",
 
     "trigger_onSummon_tip": "Aktiviert sich, wenn dieses Monster beschworen wird",
+    "trigger_onSummon_spell_tip": "Aktiviert sich, wenn diese Karte aktiviert wird",
     "trigger_onDestroyByBattle_tip": "Aktiviert sich, wenn dieses Monster im Kampf zerstört wird",
     "trigger_onDestroyByOpponent_tip": "Aktiviert sich, wenn dieses Monster vom Gegner zerstört wird",
     "trigger_passive_tip": "Immer aktiv, solange dieses Monster offen auf dem Feld liegt",

--- a/locales/en.json
+++ b/locales/en.json
@@ -538,6 +538,7 @@
   },
   "effectText": {
     "trigger_onSummon": "On Summon",
+    "trigger_onSummon_spell": "On Activation",
     "trigger_onDestroyByBattle": "When destroyed in battle",
     "trigger_onDestroyByOpponent": "When destroyed by opponent",
     "trigger_passive": "Passive",
@@ -554,6 +555,7 @@
     "trigger_onOpponentTrap": "When opponent activates a trap",
 
     "trigger_onSummon_tip": "Activates when this monster is summoned to the field",
+    "trigger_onSummon_spell_tip": "Activates when this card is activated",
     "trigger_onDestroyByBattle_tip": "Activates when this monster is destroyed in battle",
     "trigger_onDestroyByOpponent_tip": "Activates when this monster is destroyed by the opponent",
     "trigger_passive_tip": "Always active while this monster is face-up on the field",

--- a/src/effect-text-builder.ts
+++ b/src/effect-text-builder.ts
@@ -1,5 +1,6 @@
 import type { CardData, CardEffectBlock, CardFilter, EffectCost, EffectDescriptor, EffectTrigger, TrapTrigger, ValueExpr, StatTarget } from './types';
 import { getRaceById, getAttrById } from './type-metadata';
+import { CardType } from './types';
 
 export type TFunction = (key: string, opts?: Record<string, unknown>) => string;
 
@@ -53,12 +54,18 @@ function filterText(filter: CardFilter | undefined, t: TFunction): string {
   return base;
 }
 
-function triggerText(trigger: EffectTrigger | TrapTrigger, t: TFunction): string {
-  return t(`effectText.trigger_${trigger}`);
+function triggerText(trigger: EffectTrigger | TrapTrigger, t: TFunction, cardType?: CardType): string {
+  const key = trigger === 'onSummon' && (cardType === CardType.Spell || cardType === CardType.Trap)
+    ? 'effectText.trigger_onSummon_spell'
+    : `effectText.trigger_${trigger}`;
+  return t(key);
 }
 
-function triggerTooltip(trigger: EffectTrigger | TrapTrigger, t: TFunction): string {
-  return t(`effectText.trigger_${trigger}_tip`);
+function triggerTooltip(trigger: EffectTrigger | TrapTrigger, t: TFunction, cardType?: CardType): string {
+  const key = trigger === 'onSummon' && (cardType === CardType.Spell || cardType === CardType.Trap)
+    ? 'effectText.trigger_onSummon_spell_tip'
+    : `effectText.trigger_${trigger}_tip`;
+  return t(key);
 }
 
 function costText(cost: EffectCost, t: TFunction): string {
@@ -255,12 +262,12 @@ function actionTooltip(a: EffectDescriptor, t: TFunction): string | undefined {
   return result !== key ? result : undefined;
 }
 
-export function buildEffectBlockSegments(block: CardEffectBlock, t: TFunction): EffectTextSegment[] {
+export function buildEffectBlockSegments(block: CardEffectBlock, t: TFunction, cardType?: CardType): EffectTextSegment[] {
   const segments: EffectTextSegment[] = [];
 
   segments.push({
-    text: triggerText(block.trigger, t),
-    tooltip: triggerTooltip(block.trigger, t),
+    text: triggerText(block.trigger, t, cardType),
+    tooltip: triggerTooltip(block.trigger, t, cardType),
     type: 'trigger',
   });
 
@@ -289,8 +296,8 @@ export function buildEffectBlockSegments(block: CardEffectBlock, t: TFunction): 
   return segments;
 }
 
-export function buildEffectBlockText(block: CardEffectBlock, t: TFunction): string {
-  return buildEffectBlockSegments(block, t).map(s => s.text).join('');
+export function buildEffectBlockText(block: CardEffectBlock, t: TFunction, cardType?: CardType): string {
+  return buildEffectBlockSegments(block, t, cardType).map(s => s.text).join('');
 }
 
 function getEffectBlocks(card: CardData): CardEffectBlock[] {
@@ -300,9 +307,9 @@ function getEffectBlocks(card: CardData): CardEffectBlock[] {
 }
 
 export function buildCardEffectSegments(card: CardData, t: TFunction): EffectTextSegment[][] {
-  return getEffectBlocks(card).map(block => buildEffectBlockSegments(block, t));
+  return getEffectBlocks(card).map(block => buildEffectBlockSegments(block, t, card.type));
 }
 
 export function buildCardEffectText(card: CardData, t: TFunction): string[] {
-  return getEffectBlocks(card).map(block => buildEffectBlockText(block, t));
+  return getEffectBlocks(card).map(block => buildEffectBlockText(block, t, card.type));
 }

--- a/tests/effect-text-builder.test.ts
+++ b/tests/effect-text-builder.test.ts
@@ -124,6 +124,34 @@ describe('buildCardEffectText', () => {
     const lines = buildCardEffectText(card, stubT);
     expect(lines).toHaveLength(2);
   });
+
+  it('uses trigger_onSummon for monster cards', () => {
+    const card = {
+      id: '4', name: 'Spell', type: CardType.Spell, description: 'test',
+      effect: makeBlock('onSummon', [{ type: 'gainLP', target: 'self', value: 2000 }]),
+    } as CardData;
+    const lines = buildCardEffectText(card, stubT);
+    expect(lines[0]).toContain('trigger_onSummon_spell');
+  });
+
+  it('uses trigger_onSummon for trap cards too', () => {
+    const card = {
+      id: '5', name: 'Trap', type: CardType.Trap, description: 'test',
+      effect: makeBlock('onSummon', [{ type: 'dealDamage', target: 'opponent', value: 500 }]),
+    } as CardData;
+    const lines = buildCardEffectText(card, stubT);
+    expect(lines[0]).toContain('trigger_onSummon_spell');
+  });
+
+  it('still uses trigger_onSummon for monsters', () => {
+    const card = {
+      id: '6', name: 'Monster', type: CardType.Monster, description: 'test',
+      effect: makeBlock('onSummon', [{ type: 'dealDamage', target: 'opponent', value: 500 }]),
+    } as CardData;
+    const lines = buildCardEffectText(card, stubT);
+    expect(lines[0]).toContain('trigger_onSummon');
+    expect(lines[0]).not.toContain('trigger_onSummon_spell');
+  });
 });
 
 describe('action coverage', () => {


### PR DESCRIPTION
## Problem
Spell and trap cards with the `onSummon` trigger were displaying **"On Summon"** in their effect text, which is semantically incorrect — spells and traps are **activated**, not summoned.

## Solution
Make the effect text builder card-type-aware:
- **Monster cards**: still show **"On Summon"**
- **Spell/Trap cards**: now show **"On Activation"**

## Changes
- Added optional `cardType` parameter to `triggerText`, `triggerTooltip`, `buildEffectBlockSegments`, and `buildEffectBlockText`
- `buildCardEffectSegments` and `buildCardEffectText` now pass `card.type` through automatically
- Added `trigger_onSummon_spell` keys to `locales/en.json` and `locales/de.json`
- Full backward compatibility: block-level functions still work without card type
- Added test coverage for spell/trap vs monster trigger label behavior

## Verification
- All existing tests pass (106 passed)
- New tests added for the card-type-aware behavior

Closes: semantically incorrect trigger label for spell/trap effects
