### PR TITLE
ci: remove agnix agent config validation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,10 +22,6 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v6
-      - name: Validate agent configs
-        uses: agent-sh/agnix@v0.18.0
-        with:
-          target: 'claude-code'
       - uses: actions/setup-node@v6
         with:
           node-version: 24


### PR DESCRIPTION
## Summary
Remove the agnix agent configuration validation step from the deploy workflow.

## Why
- agnix was used to validate Claude Code agent configs (CLAUDE.md, SKILL.md, hooks)
- The project no longer uses Claude Code (now using OpenCode)
- No agent config files exist in the codebase that would need validation
- This step was adding unnecessary CI time

## Changes
- Removed agnix validation step from `.github/workflows/deploy.yml`

## Testing
- No functional changes to the deploy process
- Deploy workflow will continue to: checkout → setup node → install → test → build → deploy