### PR TITLE
fix: add media-src 'self' to CSP to unblock audio playback

### DIFF
--- a/.github/nginx-sanguo.conf
+++ b/.github/nginx-sanguo.conf
@@ -18,7 +18,7 @@ server {
     index index.html;
     
     # Security headers
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; media-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self';" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "DENY" always;
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,6 +34,7 @@ script-src 'self'
 style-src 'self' 'unsafe-inline'
 img-src 'self' data: blob:
 font-src 'self'
+media-src 'self'
 connect-src 'self'
 frame-ancestors 'none'
 base-uri 'self'

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests; block-all-mixed-content;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; media-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests; block-all-mixed-content;">
   <meta name="referrer" content="strict-origin-when-cross-origin">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <meta name="theme-color" content="#060e0a">

--- a/vite.config.js
+++ b/vite.config.js
@@ -66,7 +66,7 @@ export default defineConfig({
   server: {
     https: true,
     headers: {
-      'Content-Security-Policy': "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests; block-all-mixed-content;",
+      'Content-Security-Policy': "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; media-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests; block-all-mixed-content;",
       'X-Content-Type-Options': 'nosniff',
       'X-Frame-Options': 'DENY',
       'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload',
@@ -75,7 +75,7 @@ export default defineConfig({
   },
   preview: {
     headers: {
-      'Content-Security-Policy': "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests; block-all-mixed-content;",
+      'Content-Security-Policy': "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; media-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests; block-all-mixed-content;",
       'X-Content-Type-Options': 'nosniff',
       'X-Frame-Options': 'DENY',
       'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload',


### PR DESCRIPTION
## Summary

- Added `media-src 'self'` to Content-Security-Policy in all 4 runtime locations + documentation
- CSP was missing `media-src` directive since it was introduced in bd2445c, causing browsers to block audio file fetches

## Root Cause

The CSP added in #411 included `connect-src 'self'` but not `media-src 'self'`. Per the [CSP spec](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP), `default-src` does not serve as a fallback for `media-src` when other resource-type directives are specified. The Web Audio API's `fetch()` calls to `/audio/music/*.mp3` and `/audio/sfx/*.mp3` were silently blocked by the browser.

## Files Changed

| File | Change |
|------|--------|
| `index.html` | Added `media-src 'self'` to CSP meta tag |
| `vite.config.js` | Added `media-src 'self'` to dev server + preview CSP headers |
| `.github/nginx-sanguo.conf` | Added `media-src 'self'` to production CSP header |
| `SECURITY.md` | Documented `media-src 'self'` in CSP policy reference |

Fixes #638